### PR TITLE
Pin Python Version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version-file: "pyproject.toml"
+          python-version: "3.11"
 
       - name: Install dependencies
         run: uv sync --all-extras


### PR DESCRIPTION
Have to pin the python. version due to GH actions wanting to use python 3.14, even though pydantic core doesn't support it yet.