### PR TITLE
finance service: include_finance flag + 33-table schema (M1+M2)

### DIFF
--- a/.github/workflows/stack-matrix.yml
+++ b/.github/workflows/stack-matrix.yml
@@ -41,6 +41,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
+      # ubuntu-latest ships ~14 GB free on /, but this job generates every
+      # stack combination and `uv sync`s each into its own .venv (UV_LINK_MODE
+      # copy, so no hardlink dedup) — they coexist for the whole run and can
+      # exhaust the disk (the runner then can't even write its own _diag logs).
+      # Reclaim ~15 GB by dropping preinstalled toolchains this Python repo
+      # never uses. df before/after so the logs show the headroom.
+      - name: Free disk space
+        run: |
+          echo "== disk before =="; df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          echo "== disk after =="; df -h /
+
       - uses: actions/checkout@v7
 
       - name: Install uv

--- a/.gitignore
+++ b/.gitignore
@@ -148,3 +148,4 @@ demo-*/
 
 # Generated-project artifact if aegis init ever runs at repo root
 /.copier-answers.yml
+test-project/

--- a/aegis/constants.py
+++ b/aegis/constants.py
@@ -170,6 +170,7 @@ class AnswerKeys:
     INSIGHTS = "include_insights"
     PAYMENT = "include_payment"
     BLOG = "include_blog"
+    FINANCE = "include_finance"
 
     # Service names (used for selection/lookup)
     SERVICE_AUTH = "auth"
@@ -178,6 +179,7 @@ class AnswerKeys:
     SERVICE_INSIGHTS = "insights"
     SERVICE_PAYMENT = "payment"
     SERVICE_BLOG = "blog"
+    SERVICE_FINANCE = "finance"
 
     # Insights source flags
     INSIGHTS_GITHUB = "insights_github"
@@ -185,6 +187,11 @@ class AnswerKeys:
     INSIGHTS_PLAUSIBLE = "insights_plausible"
     INSIGHTS_REDDIT = "insights_reddit"
     INSIGHTS_PER_USER = "insights_per_user"
+
+    # Finance source flags
+    FINANCE_PLAID = "finance_plaid"
+    FINANCE_SNAPTRADE = "finance_snaptrade"
+    FINANCE_IMPORT = "finance_import"
 
     # Payment configuration
     PAYMENT_PROVIDER = "payment_provider"

--- a/aegis/core/copier_manager.py
+++ b/aegis/core/copier_manager.py
@@ -186,6 +186,7 @@ def generate_with_copier(
         AnswerKeys.PAYMENT_PROVIDER: template_context.get(
             AnswerKeys.PAYMENT_PROVIDER, PaymentProviders.DEFAULT
         ),
+        AnswerKeys.FINANCE: template_context.get(AnswerKeys.FINANCE, "no") == "yes",
     }
 
     # Detect dev vs production mode for template sourcing
@@ -340,6 +341,8 @@ def generate_with_copier(
     is_sqlite = database_engine == StorageBackends.SQLITE
     is_payment_included: bool = copier_data.get(AnswerKeys.PAYMENT, False) is True
     needs_migration_files = needs_migration_files or is_payment_included
+    is_finance_included: bool = copier_data.get(AnswerKeys.FINANCE, False) is True
+    needs_migration_files = needs_migration_files or is_finance_included
     # Scheduler component: job_execution history table. Postgres only — the
     # table lives in a ``scheduler`` schema (CREATE SCHEMA), which SQLite
     # can't run; SQLite scheduler stacks get the table via create_all.
@@ -374,8 +377,12 @@ def generate_with_copier(
             is True,
             AnswerKeys.BLOG: is_blog_included,
             AnswerKeys.PAYMENT: is_payment_included,
+            AnswerKeys.FINANCE: is_finance_included,
             AnswerKeys.SCHEDULER: is_scheduler_included,
             AnswerKeys.SCHEDULER_BACKEND: scheduler_backend_str,
+            # Finance tables live in a dedicated Postgres ``finance`` schema
+            # (dropped on SQLite); the migration variant is engine-resolved.
+            AnswerKeys.DATABASE_ENGINE: database_engine,
         }
         services = get_services_needing_migrations(context)
         if services:

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -16,7 +16,7 @@ Usage:
         generate_migration(project_path, "ai")
 """
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -76,6 +76,11 @@ class ForeignKeySpec:
     # (e.g. payment.payment_customer -> auth.user). When None, the
     # referenced table is assumed to live in the owning spec's schema.
     ref_schema: str | None = None
+    # Explicit constraint name for alter_tables FKs. Auto-derived as
+    # ``fk_<table>_<col>_<ref_table>`` when None, but that can exceed
+    # Postgres' 63-char identifier limit for long table/column names, so
+    # long FKs pass a short explicit name here.
+    name: str | None = None
 
 
 @dataclass
@@ -1173,6 +1178,2220 @@ PAYMENT_AUTH_LINK_MIGRATION = ServiceMigrationSpec(
 )
 
 
+# Finance service tables. Built up incrementally across the finance schema
+# tickets; all live in the default (public) schema so SQLite stacks get the
+# migration too (a Postgres-only ``schema=`` would forfeit that). Money and
+# scaled-integer columns use BigInteger — net worth / brokerage balances and
+# ``*_e8`` quantities/rates overflow int32.
+FINANCE_MIGRATION = ServiceMigrationSpec(
+    service_name="finance",
+    description="Finance service tables (currencies, fx rates)",
+    tables=[
+        # ----- Group F: reference data -------------------------------------
+        TableSpec(
+            name="finance_currency",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                # ISO-4217 or crypto ticker, lowercase (usd, eur, btc, usdc).
+                ColumnSpec("code", "sa.String(16)", nullable=False),
+                ColumnSpec("name", "sa.String(64)", nullable=False),
+                ColumnSpec("symbol", "sa.String(8)", nullable=True),
+                # Minor-unit exponent: usd=2, jpy=0, btc=8.
+                ColumnSpec("decimals", "sa.Integer()", nullable=False, default="2"),
+                ColumnSpec("kind", "sa.String(8)", nullable=False, default="'fiat'"),
+                ColumnSpec("is_active", "sa.Boolean()", nullable=False, default="True"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_currency_code", ["code"], unique=True),
+                IndexSpec("ix_finance_currency_kind", ["kind"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_currency_kind", "kind IN ('fiat', 'crypto')"
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_currency_decimals", "decimals BETWEEN 0 AND 18"
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_fx_rate",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("base_currency", "sa.String(16)", nullable=False),
+                ColumnSpec("quote_currency", "sa.String(16)", nullable=False),
+                ColumnSpec("rate_date", "sa.Date()", nullable=False),
+                # 1 base = rate_e8 / 1e8 quote. BigInteger: crypto rates × 1e8
+                # overflow int32.
+                ColumnSpec("rate_e8", "sa.BigInteger()", nullable=False),
+                ColumnSpec(
+                    "source", "sa.String(16)", nullable=False, default="'manual'"
+                ),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec(
+                    "ix_finance_fxrate_pair_date",
+                    ["base_currency", "quote_currency", "rate_date"],
+                ),
+                IndexSpec(
+                    "uq_finance_fxrate",
+                    ["base_currency", "quote_currency", "rate_date", "source"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                # RESTRICT (default): currencies are reference data, never
+                # deleted out from under a rate.
+                ForeignKeySpec(["base_currency"], "finance_currency", ["code"]),
+                ForeignKeySpec(["quote_currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_fxrate_source",
+                    "source IN ('manual', 'ecb', 'exchange_api', 'coingecko', "
+                    "'provider', 'derived')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_fxrate_distinct", "base_currency <> quote_currency"
+                ),
+            ],
+        ),
+        # ----- Group A: connections & sync ---------------------------------
+        TableSpec(
+            name="finance_institution",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("provider", "sa.String(16)", nullable=False),
+                # Plaid ins_xxx / SnapTrade brokerage id. Growing -> TEXT.
+                ColumnSpec("provider_institution_id", "sa.Text()", nullable=True),
+                ColumnSpec("name", "sa.String(128)", nullable=False),
+                ColumnSpec("domain", "sa.String(255)", nullable=True),
+                ColumnSpec("logo_url", "sa.Text()", nullable=True),
+                ColumnSpec("primary_color", "sa.String(16)", nullable=True),
+                ColumnSpec("url", "sa.Text()", nullable=True),
+                ColumnSpec("country", "sa.String(2)", nullable=True),
+                ColumnSpec(
+                    "oauth_required", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec(
+                    "uses_tokenized_account_numbers",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec(
+                    "uses_app_to_app", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec(
+                    "supported_products", "sa.JSON()", nullable=False, default="[]"
+                ),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_institution_provider", ["provider"]),
+                IndexSpec("ix_finance_institution_name", ["name"]),
+                IndexSpec(
+                    "uq_finance_institution_provider_extid",
+                    ["provider", "provider_institution_id"],
+                    unique=True,
+                    where="provider_institution_id IS NOT NULL",
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_institution_provider",
+                    "provider IN ('plaid', 'snaptrade', 'coinbase', "
+                    "'exchange_key', 'onchain', 'manual')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_connection",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                # owner_user_id is nullable: finance runs standalone (single
+                # user) without auth. The FK to user.id is added by
+                # finance_auth_link when the auth service is also included.
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                # organization_id is a reserved column (org tenancy not active
+                # yet); no FK until orgs go live.
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("institution_id", "sa.Integer()", nullable=True),
+                ColumnSpec("provider", "sa.String(16)", nullable=False),
+                ColumnSpec("connection_type", "sa.String(20)", nullable=False),
+                ColumnSpec("provider_item_id", "sa.Text()", nullable=True),
+                ColumnSpec("label", "sa.String(255)", nullable=True),
+                ColumnSpec(
+                    "environment",
+                    "sa.String(16)",
+                    nullable=False,
+                    default="'sandbox'",
+                ),
+                # AES-GCM ciphertext, encrypted/decrypted in the service layer.
+                ColumnSpec("access_token_encrypted", "sa.Text()", nullable=True),
+                ColumnSpec("api_key_encrypted", "sa.Text()", nullable=True),
+                ColumnSpec("api_secret_encrypted", "sa.Text()", nullable=True),
+                ColumnSpec("api_passphrase_encrypted", "sa.Text()", nullable=True),
+                ColumnSpec("refresh_token_encrypted", "sa.Text()", nullable=True),
+                # Public on-chain address is not a secret.
+                ColumnSpec("wallet_address", "sa.Text()", nullable=True),
+                ColumnSpec("wallet_chain", "sa.Text()", nullable=True),
+                ColumnSpec("capabilities", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec(
+                    "status", "sa.String(24)", nullable=False, default="'healthy'"
+                ),
+                ColumnSpec("status_detail", "sa.Text()", nullable=True),
+                ColumnSpec("last_error_code", "sa.Text()", nullable=True),
+                ColumnSpec(
+                    "needs_user_action",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec("sync_cursor", "sa.Text()", nullable=True),
+                ColumnSpec("days_requested", "sa.Integer()", nullable=True),
+                ColumnSpec("consent_expiration_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("last_successful_sync_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("last_sync_attempt_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("removed_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_connection_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_connection_org", ["organization_id"]),
+                IndexSpec("ix_finance_connection_institution", ["institution_id"]),
+                IndexSpec("ix_finance_connection_needs_action", ["needs_user_action"]),
+                IndexSpec("ix_finance_connection_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "ix_finance_connection_owner_status",
+                    ["owner_user_id", "status"],
+                ),
+                IndexSpec(
+                    "uq_finance_connection_provider_item",
+                    ["provider", "provider_item_id"],
+                    unique=True,
+                    where="provider_item_id IS NOT NULL AND deleted_at IS NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_connection_wallet",
+                    ["owner_user_id", "provider", "wallet_address"],
+                    unique=True,
+                    where="wallet_address IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["institution_id"],
+                    "finance_institution",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_connection_provider",
+                    "provider IN ('plaid', 'snaptrade', 'coinbase', "
+                    "'exchange_key', 'onchain', 'manual')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_connection_type",
+                    "connection_type IN ('oauth_access_token', 'api_key_secret', "
+                    "'onchain_address', 'aggregator_token', 'manual')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_connection_environment",
+                    "environment IN ('sandbox', 'production')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_connection_status",
+                    "status IN ('healthy', 'login_required', 'pending_expiration', "
+                    "'pending_disconnect', 'consent_expired', 'revoked', 'error', "
+                    "'loading', 'manual')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_webhook_event",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("connection_id", "sa.Integer()", nullable=True),
+                ColumnSpec("provider", "sa.String(16)", nullable=False),
+                ColumnSpec("provider_item_id", "sa.Text()", nullable=True),
+                ColumnSpec("webhook_type", "sa.Text()", nullable=True),
+                ColumnSpec("webhook_code", "sa.Text()", nullable=True),
+                ColumnSpec("provider_event_id", "sa.Text()", nullable=True),
+                ColumnSpec("payload", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec(
+                    "status", "sa.String(16)", nullable=False, default="'received'"
+                ),
+                ColumnSpec("error", "sa.Text()", nullable=True),
+                ColumnSpec("received_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("processed_at", "sa.DateTime()", nullable=True),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_webhook_connection", ["connection_id"]),
+                IndexSpec("ix_finance_webhook_item", ["provider_item_id"]),
+                IndexSpec(
+                    "ix_finance_webhook_status_received", ["status", "received_at"]
+                ),
+                IndexSpec(
+                    "uq_finance_webhook_event",
+                    ["provider", "provider_event_id"],
+                    unique=True,
+                    where="provider_event_id IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["connection_id"],
+                    "finance_connection",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_webhook_provider",
+                    "provider IN ('plaid', 'snaptrade', 'coinbase')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_webhook_status",
+                    "status IN ('received', 'processed', 'ignored', 'error')",
+                ),
+            ],
+        ),
+        # ----- Group B: accounts & balances --------------------------------
+        TableSpec(
+            name="finance_account",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                # NULL connection => a manual asset (real estate, vehicle, etc.).
+                ColumnSpec("connection_id", "sa.Integer()", nullable=True),
+                ColumnSpec("institution_id", "sa.Integer()", nullable=True),
+                ColumnSpec("provider", "sa.String(16)", nullable=False),
+                ColumnSpec("provider_account_id", "sa.Text()", nullable=True),
+                # Stable across relinks (a new Item mints a new provider id).
+                ColumnSpec("persistent_account_id", "sa.Text()", nullable=True),
+                ColumnSpec("name", "sa.String(255)", nullable=False),
+                ColumnSpec("official_name", "sa.String(255)", nullable=True),
+                ColumnSpec("mask", "sa.String(8)", nullable=True),
+                # Plaid top-level type / subtype — growing taxonomy, TEXT.
+                ColumnSpec("type", "sa.Text()", nullable=True),
+                ColumnSpec("subtype", "sa.Text()", nullable=True),
+                # Normalized internal type + classification, STORED for signing.
+                ColumnSpec("account_type", "sa.String(24)", nullable=False),
+                ColumnSpec("classification", "sa.String(12)", nullable=False),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("current_balance", "sa.BigInteger()", nullable=True),
+                ColumnSpec("available_balance", "sa.BigInteger()", nullable=True),
+                ColumnSpec("credit_limit", "sa.BigInteger()", nullable=True),
+                ColumnSpec("balance_as_of", "sa.DateTime()", nullable=True),
+                ColumnSpec(
+                    "is_manual", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec(
+                    "is_hidden", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec(
+                    "is_closed", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec(
+                    "is_on_budget", "sa.Boolean()", nullable=False, default="True"
+                ),
+                ColumnSpec("linked_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("last_synced_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_account_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_account_org", ["organization_id"]),
+                IndexSpec("ix_finance_account_connection", ["connection_id"]),
+                IndexSpec("ix_finance_account_institution", ["institution_id"]),
+                IndexSpec("ix_finance_account_persistent", ["persistent_account_id"]),
+                IndexSpec("ix_finance_account_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "ix_finance_account_owner_type", ["owner_user_id", "account_type"]
+                ),
+                IndexSpec(
+                    "ix_finance_account_owner_classification",
+                    ["owner_user_id", "classification"],
+                ),
+                IndexSpec(
+                    "uq_finance_account_provider",
+                    ["connection_id", "provider_account_id"],
+                    unique=True,
+                    where="provider_account_id IS NOT NULL AND deleted_at IS NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["connection_id"],
+                    "finance_connection",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(
+                    ["institution_id"],
+                    "finance_institution",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_account_type",
+                    "account_type IN ('checking', 'savings', 'credit_card', 'loan', "
+                    "'investment', 'brokerage', 'crypto', 'property', 'vehicle', "
+                    "'cash', 'other_asset', 'other_liability')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_account_classification",
+                    "classification IN ('asset', 'liability')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_account_provider",
+                    "provider IN ('plaid', 'snaptrade', 'coinbase', 'exchange_key', "
+                    "'onchain', 'manual')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_liability_detail",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=False),
+                ColumnSpec("liability_type", "sa.Text()", nullable=True),
+                ColumnSpec("last_statement_balance", "sa.BigInteger()", nullable=True),
+                ColumnSpec("last_statement_issue_date", "sa.Date()", nullable=True),
+                ColumnSpec("last_payment_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("last_payment_date", "sa.Date()", nullable=True),
+                ColumnSpec("minimum_payment_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("next_payment_due_date", "sa.Date()", nullable=True),
+                ColumnSpec("origination_date", "sa.Date()", nullable=True),
+                ColumnSpec("origination_principal", "sa.BigInteger()", nullable=True),
+                ColumnSpec("outstanding_balance", "sa.BigInteger()", nullable=True),
+                # basis points (avoids Decimal): 19.99% APR = 1999.
+                ColumnSpec("interest_rate_bps", "sa.Integer()", nullable=True),
+                ColumnSpec("ytd_interest_paid", "sa.BigInteger()", nullable=True),
+                ColumnSpec("ytd_principal_paid", "sa.BigInteger()", nullable=True),
+                ColumnSpec("loan_term_months", "sa.Integer()", nullable=True),
+                ColumnSpec("is_overdue", "sa.Boolean()", nullable=True),
+                ColumnSpec("aprs", "sa.JSON()", nullable=False, default="[]"),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("raw", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_liability_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_liability_account", ["account_id"]),
+                IndexSpec("uq_finance_liability_account", ["account_id"], unique=True),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+        ),
+        TableSpec(
+            name="finance_balance_snapshot",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=False),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("balance_date", "sa.Date()", nullable=False),
+                ColumnSpec("balance", "sa.BigInteger()", nullable=False, default="0"),
+                ColumnSpec("available_balance", "sa.BigInteger()", nullable=True),
+                ColumnSpec("cash_balance", "sa.BigInteger()", nullable=True),
+                ColumnSpec("holdings_value", "sa.BigInteger()", nullable=True),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("base_currency_value", "sa.BigInteger()", nullable=True),
+                ColumnSpec("source", "sa.String(16)", nullable=False, default="'sync'"),
+                ColumnSpec(
+                    "is_estimated", "sa.Boolean()", nullable=False, default="False"
+                ),
+            ],
+            indexes=[
+                IndexSpec(
+                    "ix_finance_balsnap_account_date", ["account_id", "balance_date"]
+                ),
+                IndexSpec(
+                    "ix_finance_balsnap_owner_date", ["owner_user_id", "balance_date"]
+                ),
+                IndexSpec(
+                    "uq_finance_balsnap",
+                    ["account_id", "balance_date"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_balsnap_source",
+                    "source IN ('sync', 'provider', 'computed', 'carried_forward', "
+                    "'manual')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_net_worth_snapshot",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("as_of_date", "sa.Date()", nullable=False),
+                ColumnSpec(
+                    "total_assets_amount",
+                    "sa.BigInteger()",
+                    nullable=False,
+                    default="0",
+                ),
+                ColumnSpec(
+                    "total_liabilities_amount",
+                    "sa.BigInteger()",
+                    nullable=False,
+                    default="0",
+                ),
+                ColumnSpec(
+                    "net_worth_amount", "sa.BigInteger()", nullable=False, default="0"
+                ),
+                ColumnSpec("cash_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("investments_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("other_assets_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("breakdown", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec(
+                    "is_estimated", "sa.Boolean()", nullable=False, default="False"
+                ),
+            ],
+            indexes=[
+                IndexSpec(
+                    "ix_finance_networth_owner_date", ["owner_user_id", "as_of_date"]
+                ),
+                IndexSpec(
+                    "ix_finance_networth_org_date", ["organization_id", "as_of_date"]
+                ),
+                IndexSpec(
+                    "uq_finance_networth",
+                    ["owner_user_id", "as_of_date", "currency"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+        ),
+        TableSpec(
+            name="finance_valuation",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=False),
+                ColumnSpec("as_of_date", "sa.Date()", nullable=False),
+                ColumnSpec("value", "sa.BigInteger()", nullable=False, default="0"),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec(
+                    "source", "sa.String(16)", nullable=False, default="'manual'"
+                ),
+                ColumnSpec("source_ref", "sa.Text()", nullable=True),
+                ColumnSpec(
+                    "is_estimate", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("fetched_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("is_stale", "sa.Boolean()", nullable=False, default="False"),
+                ColumnSpec("stale_after_days", "sa.Integer()", nullable=True),
+                ColumnSpec("note", "sa.Text()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec(
+                    "ix_finance_valuation_owner_date", ["owner_user_id", "as_of_date"]
+                ),
+                IndexSpec(
+                    "ix_finance_valuation_account_date", ["account_id", "as_of_date"]
+                ),
+                IndexSpec("ix_finance_valuation_source", ["source"]),
+                IndexSpec(
+                    "uq_finance_valuation",
+                    ["account_id", "as_of_date", "source"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_valuation_source",
+                    "source IN ('manual', 'zillow', 'kbb', 'exchange_api', 'onchain', "
+                    "'plaid', 'snaptrade', 'coingecko', 'reconciliation')",
+                ),
+            ],
+        ),
+        # ----- Group C (core): transactions, splits, transfers -------------
+        # forward/circular FK columns (transfer_group_id, category_id,
+        # merchant_id, recurring_stream_id, import_batch_id) are created here
+        # WITHOUT their FK; the constraints are added in FINANCE_MIGRATION's
+        # alter_tables (transfer_group, this ticket) or later tickets'
+        # alter_tables (category/merchant/recurring/import) once the target
+        # tables exist — all in the same generated migration file, so the FKs
+        # apply after every table is created.
+        TableSpec(
+            name="finance_transaction",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=False),
+                ColumnSpec("connection_id", "sa.Integer()", nullable=True),
+                ColumnSpec("import_batch_id", "sa.Integer()", nullable=True),
+                # Dedup: LANE 1 = (account_id, source, external_id);
+                # LANE 2 = (account_id, import_hash). ck_dedup_lane forbids both.
+                ColumnSpec("source", "sa.String(16)", nullable=False),
+                ColumnSpec("external_id", "sa.Text()", nullable=True),
+                ColumnSpec("external_id_source", "sa.Text()", nullable=True),
+                ColumnSpec("import_hash", "sa.String(64)", nullable=True),
+                ColumnSpec(
+                    "within_day_ordinal", "sa.Integer()", nullable=False, default="0"
+                ),
+                ColumnSpec(
+                    "dedup_status", "sa.String(16)", nullable=False, default="'unique'"
+                ),
+                ColumnSpec("canonical_transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "source_precedence", "sa.Integer()", nullable=False, default="0"
+                ),
+                # Sign-normalized (negative = outflow); raw_amount as delivered.
+                ColumnSpec("amount", "sa.BigInteger()", nullable=False, default="0"),
+                ColumnSpec("raw_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("raw_sign_convention", "sa.Text()", nullable=True),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("unofficial_currency_code", "sa.Text()", nullable=True),
+                ColumnSpec("date", "sa.Date()", nullable=False),
+                ColumnSpec("authorized_date", "sa.Date()", nullable=True),
+                ColumnSpec("datetime", "sa.DateTime()", nullable=True),
+                ColumnSpec("name", "sa.Text()", nullable=True),
+                ColumnSpec("original_description", "sa.Text()", nullable=True),
+                ColumnSpec("merchant_id", "sa.Integer()", nullable=True),
+                ColumnSpec("merchant_name", "sa.Text()", nullable=True),
+                ColumnSpec("merchant_entity_id", "sa.Text()", nullable=True),
+                ColumnSpec("memo", "sa.Text()", nullable=True),
+                ColumnSpec("check_number", "sa.String(32)", nullable=True),
+                ColumnSpec("payment_channel", "sa.Text()", nullable=True),
+                ColumnSpec("pfc_primary", "sa.Text()", nullable=True),
+                ColumnSpec("pfc_detailed", "sa.Text()", nullable=True),
+                ColumnSpec("pfc_confidence_level", "sa.Text()", nullable=True),
+                ColumnSpec("category_id", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "category_source",
+                    "sa.String(12)",
+                    nullable=False,
+                    default="'unset'",
+                ),
+                ColumnSpec(
+                    "is_user_categorized",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec(
+                    "is_reviewed", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("pending", "sa.Boolean()", nullable=False, default="False"),
+                ColumnSpec("pending_provider_id", "sa.Text()", nullable=True),
+                ColumnSpec("pending_transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "status", "sa.String(12)", nullable=False, default="'posted'"
+                ),
+                ColumnSpec(
+                    "is_transfer", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("transfer_group_id", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "transfer_pair_transaction_id", "sa.Integer()", nullable=True
+                ),
+                ColumnSpec("is_split", "sa.Boolean()", nullable=False, default="False"),
+                ColumnSpec(
+                    "excluded_from_reports",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec(
+                    "is_reversal", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("reverses_transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec("recurring_stream_id", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "reconciled_status",
+                    "sa.String(12)",
+                    nullable=False,
+                    default="'uncleared'",
+                ),
+                ColumnSpec("location", "sa.JSON()", nullable=True),
+                ColumnSpec("counterparties", "sa.JSON()", nullable=True),
+                ColumnSpec("raw_payload", "sa.JSON()", nullable=True),
+                ColumnSpec(
+                    "is_removed", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("removed_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_txn_owner_date", ["owner_user_id", "date"]),
+                IndexSpec("ix_finance_txn_account_date", ["account_id", "date"]),
+                IndexSpec(
+                    "ix_finance_txn_owner_cat_date",
+                    ["owner_user_id", "category_id", "date"],
+                ),
+                IndexSpec("ix_finance_txn_merchant", ["merchant_id"]),
+                IndexSpec("ix_finance_txn_merchant_entity", ["merchant_entity_id"]),
+                IndexSpec("ix_finance_txn_category", ["category_id"]),
+                IndexSpec("ix_finance_txn_connection", ["connection_id"]),
+                IndexSpec("ix_finance_txn_batch", ["import_batch_id"]),
+                IndexSpec("ix_finance_txn_recurring", ["recurring_stream_id"]),
+                IndexSpec("ix_finance_txn_transfer_group", ["transfer_group_id"]),
+                IndexSpec("ix_finance_txn_canonical", ["canonical_transaction_id"]),
+                IndexSpec("ix_finance_txn_pending_link", ["pending_transaction_id"]),
+                IndexSpec("ix_finance_txn_pair", ["transfer_pair_transaction_id"]),
+                IndexSpec("ix_finance_txn_reverses", ["reverses_transaction_id"]),
+                IndexSpec("ix_finance_txn_pending", ["pending"]),
+                IndexSpec("ix_finance_txn_is_transfer", ["is_transfer"]),
+                IndexSpec("ix_finance_txn_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_txn_external",
+                    ["account_id", "source", "external_id"],
+                    unique=True,
+                    where="external_id IS NOT NULL AND deleted_at IS NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_txn_hash",
+                    ["account_id", "import_hash"],
+                    unique=True,
+                    where=(
+                        "external_id IS NULL AND import_hash IS NOT NULL "
+                        "AND deleted_at IS NULL"
+                    ),
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(
+                    ["connection_id"],
+                    "finance_connection",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+                # Self-FKs (nullable) — pending/canonical/pair/reversal linkage.
+                ForeignKeySpec(
+                    ["canonical_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["pending_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["transfer_pair_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["reverses_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_txn_source",
+                    "source IN ('plaid', 'snaptrade', 'ofx', 'qfx', 'qif', 'csv', "
+                    "'manual', 'coinbase', 'onchain', 'simplefin', 'teller')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_txn_status",
+                    "status IN ('pending', 'posted', 'removed')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_txn_dedup_status",
+                    "dedup_status IN ('unique', 'primary', 'duplicate', 'linked')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_txn_category_source",
+                    "category_source IN ('provider', 'ml', 'rule', 'user', 'unset')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_txn_reconciled",
+                    "reconciled_status IN ('uncleared', 'cleared', 'reconciled')",
+                ),
+                # A row occupies exactly one dedup lane.
+                CheckConstraintSpec(
+                    "ck_finance_txn_dedup_lane",
+                    "NOT (external_id IS NOT NULL AND import_hash IS NOT NULL)",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_transaction_split",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("parent_transaction_id", "sa.Integer()", nullable=False),
+                ColumnSpec("category_id", "sa.Integer()", nullable=True),
+                ColumnSpec("merchant_id", "sa.Integer()", nullable=True),
+                ColumnSpec("amount", "sa.BigInteger()", nullable=False, default="0"),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("memo", "sa.Text()", nullable=True),
+                ColumnSpec("sort_order", "sa.Integer()", nullable=False, default="0"),
+                ColumnSpec("note", "sa.Text()", nullable=True),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_split_parent", ["parent_transaction_id"]),
+                IndexSpec("ix_finance_split_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_split_category", ["category_id"]),
+                IndexSpec("ix_finance_split_merchant", ["merchant_id"]),
+                IndexSpec(
+                    "uq_finance_split_parent_sort",
+                    ["parent_transaction_id", "sort_order"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["parent_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+        ),
+        TableSpec(
+            name="finance_transfer",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("from_account_id", "sa.Integer()", nullable=True),
+                ColumnSpec("to_account_id", "sa.Integer()", nullable=True),
+                ColumnSpec("from_transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec("to_transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec("amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("transfer_date", "sa.Date()", nullable=True),
+                ColumnSpec("transfer_group_key", "sa.Text()", nullable=True),
+                ColumnSpec(
+                    "is_credit_card_payment",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec("match_method", "sa.String(20)", nullable=False),
+                ColumnSpec("confidence", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "status", "sa.String(12)", nullable=False, default="'suggested'"
+                ),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_transfer_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_transfer_from_account", ["from_account_id"]),
+                IndexSpec("ix_finance_transfer_to_account", ["to_account_id"]),
+                IndexSpec("ix_finance_transfer_from_txn", ["from_transaction_id"]),
+                IndexSpec("ix_finance_transfer_to_txn", ["to_transaction_id"]),
+                IndexSpec("ix_finance_transfer_group_key", ["transfer_group_key"]),
+                IndexSpec(
+                    "uq_finance_transfer_from",
+                    ["from_transaction_id"],
+                    unique=True,
+                    where="from_transaction_id IS NOT NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_transfer_to",
+                    ["to_transaction_id"],
+                    unique=True,
+                    where="to_transaction_id IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["from_account_id"],
+                    "finance_account",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["to_account_id"], "finance_account", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["from_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(
+                    ["to_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_transfer_method",
+                    "match_method IN ('auto_amount_date', 'plaid_transfer', "
+                    "'user_manual', 'rule')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_transfer_status",
+                    "status IN ('suggested', 'confirmed', 'rejected')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_transfer_distinct",
+                    "from_transaction_id IS NULL OR to_transaction_id IS NULL "
+                    "OR from_transaction_id <> to_transaction_id",
+                ),
+            ],
+        ),
+        # ----- Group D (ref): categories, merchants, tags, rules ----------
+        # These resolve the category_id / merchant_id forward FKs left as plain
+        # columns on finance_transaction and finance_transaction_split; the FKs
+        # are added below in alter_tables, after these target tables exist.
+        TableSpec(
+            name="finance_category",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                # NULL owner = system/global seed row (Plaid PFC tree).
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("parent_id", "sa.Integer()", nullable=True),
+                ColumnSpec("name", "sa.String(128)", nullable=False),
+                ColumnSpec("slug", "sa.String(96)", nullable=False),
+                ColumnSpec("classification", "sa.String(12)", nullable=False),
+                ColumnSpec("plaid_pfc_primary", "sa.Text()", nullable=True),
+                ColumnSpec("plaid_pfc_detailed", "sa.Text()", nullable=True),
+                ColumnSpec("icon", "sa.String(64)", nullable=True),
+                ColumnSpec("color", "sa.String(16)", nullable=True),
+                ColumnSpec(
+                    "is_system", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec(
+                    "is_archived", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("sort_order", "sa.Integer()", nullable=False, default="0"),
+                ColumnSpec("tax_line", "sa.Text()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_category_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_category_parent", ["parent_id"]),
+                IndexSpec("ix_finance_category_pfc", ["plaid_pfc_detailed"]),
+                IndexSpec(
+                    "uq_finance_category_system_slug",
+                    ["slug"],
+                    unique=True,
+                    where="owner_user_id IS NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_category_user_slug",
+                    ["owner_user_id", "slug"],
+                    unique=True,
+                    where="owner_user_id IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["parent_id"], "finance_category", ["id"], ondelete="SET NULL"
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_category_classification",
+                    "classification IN ('income', 'expense', 'transfer')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_category_alias",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("category_id", "sa.Integer()", nullable=False),
+                ColumnSpec("alias_text", "sa.Text()", nullable=False),
+                ColumnSpec("normalized_alias", "sa.Text()", nullable=False),
+                ColumnSpec("source", "sa.Text()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_catalias_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_catalias_category", ["category_id"]),
+                IndexSpec("ix_finance_catalias_normalized", ["normalized_alias"]),
+                IndexSpec(
+                    "uq_finance_catalias_owner_norm",
+                    ["owner_user_id", "normalized_alias"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["category_id"], "finance_category", ["id"], ondelete="CASCADE"
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_merchant",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                # NULL owner = global/provider-seeded merchant.
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("name", "sa.String(255)", nullable=False),
+                ColumnSpec("normalized_name", "sa.String(255)", nullable=False),
+                ColumnSpec("source", "sa.String(12)", nullable=False),
+                ColumnSpec("provider_merchant_id", "sa.Text()", nullable=True),
+                ColumnSpec("logo_url", "sa.Text()", nullable=True),
+                ColumnSpec("website_url", "sa.Text()", nullable=True),
+                ColumnSpec("default_category_id", "sa.Integer()", nullable=True),
+                ColumnSpec("service_type", "sa.Text()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_merchant_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_merchant_org", ["organization_id"]),
+                IndexSpec("ix_finance_merchant_normalized", ["normalized_name"]),
+                IndexSpec("ix_finance_merchant_default_cat", ["default_category_id"]),
+                IndexSpec("ix_finance_merchant_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_merchant_global",
+                    ["normalized_name"],
+                    unique=True,
+                    where="owner_user_id IS NULL AND deleted_at IS NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_merchant_user",
+                    ["owner_user_id", "normalized_name"],
+                    unique=True,
+                    where="owner_user_id IS NOT NULL AND deleted_at IS NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_merchant_provider",
+                    ["source", "provider_merchant_id"],
+                    unique=True,
+                    where="provider_merchant_id IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["default_category_id"],
+                    "finance_category",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_merchant_source",
+                    "source IN ('plaid', 'user', 'system', 'rule', 'snaptrade')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_tag",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("name", "sa.String(64)", nullable=False),
+                ColumnSpec("normalized_name", "sa.String(64)", nullable=False),
+                ColumnSpec("color", "sa.String(16)", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_tag_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_tag_org", ["organization_id"]),
+                IndexSpec("ix_finance_tag_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_tag_owner_name",
+                    ["owner_user_id", "normalized_name"],
+                    unique=True,
+                    where="deleted_at IS NULL",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_transaction_tag",
+            columns=[
+                # Composite PK (transaction_id, tag_id) — pure join table.
+                ColumnSpec(
+                    "transaction_id", "sa.Integer()", nullable=False, primary_key=True
+                ),
+                ColumnSpec("tag_id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("split_id", "sa.Integer()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_txntag_tag", ["tag_id"]),
+                IndexSpec("ix_finance_txntag_split", ["split_id"]),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(["tag_id"], "finance_tag", ["id"], ondelete="CASCADE"),
+                ForeignKeySpec(
+                    ["split_id"],
+                    "finance_transaction_split",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_rule",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("name", "sa.String(128)", nullable=False),
+                ColumnSpec("priority", "sa.Integer()", nullable=False, default="100"),
+                ColumnSpec(
+                    "is_enabled", "sa.Boolean()", nullable=False, default="True"
+                ),
+                ColumnSpec("conditions", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("actions", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec(
+                    "stop_processing", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("match_count", "sa.Integer()", nullable=False, default="0"),
+                ColumnSpec("last_matched_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_rule_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_rule_org", ["organization_id"]),
+                IndexSpec(
+                    "ix_finance_rule_owner_priority", ["owner_user_id", "priority"]
+                ),
+                IndexSpec("ix_finance_rule_deleted", ["deleted_at"]),
+            ],
+        ),
+        # ----- Group E (investments): securities, prices, holdings, trades -
+        TableSpec(
+            name="finance_security",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                # Global catalog — no owner. All taxonomy fields are plain text.
+                ColumnSpec("provider", "sa.Text()", nullable=True),
+                ColumnSpec("provider_security_id", "sa.Text()", nullable=True),
+                ColumnSpec("figi", "sa.Text()", nullable=True),
+                ColumnSpec("cusip", "sa.String(16)", nullable=True),
+                ColumnSpec("isin", "sa.String(16)", nullable=True),
+                ColumnSpec("sedol", "sa.String(16)", nullable=True),
+                ColumnSpec("ticker", "sa.String(32)", nullable=True),
+                ColumnSpec("name", "sa.Text()", nullable=True),
+                ColumnSpec("security_type", "sa.Text()", nullable=True),
+                ColumnSpec("exchange_mic", "sa.String(10)", nullable=True),
+                ColumnSpec("exchange_operating_mic", "sa.String(10)", nullable=True),
+                ColumnSpec("country_code", "sa.String(2)", nullable=True),
+                ColumnSpec("currency", "sa.String(16)", nullable=True),
+                ColumnSpec(
+                    "is_cash_equivalent",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec(
+                    "is_crypto", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("coingecko_id", "sa.Text()", nullable=True),
+                ColumnSpec("onchain_contract", "sa.Text()", nullable=True),
+                ColumnSpec("onchain_chain", "sa.Text()", nullable=True),
+                ColumnSpec("close_price", "sa.BigInteger()", nullable=True),
+                ColumnSpec("price_scale", "sa.Integer()", nullable=False, default="2"),
+                ColumnSpec("close_price_as_of", "sa.Date()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_security_ticker", ["ticker"]),
+                IndexSpec("ix_finance_security_cusip", ["cusip"]),
+                IndexSpec("ix_finance_security_isin", ["isin"]),
+                IndexSpec(
+                    "ix_finance_security_provider_secid", ["provider_security_id"]
+                ),
+                IndexSpec("ix_finance_security_type", ["security_type"]),
+                IndexSpec(
+                    "uq_finance_security_provider",
+                    ["provider", "provider_security_id"],
+                    unique=True,
+                    where="provider_security_id IS NOT NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_security_figi",
+                    ["figi"],
+                    unique=True,
+                    where="figi IS NOT NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_security_cusip",
+                    ["cusip"],
+                    unique=True,
+                    where="cusip IS NOT NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_security_isin",
+                    ["isin"],
+                    unique=True,
+                    where="isin IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+        ),
+        TableSpec(
+            name="finance_security_price",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("security_id", "sa.Integer()", nullable=False),
+                ColumnSpec("price_date", "sa.Date()", nullable=False),
+                ColumnSpec("close_price", "sa.BigInteger()", nullable=False),
+                ColumnSpec("price_scale", "sa.Integer()", nullable=False, default="2"),
+                ColumnSpec("currency", "sa.String(16)", nullable=False),
+                ColumnSpec("source", "sa.String(16)", nullable=False),
+            ],
+            indexes=[
+                IndexSpec(
+                    "ix_finance_secprice_security_date",
+                    ["security_id", "price_date"],
+                ),
+                IndexSpec(
+                    "uq_finance_secprice",
+                    ["security_id", "price_date", "source"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["security_id"], "finance_security", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_secprice_source",
+                    "source IN ('plaid', 'snaptrade', 'exchange_api', 'onchain', "
+                    "'coingecko', 'manual', 'market_data')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_holding",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=False),
+                ColumnSpec("security_id", "sa.Integer()", nullable=False),
+                ColumnSpec("as_of_date", "sa.Date()", nullable=False),
+                # Units x 1e8 (fractional shares + crypto).
+                ColumnSpec("quantity_e8", "sa.BigInteger()", nullable=False),
+                ColumnSpec("cost_basis", "sa.BigInteger()", nullable=True),
+                ColumnSpec("average_cost", "sa.BigInteger()", nullable=True),
+                ColumnSpec("price", "sa.BigInteger()", nullable=True),
+                ColumnSpec("price_scale", "sa.Integer()", nullable=False, default="2"),
+                ColumnSpec("institution_value", "sa.BigInteger()", nullable=True),
+                ColumnSpec("vested_quantity_e8", "sa.BigInteger()", nullable=True),
+                ColumnSpec("currency", "sa.String(16)", nullable=False),
+                ColumnSpec("source", "sa.Text()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_holding_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_holding_account", ["account_id"]),
+                IndexSpec("ix_finance_holding_security", ["security_id"]),
+                IndexSpec(
+                    "ix_finance_holding_account_date", ["account_id", "as_of_date"]
+                ),
+                IndexSpec("ix_finance_holding_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_holding",
+                    ["account_id", "security_id", "as_of_date"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+                # RESTRICT: a security with holdings can't be deleted (plain FK
+                # = NO ACTION, same guard, matching the currency-FK convention).
+                ForeignKeySpec(["security_id"], "finance_security", ["id"]),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+        ),
+        TableSpec(
+            name="finance_trade",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=False),
+                ColumnSpec("security_id", "sa.Integer()", nullable=True),
+                ColumnSpec("transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec("connection_id", "sa.Integer()", nullable=True),
+                # Forward FK (finance_import_batch, FIN-10) — plain column here.
+                ColumnSpec("import_batch_id", "sa.Integer()", nullable=True),
+                # Same dual-lane dedup as cash transactions.
+                ColumnSpec("source", "sa.String(16)", nullable=False),
+                ColumnSpec("external_id", "sa.Text()", nullable=True),
+                ColumnSpec("external_id_source", "sa.Text()", nullable=True),
+                ColumnSpec("import_hash", "sa.String(64)", nullable=True),
+                ColumnSpec("type", "sa.String(16)", nullable=False),
+                ColumnSpec("subtype", "sa.Text()", nullable=True),
+                ColumnSpec("quantity_e8", "sa.BigInteger()", nullable=True),
+                ColumnSpec("price", "sa.BigInteger()", nullable=True),
+                ColumnSpec("price_scale", "sa.Integer()", nullable=False, default="2"),
+                ColumnSpec("amount", "sa.BigInteger()", nullable=False, default="0"),
+                ColumnSpec("raw_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("fees", "sa.BigInteger()", nullable=True),
+                ColumnSpec("currency", "sa.String(16)", nullable=False),
+                ColumnSpec("trade_date", "sa.Date()", nullable=False),
+                ColumnSpec("settle_date", "sa.Date()", nullable=True),
+                ColumnSpec("datetime", "sa.DateTime()", nullable=True),
+                ColumnSpec("name", "sa.Text()", nullable=True),
+                ColumnSpec("pending", "sa.Boolean()", nullable=False, default="False"),
+                ColumnSpec("raw_payload", "sa.JSON()", nullable=True),
+                ColumnSpec(
+                    "is_removed", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec(
+                    "ix_finance_trade_owner_date", ["owner_user_id", "trade_date"]
+                ),
+                IndexSpec(
+                    "ix_finance_trade_account_date", ["account_id", "trade_date"]
+                ),
+                IndexSpec("ix_finance_trade_security", ["security_id"]),
+                IndexSpec("ix_finance_trade_transaction", ["transaction_id"]),
+                IndexSpec("ix_finance_trade_connection", ["connection_id"]),
+                IndexSpec("ix_finance_trade_batch", ["import_batch_id"]),
+                IndexSpec("ix_finance_trade_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_trade_external",
+                    ["account_id", "source", "external_id"],
+                    unique=True,
+                    where="external_id IS NOT NULL AND deleted_at IS NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_trade_hash",
+                    ["account_id", "import_hash"],
+                    unique=True,
+                    where=(
+                        "external_id IS NULL AND import_hash IS NOT NULL "
+                        "AND deleted_at IS NULL"
+                    ),
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(
+                    ["security_id"], "finance_security", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["connection_id"],
+                    "finance_connection",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_trade_source",
+                    "source IN ('plaid', 'snaptrade', 'ofx', 'qfx', 'csv', "
+                    "'manual', 'coinbase', 'onchain')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_trade_type",
+                    "type IN ('buy', 'sell', 'dividend', 'interest', 'fee', "
+                    "'tax', 'transfer_in', 'transfer_out', 'deposit', "
+                    "'withdrawal', 'reinvest', 'split', 'cancel', 'other')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_trade_dedup_lane",
+                    "NOT (external_id IS NOT NULL AND import_hash IS NOT NULL)",
+                ),
+            ],
+        ),
+        # ----- Group F (analytics / import): recurring streams, budgets,
+        # baselines, insights, import pipeline, attachments, changelog -----
+        # finance_recurring_stream resolves finance_transaction.recurring_
+        # stream_id; finance_import_batch resolves the import_batch_id forward
+        # FKs on finance_transaction and finance_trade (all added below in
+        # alter_tables once these tables exist).
+        TableSpec(
+            name="finance_recurring_stream",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=True),
+                ColumnSpec("merchant_id", "sa.Integer()", nullable=True),
+                ColumnSpec("category_id", "sa.Integer()", nullable=True),
+                ColumnSpec("connection_id", "sa.Integer()", nullable=True),
+                ColumnSpec("provider_stream_id", "sa.Text()", nullable=True),
+                ColumnSpec("name", "sa.String(255)", nullable=False),
+                ColumnSpec("normalized_payee", "sa.Text()", nullable=True),
+                ColumnSpec("direction", "sa.String(8)", nullable=False),
+                ColumnSpec("frequency", "sa.String(16)", nullable=False),
+                ColumnSpec("average_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("last_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("expected_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec(
+                    "amount_is_variable",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec("amount_tolerance_bps", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("first_date", "sa.Date()", nullable=True),
+                ColumnSpec("last_date", "sa.Date()", nullable=True),
+                ColumnSpec("next_expected_date", "sa.Date()", nullable=True),
+                ColumnSpec(
+                    "occurrence_count", "sa.Integer()", nullable=False, default="0"
+                ),
+                ColumnSpec(
+                    "status",
+                    "sa.String(16)",
+                    nullable=False,
+                    default="'early_detection'",
+                ),
+                ColumnSpec("confidence", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "is_subscription",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec("is_active", "sa.Boolean()", nullable=False, default="True"),
+                ColumnSpec(
+                    "is_user_confirmed",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec("is_muted", "sa.Boolean()", nullable=False, default="False"),
+                ColumnSpec("service_type", "sa.Text()", nullable=True),
+                ColumnSpec("source", "sa.String(12)", nullable=False),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_recurring_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_recurring_account", ["account_id"]),
+                IndexSpec("ix_finance_recurring_merchant", ["merchant_id"]),
+                IndexSpec("ix_finance_recurring_category", ["category_id"]),
+                IndexSpec("ix_finance_recurring_connection", ["connection_id"]),
+                IndexSpec(
+                    "ix_finance_recurring_next",
+                    ["owner_user_id", "next_expected_date"],
+                ),
+                IndexSpec("ix_finance_recurring_status", ["status"]),
+                IndexSpec("ix_finance_recurring_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_recurring_provider",
+                    ["connection_id", "provider_stream_id"],
+                    unique=True,
+                    where="provider_stream_id IS NOT NULL",
+                ),
+                IndexSpec(
+                    "uq_finance_recurring_detected",
+                    ["owner_user_id", "account_id", "direction", "normalized_payee"],
+                    unique=True,
+                    where="provider_stream_id IS NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(
+                    ["merchant_id"], "finance_merchant", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["category_id"], "finance_category", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["connection_id"],
+                    "finance_connection",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_recurring_direction",
+                    "direction IN ('inflow', 'outflow')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_recurring_frequency",
+                    "frequency IN ('weekly', 'biweekly', 'semi_monthly', "
+                    "'monthly', 'bimonthly', 'quarterly', 'semi_annually', "
+                    "'annually', 'irregular', 'unknown')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_recurring_status",
+                    "status IN ('early_detection', 'mature', 'inactive', 'cancelled')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_recurring_source",
+                    "source IN ('plaid', 'derived', 'user')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_budget",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("name", "sa.String(128)", nullable=False),
+                ColumnSpec("period", "sa.String(16)", nullable=False),
+                ColumnSpec("start_date", "sa.Date()", nullable=False),
+                ColumnSpec("end_date", "sa.Date()", nullable=True),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("philosophy", "sa.Text()", nullable=True),
+                ColumnSpec("rollover", "sa.Boolean()", nullable=False, default="False"),
+                ColumnSpec("is_active", "sa.Boolean()", nullable=False, default="True"),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_budget_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_budget_org", ["organization_id"]),
+                IndexSpec("ix_finance_budget_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_budget_owner_name_start",
+                    ["owner_user_id", "name", "start_date"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_budget_period",
+                    "period IN ('monthly', 'weekly', 'quarterly', 'yearly', 'custom')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_budget_category",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("budget_id", "sa.Integer()", nullable=False),
+                # NULL category = the budget's overall line.
+                ColumnSpec("category_id", "sa.Integer()", nullable=True),
+                ColumnSpec("period_month", "sa.Integer()", nullable=True),
+                ColumnSpec(
+                    "allocated_amount", "sa.BigInteger()", nullable=False, default="0"
+                ),
+                ColumnSpec("goal_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec(
+                    "carryover_amount", "sa.BigInteger()", nullable=False, default="0"
+                ),
+                ColumnSpec(
+                    "rollover_enabled",
+                    "sa.Boolean()",
+                    nullable=False,
+                    default="False",
+                ),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_budgetcat_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_budgetcat_budget", ["budget_id"]),
+                IndexSpec("ix_finance_budgetcat_category", ["category_id"]),
+                IndexSpec("ix_finance_budgetcat_month", ["period_month"]),
+                IndexSpec(
+                    "uq_finance_budgetcat",
+                    ["budget_id", "category_id", "period_month"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["budget_id"], "finance_budget", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(
+                    ["category_id"], "finance_category", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+        ),
+        TableSpec(
+            name="finance_spending_baseline",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("category_id", "sa.Integer()", nullable=True),
+                ColumnSpec("merchant_id", "sa.Integer()", nullable=True),
+                ColumnSpec("window_months", "sa.Integer()", nullable=False),
+                ColumnSpec("period_month", "sa.Integer()", nullable=False),
+                ColumnSpec(
+                    "trailing_avg_amount",
+                    "sa.BigInteger()",
+                    nullable=False,
+                    default="0",
+                ),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec("computed_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_baseline_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_baseline_category", ["category_id"]),
+                IndexSpec("ix_finance_baseline_merchant", ["merchant_id"]),
+                IndexSpec(
+                    "uq_finance_baseline",
+                    [
+                        "owner_user_id",
+                        "category_id",
+                        "merchant_id",
+                        "window_months",
+                        "period_month",
+                    ],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["category_id"], "finance_category", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(
+                    ["merchant_id"], "finance_merchant", ["id"], ondelete="CASCADE"
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_baseline_window",
+                    "window_months IN (3, 6, 12)",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_insight",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("insight_type", "sa.Text()", nullable=False),
+                ColumnSpec("severity", "sa.String(16)", nullable=False),
+                ColumnSpec("title", "sa.Text()", nullable=False),
+                ColumnSpec("body", "sa.Text()", nullable=True),
+                ColumnSpec("related_account_id", "sa.Integer()", nullable=True),
+                ColumnSpec("related_transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec("related_category_id", "sa.Integer()", nullable=True),
+                ColumnSpec("related_stream_id", "sa.Integer()", nullable=True),
+                ColumnSpec("detected_amount", "sa.BigInteger()", nullable=True),
+                ColumnSpec("currency", "sa.String(16)", nullable=True),
+                ColumnSpec("dedup_key", "sa.Text()", nullable=False),
+                ColumnSpec("period_start", "sa.Date()", nullable=True),
+                ColumnSpec("period_end", "sa.Date()", nullable=True),
+                ColumnSpec("data", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("status", "sa.String(12)", nullable=False, default="'new'"),
+                ColumnSpec("is_read", "sa.Boolean()", nullable=False, default="False"),
+                ColumnSpec("dismissed_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("metadata", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_insight_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_insight_org", ["organization_id"]),
+                IndexSpec("ix_finance_insight_type", ["insight_type"]),
+                IndexSpec("ix_finance_insight_status", ["status"]),
+                IndexSpec("ix_finance_insight_account", ["related_account_id"]),
+                IndexSpec("ix_finance_insight_transaction", ["related_transaction_id"]),
+                IndexSpec("ix_finance_insight_category", ["related_category_id"]),
+                IndexSpec("ix_finance_insight_stream", ["related_stream_id"]),
+                IndexSpec(
+                    "ix_finance_insight_owner_read", ["owner_user_id", "is_read"]
+                ),
+                IndexSpec(
+                    "uq_finance_insight_dedup",
+                    ["owner_user_id", "dedup_key"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["related_account_id"],
+                    "finance_account",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(
+                    ["related_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(
+                    ["related_category_id"],
+                    "finance_category",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["related_stream_id"],
+                    "finance_recurring_stream",
+                    ["id"],
+                    ondelete="SET NULL",
+                    name="fk_finance_insight_stream",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_insight_severity",
+                    "severity IN ('info', 'warning', 'critical')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_insight_status",
+                    "status IN ('new', 'seen', 'dismissed', 'actioned')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_import_profile",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                # NULL owner = system seed profile (Chase CC, AMEX v2, ...).
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("institution_id", "sa.Integer()", nullable=True),
+                ColumnSpec("name", "sa.String(128)", nullable=False),
+                ColumnSpec("source_format", "sa.String(8)", nullable=False),
+                ColumnSpec(
+                    "header_signature", "sa.JSON()", nullable=False, default="{}"
+                ),
+                ColumnSpec("column_mapping", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("date_format", "sa.Text()", nullable=True),
+                ColumnSpec("amount_sign_convention", "sa.String(20)", nullable=False),
+                ColumnSpec("decimal_separator", "sa.String(1)", nullable=True),
+                ColumnSpec("thousands_separator", "sa.String(1)", nullable=True),
+                ColumnSpec(
+                    "currency", "sa.String(16)", nullable=False, default="'usd'"
+                ),
+                ColumnSpec(
+                    "is_system", "sa.Boolean()", nullable=False, default="False"
+                ),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_importprofile_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_importprofile_org", ["organization_id"]),
+                IndexSpec("ix_finance_importprofile_institution", ["institution_id"]),
+                IndexSpec("ix_finance_importprofile_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_importprofile_owner_name",
+                    ["owner_user_id", "name"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["institution_id"],
+                    "finance_institution",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_importprofile_format",
+                    "source_format IN ('csv', 'ofx', 'qfx', 'qif')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_importprofile_sign",
+                    "amount_sign_convention IN ('outflow_negative', "
+                    "'outflow_positive', 'split_debit_credit')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_import_batch",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("connection_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=True),
+                ColumnSpec("import_profile_id", "sa.Integer()", nullable=True),
+                ColumnSpec("source_type", "sa.String(16)", nullable=False),
+                ColumnSpec("file_name", "sa.String(255)", nullable=True),
+                ColumnSpec("file_sha256", "sa.Text()", nullable=True),
+                ColumnSpec("sync_cursor_before", "sa.Text()", nullable=True),
+                ColumnSpec("sync_cursor_after", "sa.Text()", nullable=True),
+                ColumnSpec("rows_total", "sa.Integer()", nullable=False, default="0"),
+                ColumnSpec(
+                    "rows_inserted", "sa.Integer()", nullable=False, default="0"
+                ),
+                ColumnSpec("rows_updated", "sa.Integer()", nullable=False, default="0"),
+                ColumnSpec(
+                    "rows_duplicate", "sa.Integer()", nullable=False, default="0"
+                ),
+                ColumnSpec("rows_error", "sa.Integer()", nullable=False, default="0"),
+                ColumnSpec(
+                    "status", "sa.String(16)", nullable=False, default="'pending'"
+                ),
+                ColumnSpec("error", "sa.Text()", nullable=True),
+                ColumnSpec("started_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("finished_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_importbatch_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_importbatch_org", ["organization_id"]),
+                IndexSpec("ix_finance_importbatch_connection", ["connection_id"]),
+                IndexSpec("ix_finance_importbatch_account", ["account_id"]),
+                IndexSpec("ix_finance_importbatch_profile", ["import_profile_id"]),
+                IndexSpec("ix_finance_importbatch_status", ["status"]),
+                IndexSpec(
+                    "ix_finance_importbatch_owner_started",
+                    ["owner_user_id", "started_at"],
+                ),
+                IndexSpec(
+                    "uq_finance_importbatch_file",
+                    ["owner_user_id", "file_sha256"],
+                    unique=True,
+                    where="file_sha256 IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["connection_id"],
+                    "finance_connection",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["import_profile_id"],
+                    "finance_import_profile",
+                    ["id"],
+                    ondelete="SET NULL",
+                    name="fk_finance_importbatch_profile",
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_importbatch_source",
+                    "source_type IN ('plaid_sync', 'snaptrade_sync', 'ofx', "
+                    "'qfx', 'qif', 'csv', 'manual')",
+                ),
+                CheckConstraintSpec(
+                    "ck_finance_importbatch_status",
+                    "status IN ('pending', 'processing', 'committed', 'failed', "
+                    "'rolled_back')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_import_batch_row",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("import_batch_id", "sa.Integer()", nullable=False),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("account_id", "sa.Integer()", nullable=True),
+                ColumnSpec("row_number", "sa.Integer()", nullable=False),
+                ColumnSpec("raw_line", "sa.Text()", nullable=True),
+                ColumnSpec("parsed", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("content_hash", "sa.String(64)", nullable=True),
+                ColumnSpec("fitid", "sa.Text()", nullable=True),
+                ColumnSpec("parsed_status", "sa.String(12)", nullable=False),
+                ColumnSpec("matched_transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec("matched_trade_id", "sa.Integer()", nullable=True),
+                ColumnSpec("reason", "sa.Text()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_importrow_batch", ["import_batch_id"]),
+                IndexSpec("ix_finance_importrow_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_importrow_account", ["account_id"]),
+                IndexSpec(
+                    "ix_finance_importrow_matched_txn", ["matched_transaction_id"]
+                ),
+                IndexSpec("ix_finance_importrow_matched_trade", ["matched_trade_id"]),
+                IndexSpec("ix_finance_importrow_hash", ["content_hash"]),
+                IndexSpec(
+                    "uq_finance_importrow_batch_num",
+                    ["import_batch_id", "row_number"],
+                    unique=True,
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["import_batch_id"],
+                    "finance_import_batch",
+                    ["id"],
+                    ondelete="CASCADE",
+                    name="fk_finance_importrow_batch",
+                ),
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["matched_transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="SET NULL",
+                    name="fk_finance_importrow_matched_txn",
+                ),
+                ForeignKeySpec(
+                    ["matched_trade_id"],
+                    "finance_trade",
+                    ["id"],
+                    ondelete="SET NULL",
+                    name="fk_finance_importrow_matched_trade",
+                ),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_importrow_status",
+                    "parsed_status IN ('parsed', 'inserted', 'updated', "
+                    "'duplicate', 'error', 'matched', 'skipped')",
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_attachment",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("organization_id", "sa.Integer()", nullable=True),
+                ColumnSpec("transaction_id", "sa.Integer()", nullable=True),
+                ColumnSpec("account_id", "sa.Integer()", nullable=True),
+                ColumnSpec("file_name", "sa.Text()", nullable=False),
+                ColumnSpec("content_type", "sa.Text()", nullable=True),
+                ColumnSpec("byte_size", "sa.Integer()", nullable=True),
+                ColumnSpec("storage_key", "sa.Text()", nullable=False),
+                ColumnSpec("sha256", "sa.Text()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_attachment_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_attachment_org", ["organization_id"]),
+                IndexSpec("ix_finance_attachment_transaction", ["transaction_id"]),
+                IndexSpec("ix_finance_attachment_account", ["account_id"]),
+                IndexSpec("ix_finance_attachment_deleted", ["deleted_at"]),
+                IndexSpec(
+                    "uq_finance_attachment_owner_sha",
+                    ["owner_user_id", "sha256"],
+                    unique=True,
+                    where="sha256 IS NOT NULL",
+                ),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="CASCADE",
+                ),
+                ForeignKeySpec(
+                    ["account_id"], "finance_account", ["id"], ondelete="CASCADE"
+                ),
+            ],
+        ),
+        TableSpec(
+            name="finance_transaction_changelog",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("transaction_id", "sa.Integer()", nullable=False),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("field", "sa.Text()", nullable=False),
+                ColumnSpec("old_value", "sa.Text()", nullable=True),
+                ColumnSpec("new_value", "sa.Text()", nullable=True),
+                ColumnSpec("change_source", "sa.Text()", nullable=False),
+                ColumnSpec("sync_cursor", "sa.Text()", nullable=True),
+                ColumnSpec("changed_at", "sa.DateTime()", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_changelog_transaction", ["transaction_id"]),
+                IndexSpec("ix_finance_changelog_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_changelog_changed", ["changed_at"]),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(
+                    ["transaction_id"],
+                    "finance_transaction",
+                    ["id"],
+                    ondelete="CASCADE",
+                    name="fk_finance_changelog_txn",
+                ),
+            ],
+        ),
+    ],
+    alter_tables=[
+        # Circular FK: finance_transaction.transfer_group_id ->
+        # finance_transfer.id (finance_transfer references finance_transaction),
+        # plus the category_id / merchant_id forward FKs now that Group D tables
+        # exist. One batch per table (SQLite recreates the table per batch).
+        AlterTableSpec(
+            name="finance_transaction",
+            add_foreign_keys=[
+                ForeignKeySpec(
+                    ["transfer_group_id"],
+                    "finance_transfer",
+                    ["id"],
+                    ondelete="SET NULL",
+                ),
+                ForeignKeySpec(
+                    ["category_id"], "finance_category", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["merchant_id"], "finance_merchant", ["id"], ondelete="SET NULL"
+                ),
+                # Short explicit names: the auto-derived
+                # fk_finance_transaction_recurring_stream_id_finance_recurring_
+                # stream exceeds Postgres' 63-char identifier limit.
+                ForeignKeySpec(
+                    ["recurring_stream_id"],
+                    "finance_recurring_stream",
+                    ["id"],
+                    ondelete="SET NULL",
+                    name="fk_finance_txn_recurring_stream",
+                ),
+                ForeignKeySpec(
+                    ["import_batch_id"],
+                    "finance_import_batch",
+                    ["id"],
+                    ondelete="SET NULL",
+                    name="fk_finance_txn_import_batch",
+                ),
+            ],
+        ),
+        AlterTableSpec(
+            name="finance_transaction_split",
+            add_foreign_keys=[
+                ForeignKeySpec(
+                    ["category_id"], "finance_category", ["id"], ondelete="SET NULL"
+                ),
+                ForeignKeySpec(
+                    ["merchant_id"], "finance_merchant", ["id"], ondelete="SET NULL"
+                ),
+            ],
+        ),
+        AlterTableSpec(
+            name="finance_trade",
+            add_foreign_keys=[
+                ForeignKeySpec(
+                    ["import_batch_id"],
+                    "finance_import_batch",
+                    ["id"],
+                    ondelete="SET NULL",
+                    name="fk_finance_trade_import_batch",
+                ),
+            ],
+        ),
+    ],
+)
+
+
+# Postgres schema finance tables live in (dropped on SQLite, which has none).
+FINANCE_SCHEMA = "finance"
+
+# Every finance table with an ``owner_user_id`` column. The auth-link migration
+# adds an FK from each to ``user.id`` when the auth service is present. Grows as
+# owner-scoped tables land across the schema tickets.
+_FINANCE_OWNED_TABLES: tuple[str, ...] = (
+    "finance_connection",
+    "finance_account",
+    "finance_liability_detail",
+    "finance_balance_snapshot",
+    "finance_net_worth_snapshot",
+    "finance_valuation",
+    "finance_transaction",
+    "finance_transaction_split",
+    "finance_transfer",
+    "finance_category",
+    "finance_category_alias",
+    "finance_merchant",
+    "finance_tag",
+    "finance_rule",
+    "finance_holding",
+    "finance_trade",
+    "finance_recurring_stream",
+    "finance_budget",
+    "finance_budget_category",
+    "finance_spending_baseline",
+    "finance_insight",
+    "finance_import_profile",
+    "finance_import_batch",
+    "finance_import_batch_row",
+    "finance_attachment",
+    "finance_transaction_changelog",
+)
+
+
+def _build_finance_auth_link(
+    *, schema: str | None, user_ref_schema: str | None
+) -> ServiceMigrationSpec:
+    """Owner FK from each owner-scoped finance table to the auth ``user`` table.
+
+    Emitted only when BOTH finance and auth are included (see
+    get_services_needing_migrations), so a standalone (no-auth) finance stack
+    never references a missing table. ON DELETE CASCADE: a deleted user takes
+    their finance data with them.
+
+    On Postgres the finance tables live in the ``finance`` schema while ``user``
+    lives in ``public``, so these are cross-schema FKs: ``schema`` puts the
+    batch-alter on the finance-schema tables and ``user_ref_schema`` qualifies
+    the referent. On SQLite both are None (single unqualified DB).
+    """
+    return ServiceMigrationSpec(
+        service_name="finance_auth_link",
+        description="Link finance owner_user_id columns to user.id (auth + finance)",
+        tables=[],
+        schema=schema,
+        alter_tables=[
+            AlterTableSpec(
+                name=table,
+                add_foreign_keys=[
+                    ForeignKeySpec(
+                        ["owner_user_id"],
+                        "user",
+                        ["id"],
+                        ondelete="CASCADE",
+                        ref_schema=user_ref_schema,
+                    ),
+                ],
+            )
+            for table in _FINANCE_OWNED_TABLES
+        ],
+    )
+
+
+# Static (SQLite / default) variant; the Postgres schema-qualified variant is
+# built on demand in _resolve_spec.
+FINANCE_AUTH_LINK_MIGRATION = _build_finance_auth_link(
+    schema=None, user_ref_schema=None
+)
+
+
 BLOG_MIGRATION = ServiceMigrationSpec(
     service_name="blog",
     description="Blog service tables (posts, tags, post/tag links)",
@@ -1424,7 +3643,7 @@ def upgrade() -> None:
         batch_op.add_column(sa.Column('{{ column.name }}', {{ column.type }}, nullable={{ column.nullable }}{% if column.server_default %}, server_default={{ column.server_default }}{% endif %}))
 {% endfor %}
 {% for fk in alter.add_foreign_keys %}
-        batch_op.create_foreign_key('fk_{{ alter.name }}_{{ fk.columns[0] }}_{{ fk.ref_table }}', '{{ fk.ref_table }}', {{ fk.columns }}, {{ fk.ref_columns }}{% if fk.ondelete %}, ondelete='{{ fk.ondelete }}'{% endif %}{% if fk.ref_schema %}, referent_schema='{{ fk.ref_schema }}'{% endif %})
+        batch_op.create_foreign_key('{{ fk.constraint_name }}', '{{ fk.ref_table }}', {{ fk.columns }}, {{ fk.ref_columns }}{% if fk.ondelete %}, ondelete='{{ fk.ondelete }}'{% endif %}{% if fk.ref_schema %}, referent_schema='{{ fk.ref_schema }}'{% endif %})
 {% endfor %}
 {% for index in alter.add_indexes %}
         batch_op.create_index('{{ index.name }}', {{ index.columns }}{% if index.unique %}, unique=True{% endif %}{% if index.where %}, sqlite_where=sa.text("{{ index.where }}"), postgresql_where=sa.text("{{ index.where }}"){% endif %})
@@ -1447,7 +3666,7 @@ def downgrade() -> None:
         batch_op.drop_index('{{ index.name }}')
 {% endfor %}
 {% for fk in alter.add_foreign_keys|reverse %}
-        batch_op.drop_constraint('fk_{{ alter.name }}_{{ fk.columns[0] }}_{{ fk.ref_table }}', type_='foreignkey')
+        batch_op.drop_constraint('{{ fk.constraint_name }}', type_='foreignkey')
 {% endfor %}
 {% for column in alter.add_columns|reverse %}
         batch_op.drop_column('{{ column.name }}')
@@ -1620,6 +3839,11 @@ def _render_migration(
                 "ref_columns": fk.ref_columns,
                 "ondelete": fk.ondelete,
                 "ref_schema": fk.ref_schema or spec.schema,
+                # Explicit name (short, for the 63-char Postgres limit) or the
+                # auto-derived default. Used identically on create and drop.
+                "constraint_name": (
+                    fk.name or f"fk_{alter.name}_{fk.columns[0]}_{fk.ref_table}"
+                ),
             }
             for fk in alter.add_foreign_keys
         ]
@@ -1686,6 +3910,20 @@ def _resolve_spec(
         per_user = flag == "yes" or flag is True
         if per_user:
             return _build_insights_migration(per_user=True)
+
+    # Finance tables live in a dedicated Postgres ``finance`` schema; SQLite has
+    # no schemas, so there they stay unqualified. Resolve the schema-qualified
+    # variant only for a Postgres target.
+    if service_name in ("finance", "finance_auth_link") and context is not None:
+        engine = context.get(AnswerKeys.DATABASE_ENGINE, StorageBackends.SQLITE)
+        if engine == StorageBackends.POSTGRES:
+            if service_name == "finance":
+                return replace(migration_specs["finance"], schema=FINANCE_SCHEMA)
+            # user lives in the default (public) schema, finance_connection in
+            # the finance schema — cross-schema FK.
+            return _build_finance_auth_link(
+                schema=FINANCE_SCHEMA, user_ref_schema="public"
+            )
 
     return migration_specs[service_name]
 
@@ -1854,6 +4092,18 @@ def get_services_needing_migrations(context: dict[str, Any]) -> list[str]:
     include_blog_on = include_blog == "yes" or include_blog is True
     if include_blog_on:
         services.append("blog")
+
+    # Finance service (always needs database).
+    include_finance = context.get(AnswerKeys.FINANCE)
+    include_finance_on = include_finance == "yes" or include_finance is True
+    if include_finance_on:
+        services.append("finance")
+
+    # Finance + Auth: add FK from finance_connection.owner_user_id -> user.id.
+    # Only when BOTH are included; runs after both base migrations so `user`
+    # exists. include_auth_on is defined above (payment_auth_link block).
+    if include_finance_on and include_auth_on:
+        services.append("finance_auth_link")
 
     # Scheduler component — the job_execution history table. Postgres ONLY:
     # the table lives in a ``scheduler`` schema, and the migration emits

--- a/aegis/core/post_gen_tasks.py
+++ b/aegis/core/post_gen_tasks.py
@@ -412,6 +412,7 @@ def cleanup_components(project_path: Path, context: dict[str, Any]) -> None:
         and not is_enabled(AnswerKeys.INSIGHTS)
         and not is_enabled(AnswerKeys.PAYMENT)
         and not is_enabled(AnswerKeys.BLOG)
+        and not is_enabled(AnswerKeys.FINANCE)
     ):
         remove_file(
             project_path, "app/components/frontend/dashboard/cards/services_card.py"
@@ -426,6 +427,7 @@ def cleanup_components(project_path: Path, context: dict[str, Any]) -> None:
     include_insights = is_enabled(AnswerKeys.INSIGHTS)
     include_payment = is_enabled(AnswerKeys.PAYMENT)
     include_blog = is_enabled(AnswerKeys.BLOG)
+    include_finance = is_enabled(AnswerKeys.FINANCE)
     ai_backend = context.get(AnswerKeys.AI_BACKEND, StorageBackends.MEMORY)
     ai_needs_migrations = include_ai and ai_backend != StorageBackends.MEMORY
     scheduler_backend = context.get(
@@ -441,6 +443,7 @@ def cleanup_components(project_path: Path, context: dict[str, Any]) -> None:
         or include_insights
         or include_payment
         or include_blog
+        or include_finance
         or scheduler_needs_migrations
     )
 

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -25,6 +25,8 @@ from .migration_generator import (
     AUTH_RBAC_MIGRATION,
     AUTH_TOKENS_MIGRATION,
     BLOG_MIGRATION,
+    FINANCE_AUTH_LINK_MIGRATION,
+    FINANCE_MIGRATION,
     INSIGHTS_MIGRATION,
     ORG_MIGRATION,
     PAYMENT_AUTH_LINK_MIGRATION,
@@ -52,6 +54,7 @@ class ServiceType(Enum):
     ANALYTICS = "analytics"  # Usage analytics and metrics
     STORAGE = "storage"  # File storage and CDN
     CONTENT = "content"  # Content publishing and editorial workflows
+    FINANCE = "finance"  # Personal finance aggregation and ledger
 
 
 # Translation key for each service type's display header. Used by the
@@ -65,6 +68,7 @@ SERVICE_TYPE_I18N_KEYS: dict[ServiceType, str] = {
     ServiceType.ANALYTICS: "services.type_analytics",
     ServiceType.STORAGE: "services.type_storage",
     ServiceType.CONTENT: "services.type_content",
+    ServiceType.FINANCE: "services.type_finance",
 }
 
 
@@ -830,6 +834,51 @@ SERVICES: dict[str, ServiceSpec] = {
                 "tests/api/test_blog_endpoints.py",
                 "app/components/frontend/dashboard/cards/blog_card.py",
                 "app/components/frontend/dashboard/modals/blog_modal.py",
+            ],
+        ),
+    ),
+    "finance": ServiceSpec(
+        name="finance",
+        # docs_path is set once the docs/services/finance page ships.
+        docs_path="",
+        marker_path="app/services/finance",
+        type=ServiceType.FINANCE,
+        description="Personal finance aggregation (accounts, transactions, net worth, import)",
+        long_description=(
+            "Aggregates bank, credit-card, and brokerage accounts, imports "
+            "Quicken/OFX/CSV files, tracks net worth over time, and surfaces "
+            "recurring-spend insights. Connectivity ships behind provider "
+            "flags (Plaid, SnapTrade); file import and manual accounts work "
+            "with no third-party service. When the auth service is present, "
+            "finance rows are owned by the app user (FK wired via the "
+            "finance_auth_link migration); standalone finance is single-user."
+        ),
+        required_components=[
+            ComponentNames.BACKEND,
+            ComponentNames.DATABASE,
+            ComponentNames.SCHEDULER,
+        ],
+        recommended_components=[ComponentNames.WORKER],
+        # Auth is integrated-when-present (owner FK via finance_auth_link),
+        # not required — mirrors payment_customer.user_id. Keeping it optional
+        # lets the guided/interactive flows select finance without forcing a
+        # service-to-service dependency they don't resolve.
+        # Wiring (routers/cards/modals/deps) is added by the tickets that
+        # create those modules; the schema tickets grow FINANCE_MIGRATION.
+        wiring=PluginWiring(),
+        migrations=[FINANCE_MIGRATION, FINANCE_AUTH_LINK_MIGRATION],
+        # Alembic is installed via the shared migration gate in
+        # pyproject.toml.jinja; runtime deps (plaid/ofx/...) land with their
+        # provider/import tickets. ``aegis add-service finance`` bootstraps
+        # alembic itself, so no alembic pin is needed here.
+        pyproject_deps=[],
+        template_files=[
+            "app/services/finance/",
+        ],
+        files=FileManifest(
+            primary=[
+                "app/services/finance",
+                "tests/services/test_finance_models.py",
             ],
         ),
     ),

--- a/aegis/core/template_generator.py
+++ b/aegis/core/template_generator.py
@@ -289,6 +289,12 @@ class TemplateGenerator:
                 for s in self.selected_services
             )
             else "no",
+            AnswerKeys.FINANCE: "yes"
+            if any(
+                extract_base_service_name(s) == AnswerKeys.SERVICE_FINANCE
+                for s in self.selected_services
+            )
+            else "no",
             AnswerKeys.PAYMENT_PROVIDER: PaymentProviders.DEFAULT,
             # Insights source flags
             AnswerKeys.INSIGHTS_GITHUB: "yes"

--- a/aegis/i18n/locales/de.py
+++ b/aegis/i18n/locales/de.py
@@ -561,6 +561,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "Analysedienste",
     "services.type_storage": "Speicherdienste",
     "services.type_content": "Content-Dienste",
+    "services.type_finance": "Finanzdienste",
     "services.requires_components": "Benötigt Komponenten: {deps}",
     "services.recommends_components": "Empfiehlt Komponenten: {deps}",
     "services.requires_services": "Benötigt Services: {deps}",

--- a/aegis/i18n/locales/en.py
+++ b/aegis/i18n/locales/en.py
@@ -571,6 +571,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "Analytics Services",
     "services.type_storage": "Storage Services",
     "services.type_content": "Content Services",
+    "services.type_finance": "Finance Services",
     "services.requires_components": "Requires components: {deps}",
     "services.recommends_components": "Recommends components: {deps}",
     "services.requires_services": "Requires services: {deps}",

--- a/aegis/i18n/locales/es.py
+++ b/aegis/i18n/locales/es.py
@@ -563,6 +563,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "Servicios de analítica",
     "services.type_storage": "Servicios de almacenamiento",
     "services.type_content": "Servicios de contenido",
+    "services.type_finance": "Servicios de finanzas",
     "services.requires_components": "Requiere componentes: {deps}",
     "services.recommends_components": "Recomienda componentes: {deps}",
     "services.requires_services": "Requiere servicios: {deps}",

--- a/aegis/i18n/locales/fr.py
+++ b/aegis/i18n/locales/fr.py
@@ -563,6 +563,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "Services d'analyse",
     "services.type_storage": "Services de stockage",
     "services.type_content": "Services de contenu",
+    "services.type_finance": "Services de finance",
     "services.requires_components": "Composants requis : {deps}",
     "services.recommends_components": "Composants recommandés : {deps}",
     "services.requires_services": "Services requis : {deps}",

--- a/aegis/i18n/locales/ja.py
+++ b/aegis/i18n/locales/ja.py
@@ -547,6 +547,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "分析サービス",
     "services.type_storage": "ストレージサービス",
     "services.type_content": "コンテンツサービス",
+    "services.type_finance": "ファイナンスサービス",
     "services.requires_components": "必須コンポーネント：{deps}",
     "services.recommends_components": "推奨コンポーネント：{deps}",
     "services.requires_services": "必須サービス：{deps}",

--- a/aegis/i18n/locales/ko.py
+++ b/aegis/i18n/locales/ko.py
@@ -528,6 +528,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "분석 서비스",
     "services.type_storage": "스토리지 서비스",
     "services.type_content": "콘텐츠 서비스",
+    "services.type_finance": "금융 서비스",
     "services.requires_components": "필수 컴포넌트: {deps}",
     "services.recommends_components": "권장 컴포넌트: {deps}",
     "services.requires_services": "필수 서비스: {deps}",

--- a/aegis/i18n/locales/ru.py
+++ b/aegis/i18n/locales/ru.py
@@ -537,6 +537,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "Сервисы аналитики",
     "services.type_storage": "Сервисы хранения",
     "services.type_content": "Контент-сервисы",
+    "services.type_finance": "Финансовые сервисы",
     "services.requires_components": "Требуемые компоненты: {deps}",
     "services.recommends_components": "Рекомендуемые компоненты: {deps}",
     "services.requires_services": "Требуемые сервисы: {deps}",

--- a/aegis/i18n/locales/zh.py
+++ b/aegis/i18n/locales/zh.py
@@ -435,6 +435,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "数据分析服务",
     "services.type_storage": "存储服务",
     "services.type_content": "内容服务",
+    "services.type_finance": "财务服务",
     "services.requires_components": "依赖组件：{deps}",
     "services.recommends_components": "推荐组件：{deps}",
     "services.requires_services": "依赖服务：{deps}",

--- a/aegis/i18n/locales/zh_hant.py
+++ b/aegis/i18n/locales/zh_hant.py
@@ -435,6 +435,7 @@ MESSAGES: dict[str, str] = {
     "services.type_analytics": "數據分析服務",
     "services.type_storage": "存儲服務",
     "services.type_content": "內容服務",
+    "services.type_finance": "財務服務",
     "services.requires_components": "依賴元件：{deps}",
     "services.recommends_components": "推薦元件：{deps}",
     "services.requires_services": "依賴服務：{deps}",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/.copier-answers.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/.copier-answers.yml.jinja
@@ -26,7 +26,11 @@ include_ai: {{ include_ai }}
 include_comms: {{ include_comms }}
 include_payment: {{ include_payment }}
 include_blog: {{ include_blog }}
+include_finance: {{ include_finance }}
 payment_provider: {{ payment_provider }}
+finance_plaid: {{ finance_plaid }}
+finance_snaptrade: {{ finance_snaptrade }}
+finance_import: {{ finance_import }}
 ai_providers: {{ ai_providers }}
 ai_framework: {{ ai_framework }}
 ai_backend: {{ ai_backend }}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/alembic/env.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/alembic/env.py.jinja
@@ -39,6 +39,43 @@ from app.services.insights.models import (  # noqa: E402,F401
 {% if include_blog %}
 from app.services.blog.models import BlogPost, BlogPostTag, BlogTag  # noqa: E402,F401
 {% endif %}
+{% if include_finance %}
+from app.services.finance.models import (  # noqa: E402,F401
+    FinanceAccount,
+    FinanceAttachment,
+    FinanceBalanceSnapshot,
+    FinanceBudget,
+    FinanceBudgetCategory,
+    FinanceCategory,
+    FinanceCategoryAlias,
+    FinanceConnection,
+    FinanceCurrency,
+    FinanceFxRate,
+    FinanceHolding,
+    FinanceImportBatch,
+    FinanceImportBatchRow,
+    FinanceImportProfile,
+    FinanceInsight,
+    FinanceInstitution,
+    FinanceLiabilityDetail,
+    FinanceMerchant,
+    FinanceNetWorthSnapshot,
+    FinanceRecurringStream,
+    FinanceRule,
+    FinanceSecurity,
+    FinanceSecurityPrice,
+    FinanceSpendingBaseline,
+    FinanceTag,
+    FinanceTrade,
+    FinanceTransaction,
+    FinanceTransactionChangelog,
+    FinanceTransactionSplit,
+    FinanceTransactionTag,
+    FinanceTransfer,
+    FinanceValuation,
+    FinanceWebhookEvent,
+)
+{% endif %}
 {% if include_scheduler and scheduler_backend != "memory" %}
 from app.services.scheduler.models import JobExecution  # noqa: E402,F401
 {% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/__init__.py
@@ -1,0 +1,5 @@
+"""Finance service: account aggregation, transactions, net worth, and import.
+
+Connectivity providers (Plaid, SnapTrade) ship behind their own copier
+sub-flags; file import and manual accounts have no third-party dependency.
+"""

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/constants.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/constants.py
@@ -1,0 +1,29 @@
+"""Finance service constants: provider keys, ciphertext column registry.
+
+Enum-style value sets that back ``String`` + ``CheckConstraint`` columns are
+added here as their tables land. Kept as plain string constants (not native
+DB enums) so adding a value is a normal migration on both SQLite and Postgres.
+"""
+
+SERVICE_NAME = "finance"
+
+
+class Provider:
+    """Connection providers. ``manual`` always ships; the rest are flag-gated."""
+
+    PLAID = "plaid"
+    SNAPTRADE = "snaptrade"
+    MANUAL = "manual"
+
+
+# Encrypted (AES-GCM ciphertext) columns on ``finance_connection``. Registered
+# here so key-rotation tooling can find every finance secret. Encryption /
+# decryption happens in the service layer with a row-bound AAD context
+# ``finance_connection:{id}:{column}``.
+ENCRYPTED_COLUMNS: tuple[str, ...] = (
+    "access_token_encrypted",
+    "api_key_encrypted",
+    "api_secret_encrypted",
+    "api_passphrase_encrypted",
+    "refresh_token_encrypted",
+)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models.py.jinja
@@ -1,0 +1,2008 @@
+"""Finance service database models.
+
+SQLModel tables for the finance aggregator. Grown incrementally across the
+finance schema tickets; the migration in ``aegis.core.migration_generator``
+(``FINANCE_MIGRATION``) is the parallel definition and must stay column-for-
+column compatible (tests build tables from these models via
+``SQLModel.metadata.create_all``; the generated project builds them from the
+migration).
+
+Conventions (see docs/plans/finance-service/finance-schema-canonical.md):
+- int autoincrement PKs; money + scaled integers use ``BigInteger`` (net worth
+  and ``*_e8`` values overflow int32);
+- enums are ``String`` + ``CheckConstraint`` (portable across SQLite/Postgres),
+  never native enums; provider taxonomies that grow are plain ``str`` columns;
+- partial-unique indexes declare BOTH ``sqlite_where`` and ``postgresql_where``;
+- timestamps are naive UTC via ``_utcnow``;
+- on Postgres every finance table lives in a dedicated ``finance`` schema
+  (``_SCHEMA``); SQLite has no schemas so ``_SCHEMA`` is None (default DB).
+  Tests run on SQLite and attach an in-memory ``finance`` database per the
+  conftest schema-attach, so schema-qualified models still create_all cleanly.
+"""
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    Index,
+)
+from sqlmodel import Field, SQLModel
+
+# Postgres schema for finance tables; None on SQLite (no schema support).
+_SCHEMA: str | None = {% if database_engine == "postgres" %}"finance"{% else %}None{% endif %}
+# Foreign-key target prefix ("finance." on Postgres, "" on SQLite).
+_FK = f"{_SCHEMA}." if _SCHEMA else ""
+
+
+def _bigint(name: str, *, nullable: bool = True, default: Any = None) -> Any:
+    """A BigInteger money / scaled-integer column.
+
+    Net worth and brokerage balances (and ``*_e8`` quantities/rates) overflow
+    int32, so all money columns are BigInteger. Values are integer minor units
+    (cents), never floats.
+    """
+    return Field(default=default, sa_column=Column(name, BigInteger, nullable=nullable))
+
+
+def _utcnow() -> datetime:
+    """UTC timestamp stored as naive datetime for SQLite/Postgres portability."""
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+# Ciphertext columns on FinanceConnection: encrypted in the service layer,
+# masked in __repr__. Mirror of app.services.finance.constants.ENCRYPTED_COLUMNS.
+_ENCRYPTED_COLUMNS: tuple[str, ...] = (
+    "access_token_encrypted",
+    "api_key_encrypted",
+    "api_secret_encrypted",
+    "api_passphrase_encrypted",
+    "refresh_token_encrypted",
+)
+
+
+# ---------------------------------------------------------------------------
+# Group F — reference data
+# ---------------------------------------------------------------------------
+
+
+class FinanceCurrency(SQLModel, table=True):
+    """A unit of account (fiat or crypto).
+
+    Money columns elsewhere store integer minor units; ``decimals`` says how
+    many minor units make one whole unit (usd=2, jpy=0, btc=8), so amounts can
+    be rendered without hardcoding per-currency scale.
+    """
+
+    __tablename__ = "finance_currency"
+    __table_args__ = (
+        CheckConstraint("kind IN ('fiat', 'crypto')", name="ck_finance_currency_kind"),
+        CheckConstraint(
+            "decimals BETWEEN 0 AND 18", name="ck_finance_currency_decimals"
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    # ISO-4217 or crypto ticker, stored lowercase (usd, eur, btc, usdc).
+    code: str = Field(index=True, unique=True, max_length=16)
+    name: str = Field(max_length=64)
+    symbol: str | None = Field(default=None, max_length=8)
+    decimals: int = Field(default=2)
+    kind: str = Field(default="fiat", max_length=8, index=True)
+    is_active: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceFxRate(SQLModel, table=True):
+    """Historical FX rate for base-currency net-worth rollups.
+
+    ``rate_e8`` is the rate scaled by 1e8 (1 base = ``rate_e8`` / 1e8 quote) so
+    conversion stays integer-exact. Convert at display time against dated rates.
+    """
+
+    __tablename__ = "finance_fx_rate"
+    __table_args__ = (
+        Index(
+            "ix_finance_fxrate_pair_date",
+            "base_currency",
+            "quote_currency",
+            "rate_date",
+        ),
+        Index(
+            "uq_finance_fxrate",
+            "base_currency",
+            "quote_currency",
+            "rate_date",
+            "source",
+            unique=True,
+        ),
+        CheckConstraint(
+            "source IN ('manual', 'ecb', 'exchange_api', 'coingecko', "
+            "'provider', 'derived')",
+            name="ck_finance_fxrate_source",
+        ),
+        CheckConstraint(
+            "base_currency <> quote_currency", name="ck_finance_fxrate_distinct"
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    # currency FKs are intentionally unindexed (low cardinality); the composite
+    # index above covers base_currency as its leading column.
+    base_currency: str = Field(
+        foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    quote_currency: str = Field(
+        foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    rate_date: date
+    rate_e8: int = Field(sa_column=Column("rate_e8", BigInteger, nullable=False))
+    source: str = Field(default="manual", max_length=16)
+    created_at: datetime = Field(default_factory=_utcnow)
+
+
+# ---------------------------------------------------------------------------
+# Group A — connections & sync
+# ---------------------------------------------------------------------------
+
+
+class FinanceInstitution(SQLModel, table=True):
+    """Provider-agnostic institution directory (one row per provider view).
+
+    Shared/global reference (not user-scoped). Carries the per-institution
+    capability flags the connection layer gates on (AMEX has no liabilities,
+    Chase uses tokenized account numbers, etc.).
+    """
+
+    __tablename__ = "finance_institution"
+    __table_args__ = (
+        Index(
+            "uq_finance_institution_provider_extid",
+            "provider",
+            "provider_institution_id",
+            unique=True,
+            sqlite_where=Column("provider_institution_id").isnot(None),
+            postgresql_where=Column("provider_institution_id").isnot(None),
+        ),
+        CheckConstraint(
+            "provider IN ('plaid', 'snaptrade', 'coinbase', 'exchange_key', "
+            "'onchain', 'manual')",
+            name="ck_finance_institution_provider",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    provider: str = Field(max_length=16, index=True)
+    # Plaid ins_xxx / SnapTrade brokerage id — provider taxonomy, plain text.
+    provider_institution_id: str | None = Field(default=None)
+    name: str = Field(max_length=128, index=True)
+    domain: str | None = Field(default=None, max_length=255)
+    logo_url: str | None = Field(default=None)
+    primary_color: str | None = Field(default=None, max_length=16)
+    url: str | None = Field(default=None)
+    country: str | None = Field(default=None, max_length=2)
+    oauth_required: bool = Field(default=False)
+    uses_tokenized_account_numbers: bool = Field(default=False)
+    uses_app_to_app: bool = Field(default=False)
+    supported_products: list[Any] = Field(
+        default_factory=list, sa_column=Column("supported_products", JSON)
+    )
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceConnection(SQLModel, table=True):
+    """A provider-polymorphic connection (Plaid Item, SnapTrade authorization,
+    exchange api-key, on-chain wallet, or manual).
+
+    One fat row: inline AES-GCM-encrypted credential columns, a JSON capability
+    matrix, inline health/status, and the sync cursor. Credentials are ciphertext
+    at rest (encrypted in the service layer) and masked in ``__repr__``.
+    ``owner_user_id`` has no model-level FK: the FK to ``user.id`` is added by
+    the finance_auth_link migration only when the auth service is present, so
+    finance runs standalone (single-user) too.
+    """
+
+    __tablename__ = "finance_connection"
+    __table_args__ = (
+        Index("ix_finance_connection_owner_status", "owner_user_id", "status"),
+        Index(
+            "uq_finance_connection_provider_item",
+            "provider",
+            "provider_item_id",
+            unique=True,
+            sqlite_where=(
+                Column("provider_item_id").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("provider_item_id").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+        ),
+        Index(
+            "uq_finance_connection_wallet",
+            "owner_user_id",
+            "provider",
+            "wallet_address",
+            unique=True,
+            sqlite_where=Column("wallet_address").isnot(None),
+            postgresql_where=Column("wallet_address").isnot(None),
+        ),
+        CheckConstraint(
+            "provider IN ('plaid', 'snaptrade', 'coinbase', 'exchange_key', "
+            "'onchain', 'manual')",
+            name="ck_finance_connection_provider",
+        ),
+        CheckConstraint(
+            "connection_type IN ('oauth_access_token', 'api_key_secret', "
+            "'onchain_address', 'aggregator_token', 'manual')",
+            name="ck_finance_connection_type",
+        ),
+        CheckConstraint(
+            "environment IN ('sandbox', 'production')",
+            name="ck_finance_connection_environment",
+        ),
+        CheckConstraint(
+            "status IN ('healthy', 'login_required', 'pending_expiration', "
+            "'pending_disconnect', 'consent_expired', 'revoked', 'error', "
+            "'loading', 'manual')",
+            name="ck_finance_connection_status",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None, index=True)
+    organization_id: int | None = Field(default=None, index=True)
+    institution_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_institution.id", index=True
+    )
+    provider: str = Field(max_length=16)
+    connection_type: str = Field(max_length=20)
+    provider_item_id: str | None = Field(default=None)
+    label: str | None = Field(default=None, max_length=255)
+    environment: str = Field(default="sandbox", max_length=16)
+    # Encrypted at rest via FinanceService (ciphertext text columns).
+    access_token_encrypted: str | None = Field(default=None)
+    api_key_encrypted: str | None = Field(default=None)
+    api_secret_encrypted: str | None = Field(default=None)
+    api_passphrase_encrypted: str | None = Field(default=None)
+    refresh_token_encrypted: str | None = Field(default=None)
+    # Public on-chain address is not a secret.
+    wallet_address: str | None = Field(default=None)
+    wallet_chain: str | None = Field(default=None)
+    capabilities: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("capabilities", JSON)
+    )
+    status: str = Field(default="healthy", max_length=24)
+    status_detail: str | None = Field(default=None)
+    last_error_code: str | None = Field(default=None)
+    needs_user_action: bool = Field(default=False, index=True)
+    sync_cursor: str | None = Field(default=None)
+    days_requested: int | None = Field(default=None)
+    consent_expiration_at: datetime | None = Field(default=None)
+    last_successful_sync_at: datetime | None = Field(default=None)
+    last_sync_attempt_at: datetime | None = Field(default=None)
+    removed_at: datetime | None = Field(default=None)
+    deleted_at: datetime | None = Field(default=None, index=True)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+    def __repr__(self) -> str:
+        """Logging-safe repr — credential columns masked."""
+        creds = {
+            col: ("***" if getattr(self, col, None) else None)
+            for col in _ENCRYPTED_COLUMNS
+        }
+        return (
+            f"FinanceConnection(id={self.id!r}, provider={self.provider!r}, "
+            f"owner_user_id={self.owner_user_id!r}, status={self.status!r}, "
+            f"creds={creds})"
+        )
+
+
+class FinanceWebhookEvent(SQLModel, table=True):
+    """Idempotent inbound provider-webhook log; dedups on provider_event_id so a
+    re-delivered webhook is a no-op, and is the replay/debug buffer."""
+
+    __tablename__ = "finance_webhook_event"
+    __table_args__ = (
+        Index("ix_finance_webhook_status_received", "status", "received_at"),
+        Index(
+            "uq_finance_webhook_event",
+            "provider",
+            "provider_event_id",
+            unique=True,
+            sqlite_where=Column("provider_event_id").isnot(None),
+            postgresql_where=Column("provider_event_id").isnot(None),
+        ),
+        CheckConstraint(
+            "provider IN ('plaid', 'snaptrade', 'coinbase')",
+            name="ck_finance_webhook_provider",
+        ),
+        CheckConstraint(
+            "status IN ('received', 'processed', 'ignored', 'error')",
+            name="ck_finance_webhook_status",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    connection_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_connection.id", index=True
+    )
+    provider: str = Field(max_length=16)
+    provider_item_id: str | None = Field(default=None, index=True)
+    webhook_type: str | None = Field(default=None)
+    webhook_code: str | None = Field(default=None)
+    provider_event_id: str | None = Field(default=None)
+    payload: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("payload", JSON)
+    )
+    status: str = Field(default="received", max_length=16)
+    error: str | None = Field(default=None)
+    received_at: datetime = Field(default_factory=_utcnow)
+    processed_at: datetime | None = Field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# Group B — accounts & balances
+# ---------------------------------------------------------------------------
+
+
+class FinanceAccount(SQLModel, table=True):
+    """One row per provider account AND per manual asset (``is_manual``).
+
+    The provider-reported balance is authoritative. ``account_type`` and
+    ``classification`` are normalized and STORED so net-worth signing is a
+    simple column read; Plaid ``type``/``subtype`` are kept raw. A NULL
+    ``connection_id`` marks a manually-tracked asset (house, car, crypto).
+    """
+
+    __tablename__ = "finance_account"
+    __table_args__ = (
+        Index("ix_finance_account_owner_type", "owner_user_id", "account_type"),
+        Index(
+            "ix_finance_account_owner_classification",
+            "owner_user_id",
+            "classification",
+        ),
+        Index(
+            "uq_finance_account_provider",
+            "connection_id",
+            "provider_account_id",
+            unique=True,
+            sqlite_where=(
+                Column("provider_account_id").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("provider_account_id").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+        ),
+        CheckConstraint(
+            "account_type IN ('checking', 'savings', 'credit_card', 'loan', "
+            "'investment', 'brokerage', 'crypto', 'property', 'vehicle', "
+            "'cash', 'other_asset', 'other_liability')",
+            name="ck_finance_account_type",
+        ),
+        CheckConstraint(
+            "classification IN ('asset', 'liability')",
+            name="ck_finance_account_classification",
+        ),
+        CheckConstraint(
+            "provider IN ('plaid', 'snaptrade', 'coinbase', 'exchange_key', "
+            "'onchain', 'manual')",
+            name="ck_finance_account_provider",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None, index=True)
+    organization_id: int | None = Field(default=None, index=True)
+    connection_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_connection.id", index=True
+    )
+    institution_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_institution.id", index=True
+    )
+    provider: str = Field(max_length=16)
+    provider_account_id: str | None = Field(default=None)
+    persistent_account_id: str | None = Field(default=None, index=True)
+    name: str = Field(max_length=255)
+    official_name: str | None = Field(default=None, max_length=255)
+    mask: str | None = Field(default=None, max_length=8)
+    type: str | None = Field(default=None)
+    subtype: str | None = Field(default=None)
+    account_type: str = Field(max_length=24)
+    classification: str = Field(max_length=12)
+    currency: str = Field(default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16)
+    current_balance: int | None = _bigint("current_balance")
+    available_balance: int | None = _bigint("available_balance")
+    credit_limit: int | None = _bigint("credit_limit")
+    balance_as_of: datetime | None = Field(default=None)
+    is_manual: bool = Field(default=False)
+    is_hidden: bool = Field(default=False)
+    is_closed: bool = Field(default=False)
+    is_on_budget: bool = Field(default=True)
+    linked_at: datetime | None = Field(default=None)
+    last_synced_at: datetime | None = Field(default=None)
+    deleted_at: datetime | None = Field(default=None, index=True)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceLiabilityDetail(SQLModel, table=True):
+    """1:1 per credit/loan account — statement/payment/APR detail (Chase; AMEX
+    fields stay NULL). APRs are a JSON array (APR-by-type is not relational).
+    Rates are basis points (int) to avoid Decimal."""
+
+    __tablename__ = "finance_liability_detail"
+    __table_args__ = (
+        Index("ix_finance_liability_owner", "owner_user_id"),
+        Index("ix_finance_liability_account", "account_id", unique=True),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    account_id: int = Field(foreign_key=f"{_FK}finance_account.id")
+    liability_type: str | None = Field(default=None)
+    last_statement_balance: int | None = _bigint("last_statement_balance")
+    last_statement_issue_date: date | None = Field(default=None)
+    last_payment_amount: int | None = _bigint("last_payment_amount")
+    last_payment_date: date | None = Field(default=None)
+    minimum_payment_amount: int | None = _bigint("minimum_payment_amount")
+    next_payment_due_date: date | None = Field(default=None)
+    origination_date: date | None = Field(default=None)
+    origination_principal: int | None = _bigint("origination_principal")
+    outstanding_balance: int | None = _bigint("outstanding_balance")
+    interest_rate_bps: int | None = Field(default=None)
+    ytd_interest_paid: int | None = _bigint("ytd_interest_paid")
+    ytd_principal_paid: int | None = _bigint("ytd_principal_paid")
+    loan_term_months: int | None = Field(default=None)
+    is_overdue: bool | None = Field(default=None)
+    aprs: list[Any] = Field(default_factory=list, sa_column=Column("aprs", JSON))
+    currency: str = Field(default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16)
+    raw: dict[str, Any] = Field(default_factory=dict, sa_column=Column("raw", JSON))
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceBalanceSnapshot(SQLModel, table=True):
+    """The net-worth-over-time primitive: one materialized balance per account
+    per day, upserted by a background job (carried forward on gap days)."""
+
+    __tablename__ = "finance_balance_snapshot"
+    __table_args__ = (
+        Index("ix_finance_balsnap_account_date", "account_id", "balance_date"),
+        Index("ix_finance_balsnap_owner_date", "owner_user_id", "balance_date"),
+        Index("uq_finance_balsnap", "account_id", "balance_date", unique=True),
+        CheckConstraint(
+            "source IN ('sync', 'provider', 'computed', 'carried_forward', 'manual')",
+            name="ck_finance_balsnap_source",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    account_id: int = Field(foreign_key=f"{_FK}finance_account.id")
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    balance_date: date
+    balance: int = _bigint("balance", nullable=False, default=0)
+    available_balance: int | None = _bigint("available_balance")
+    cash_balance: int | None = _bigint("cash_balance")
+    holdings_value: int | None = _bigint("holdings_value")
+    currency: str = Field(default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16)
+    base_currency_value: int | None = _bigint("base_currency_value")
+    source: str = Field(default="sync", max_length=16)
+    is_estimated: bool = Field(default=False)
+
+
+class FinanceNetWorthSnapshot(SQLModel, table=True):
+    """Per-user daily net-worth rollup so the headline chart is O(1)."""
+
+    __tablename__ = "finance_net_worth_snapshot"
+    __table_args__ = (
+        Index("ix_finance_networth_owner_date", "owner_user_id", "as_of_date"),
+        Index("ix_finance_networth_org_date", "organization_id", "as_of_date"),
+        Index(
+            "uq_finance_networth",
+            "owner_user_id",
+            "as_of_date",
+            "currency",
+            unique=True,
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    as_of_date: date
+    total_assets_amount: int = _bigint("total_assets_amount", nullable=False, default=0)
+    total_liabilities_amount: int = _bigint(
+        "total_liabilities_amount", nullable=False, default=0
+    )
+    net_worth_amount: int = _bigint("net_worth_amount", nullable=False, default=0)
+    cash_amount: int | None = _bigint("cash_amount")
+    investments_amount: int | None = _bigint("investments_amount")
+    other_assets_amount: int | None = _bigint("other_assets_amount")
+    currency: str = Field(default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16)
+    breakdown: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("breakdown", JSON)
+    )
+    is_estimated: bool = Field(default=False)
+
+
+class FinanceValuation(SQLModel, table=True):
+    """Source-tagged dated-value series for manual/off-aggregator assets (real
+    estate, vehicles, crypto marks). Feeds the balance-snapshot recompute for
+    non-transactional assets; carries staleness tracking."""
+
+    __tablename__ = "finance_valuation"
+    __table_args__ = (
+        Index("ix_finance_valuation_owner_date", "owner_user_id", "as_of_date"),
+        Index("ix_finance_valuation_account_date", "account_id", "as_of_date"),
+        Index("ix_finance_valuation_source", "source"),
+        Index(
+            "uq_finance_valuation", "account_id", "as_of_date", "source", unique=True
+        ),
+        CheckConstraint(
+            "source IN ('manual', 'zillow', 'kbb', 'exchange_api', 'onchain', "
+            "'plaid', 'snaptrade', 'coingecko', 'reconciliation')",
+            name="ck_finance_valuation_source",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    account_id: int = Field(foreign_key=f"{_FK}finance_account.id")
+    as_of_date: date
+    value: int = _bigint("value", nullable=False, default=0)
+    currency: str = Field(default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16)
+    source: str = Field(default="manual", max_length=16)
+    source_ref: str | None = Field(default=None)
+    is_estimate: bool = Field(default=False)
+    fetched_at: datetime | None = Field(default=None)
+    is_stale: bool = Field(default=False)
+    stale_after_days: int | None = Field(default=None)
+    note: str | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+# ---------------------------------------------------------------------------
+# Group C (core) — transactions, splits, transfers
+# ---------------------------------------------------------------------------
+#
+# Forward/circular FK columns (``category_id``, ``merchant_id``,
+# ``recurring_stream_id``, ``import_batch_id``, ``transfer_group_id``) are plain
+# integer columns here — NO model-level ``foreign_key=``. Their target tables
+# are defined in later tickets (categories/merchants FIN-08, recurring/import
+# FIN-10) or would form a create_all cycle (transfer_group_id <-> finance_
+# transfer). The FK constraints live in the generated migration's alter_tables
+# (transfer_group_id in FINANCE_MIGRATION, the rest in later tickets), so the
+# generated project enforces them; ``create_all`` in tests stays acyclic.
+
+
+class FinanceTransaction(SQLModel, table=True):
+    """A normalized money movement — the ledger fact table.
+
+    Two-lane provider/import dedup: LANE 1 is (account_id, source, external_id)
+    for provider rows; LANE 2 is (account_id, import_hash) for file imports with
+    no stable id. ``ck_finance_txn_dedup_lane`` forbids a row from carrying both
+    an ``external_id`` and an ``import_hash``. ``amount`` is sign-normalized
+    (negative = outflow) integer minor units; ``raw_amount`` keeps the provider
+    value as delivered. Self-FKs thread pending->posted, canonical dedup, the
+    transfer pair, and reversal linkage. ``owner_user_id`` has no model FK (the
+    finance_auth_link migration adds it only when auth is present).
+    """
+
+    __tablename__ = "finance_transaction"
+    __table_args__ = (
+        Index("ix_finance_txn_owner_date", "owner_user_id", "date"),
+        Index("ix_finance_txn_account_date", "account_id", "date"),
+        Index(
+            "ix_finance_txn_owner_cat_date", "owner_user_id", "category_id", "date"
+        ),
+        Index("ix_finance_txn_merchant", "merchant_id"),
+        Index("ix_finance_txn_merchant_entity", "merchant_entity_id"),
+        Index("ix_finance_txn_category", "category_id"),
+        Index("ix_finance_txn_connection", "connection_id"),
+        Index("ix_finance_txn_batch", "import_batch_id"),
+        Index("ix_finance_txn_recurring", "recurring_stream_id"),
+        Index("ix_finance_txn_transfer_group", "transfer_group_id"),
+        Index("ix_finance_txn_canonical", "canonical_transaction_id"),
+        Index("ix_finance_txn_pending_link", "pending_transaction_id"),
+        Index("ix_finance_txn_pair", "transfer_pair_transaction_id"),
+        Index("ix_finance_txn_reverses", "reverses_transaction_id"),
+        Index("ix_finance_txn_pending", "pending"),
+        Index("ix_finance_txn_is_transfer", "is_transfer"),
+        Index("ix_finance_txn_deleted", "deleted_at"),
+        Index(
+            "uq_finance_txn_external",
+            "account_id",
+            "source",
+            "external_id",
+            unique=True,
+            sqlite_where=(
+                Column("external_id").isnot(None) & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("external_id").isnot(None) & Column("deleted_at").is_(None)
+            ),
+        ),
+        Index(
+            "uq_finance_txn_hash",
+            "account_id",
+            "import_hash",
+            unique=True,
+            sqlite_where=(
+                Column("external_id").is_(None)
+                & Column("import_hash").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("external_id").is_(None)
+                & Column("import_hash").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+        ),
+        CheckConstraint(
+            "source IN ('plaid', 'snaptrade', 'ofx', 'qfx', 'qif', 'csv', "
+            "'manual', 'coinbase', 'onchain', 'simplefin', 'teller')",
+            name="ck_finance_txn_source",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'posted', 'removed')",
+            name="ck_finance_txn_status",
+        ),
+        CheckConstraint(
+            "dedup_status IN ('unique', 'primary', 'duplicate', 'linked')",
+            name="ck_finance_txn_dedup_status",
+        ),
+        CheckConstraint(
+            "category_source IN ('provider', 'ml', 'rule', 'user', 'unset')",
+            name="ck_finance_txn_category_source",
+        ),
+        CheckConstraint(
+            "reconciled_status IN ('uncleared', 'cleared', 'reconciled')",
+            name="ck_finance_txn_reconciled",
+        ),
+        CheckConstraint(
+            "NOT (external_id IS NOT NULL AND import_hash IS NOT NULL)",
+            name="ck_finance_txn_dedup_lane",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    account_id: int = Field(foreign_key=f"{_FK}finance_account.id")
+    connection_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_connection.id"
+    )
+    # Forward FK (finance_import_batch, FIN-10) — plain column here.
+    import_batch_id: int | None = Field(default=None)
+    source: str = Field(max_length=16)
+    external_id: str | None = Field(default=None)
+    external_id_source: str | None = Field(default=None)
+    import_hash: str | None = Field(default=None, max_length=64)
+    within_day_ordinal: int = Field(default=0)
+    dedup_status: str = Field(default="unique", max_length=16)
+    canonical_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    source_precedence: int = Field(default=0)
+    amount: int = _bigint("amount", nullable=False, default=0)
+    raw_amount: int | None = _bigint("raw_amount")
+    raw_sign_convention: str | None = Field(default=None)
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    unofficial_currency_code: str | None = Field(default=None)
+    # Column is literally named "date"/"datetime"; the sa_column keeps the DB
+    # name while the Python attribute avoids shadowing the imported types.
+    date_: date = Field(sa_column=Column("date", Date, nullable=False))
+    authorized_date: date | None = Field(default=None)
+    datetime_: datetime | None = Field(
+        default=None, sa_column=Column("datetime", DateTime)
+    )
+    name: str | None = Field(default=None)
+    original_description: str | None = Field(default=None)
+    # Forward FK (finance_merchant, FIN-08) — plain column here.
+    merchant_id: int | None = Field(default=None)
+    merchant_name: str | None = Field(default=None)
+    merchant_entity_id: str | None = Field(default=None)
+    memo: str | None = Field(default=None)
+    check_number: str | None = Field(default=None, max_length=32)
+    payment_channel: str | None = Field(default=None)
+    pfc_primary: str | None = Field(default=None)
+    pfc_detailed: str | None = Field(default=None)
+    pfc_confidence_level: str | None = Field(default=None)
+    # Forward FK (finance_category, FIN-08) — plain column here.
+    category_id: int | None = Field(default=None)
+    category_source: str = Field(default="unset", max_length=12)
+    is_user_categorized: bool = Field(default=False)
+    is_reviewed: bool = Field(default=False)
+    pending: bool = Field(default=False)
+    pending_provider_id: str | None = Field(default=None)
+    pending_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    status: str = Field(default="posted", max_length=12)
+    is_transfer: bool = Field(default=False)
+    # Circular FK (finance_transfer) — plain column; constraint via alter_tables.
+    transfer_group_id: int | None = Field(default=None)
+    transfer_pair_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    is_split: bool = Field(default=False)
+    excluded_from_reports: bool = Field(default=False)
+    is_reversal: bool = Field(default=False)
+    reverses_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    # Forward FK (finance_recurring_stream, FIN-10) — plain column here.
+    recurring_stream_id: int | None = Field(default=None)
+    reconciled_status: str = Field(default="uncleared", max_length=12)
+    location: dict[str, Any] | None = Field(
+        default=None, sa_column=Column("location", JSON)
+    )
+    counterparties: list[Any] | None = Field(
+        default=None, sa_column=Column("counterparties", JSON)
+    )
+    raw_payload: dict[str, Any] | None = Field(
+        default=None, sa_column=Column("raw_payload", JSON)
+    )
+    is_removed: bool = Field(default=False)
+    removed_at: datetime | None = Field(default=None)
+    deleted_at: datetime | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceTransactionSplit(SQLModel, table=True):
+    """A line item that carves one transaction into multiple categories.
+
+    The parent's ``is_split`` flag is set when splits exist; each split has its
+    own category/merchant and signed ``amount`` (integer minor units). Splits
+    should sum to the parent amount, enforced in the service layer. Deleting the
+    parent cascades to its splits.
+    """
+
+    __tablename__ = "finance_transaction_split"
+    __table_args__ = (
+        Index("ix_finance_split_parent", "parent_transaction_id"),
+        Index("ix_finance_split_owner", "owner_user_id"),
+        Index("ix_finance_split_category", "category_id"),
+        Index("ix_finance_split_merchant", "merchant_id"),
+        Index(
+            "uq_finance_split_parent_sort",
+            "parent_transaction_id",
+            "sort_order",
+            unique=True,
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    parent_transaction_id: int = Field(
+        foreign_key=f"{_FK}finance_transaction.id"
+    )
+    # Forward FKs (finance_category / finance_merchant, FIN-08) — plain columns.
+    category_id: int | None = Field(default=None)
+    merchant_id: int | None = Field(default=None)
+    amount: int = _bigint("amount", nullable=False, default=0)
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    memo: str | None = Field(default=None)
+    sort_order: int = Field(default=0)
+    note: str | None = Field(default=None)
+
+
+class FinanceTransfer(SQLModel, table=True):
+    """A matched internal transfer between two of the user's own accounts.
+
+    Pairs the outflow (``from_transaction_id``) and inflow
+    (``to_transaction_id``) legs so a transfer is excluded from spend/income
+    exactly once. ``transfer_group_id`` on the transaction points back here
+    (the circular FK closed in the migration's alter_tables). Credit-card
+    payments are the common case (``is_credit_card_payment``). A leg id is
+    unique across transfers (partial-unique) so a transaction pairs at most one
+    transfer per direction.
+    """
+
+    __tablename__ = "finance_transfer"
+    __table_args__ = (
+        Index("ix_finance_transfer_owner", "owner_user_id"),
+        Index("ix_finance_transfer_from_account", "from_account_id"),
+        Index("ix_finance_transfer_to_account", "to_account_id"),
+        Index("ix_finance_transfer_from_txn", "from_transaction_id"),
+        Index("ix_finance_transfer_to_txn", "to_transaction_id"),
+        Index("ix_finance_transfer_group_key", "transfer_group_key"),
+        Index(
+            "uq_finance_transfer_from",
+            "from_transaction_id",
+            unique=True,
+            sqlite_where=Column("from_transaction_id").isnot(None),
+            postgresql_where=Column("from_transaction_id").isnot(None),
+        ),
+        Index(
+            "uq_finance_transfer_to",
+            "to_transaction_id",
+            unique=True,
+            sqlite_where=Column("to_transaction_id").isnot(None),
+            postgresql_where=Column("to_transaction_id").isnot(None),
+        ),
+        CheckConstraint(
+            "match_method IN ('auto_amount_date', 'plaid_transfer', "
+            "'user_manual', 'rule')",
+            name="ck_finance_transfer_method",
+        ),
+        CheckConstraint(
+            "status IN ('suggested', 'confirmed', 'rejected')",
+            name="ck_finance_transfer_status",
+        ),
+        CheckConstraint(
+            "from_transaction_id IS NULL OR to_transaction_id IS NULL "
+            "OR from_transaction_id <> to_transaction_id",
+            name="ck_finance_transfer_distinct",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    from_account_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_account.id"
+    )
+    to_account_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_account.id"
+    )
+    from_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    to_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    amount: int | None = _bigint("amount")
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    transfer_date: date | None = Field(default=None)
+    transfer_group_key: str | None = Field(default=None)
+    is_credit_card_payment: bool = Field(default=False)
+    match_method: str = Field(max_length=20)
+    confidence: int | None = Field(default=None)
+    status: str = Field(default="suggested", max_length=12)
+
+
+# ---------------------------------------------------------------------------
+# Group D (ref) — categories, merchants, tags, rules
+# ---------------------------------------------------------------------------
+#
+# ``category_id`` / ``merchant_id`` on FinanceTransaction and
+# FinanceTransactionSplit are plain columns above; their FK constraints are
+# added in the generated migration's alter_tables now that these target tables
+# exist. ``owner_user_id`` has no model FK (added by finance_auth_link when auth
+# is present); a NULL owner marks a system/global seed row.
+
+
+class FinanceCategory(SQLModel, table=True):
+    """Owned two-level category tree (seeded from Plaid PFC), user-editable.
+
+    ``owner_user_id`` NULL is a system/global seed row; a user's edits create
+    owned rows. Self-referencing hierarchy via ``parent_id``. ``slug`` is unique
+    per scope: once globally for seeds, once per owner for user rows.
+    """
+
+    __tablename__ = "finance_category"
+    __table_args__ = (
+        Index("ix_finance_category_owner", "owner_user_id"),
+        Index("ix_finance_category_parent", "parent_id"),
+        Index("ix_finance_category_pfc", "plaid_pfc_detailed"),
+        Index(
+            "uq_finance_category_system_slug",
+            "slug",
+            unique=True,
+            sqlite_where=Column("owner_user_id").is_(None),
+            postgresql_where=Column("owner_user_id").is_(None),
+        ),
+        Index(
+            "uq_finance_category_user_slug",
+            "owner_user_id",
+            "slug",
+            unique=True,
+            sqlite_where=Column("owner_user_id").isnot(None),
+            postgresql_where=Column("owner_user_id").isnot(None),
+        ),
+        CheckConstraint(
+            "classification IN ('income', 'expense', 'transfer')",
+            name="ck_finance_category_classification",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    parent_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_category.id"
+    )
+    name: str = Field(max_length=128)
+    slug: str = Field(max_length=96)
+    classification: str = Field(max_length=12)
+    plaid_pfc_primary: str | None = Field(default=None)
+    plaid_pfc_detailed: str | None = Field(default=None)
+    icon: str | None = Field(default=None, max_length=64)
+    color: str | None = Field(default=None, max_length=16)
+    is_system: bool = Field(default=False)
+    is_archived: bool = Field(default=False)
+    sort_order: int = Field(default=0)
+    tax_line: str | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceCategoryAlias(SQLModel, table=True):
+    """Free-text category string (QIF/Chase/AMEX/Plaid PFC) -> canonical
+    category. N:1 lookup keyed on normalized text; unmatched imports fall back
+    to the seeded ``uncategorized`` category."""
+
+    __tablename__ = "finance_category_alias"
+    __table_args__ = (
+        Index("ix_finance_catalias_owner", "owner_user_id"),
+        Index("ix_finance_catalias_category", "category_id"),
+        Index("ix_finance_catalias_normalized", "normalized_alias"),
+        Index(
+            "uq_finance_catalias_owner_norm",
+            "owner_user_id",
+            "normalized_alias",
+            unique=True,
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    category_id: int = Field(foreign_key=f"{_FK}finance_category.id")
+    alias_text: str
+    normalized_alias: str
+    source: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceMerchant(SQLModel, table=True):
+    """Normalized payee directory — the prerequisite for recurring/subscription
+    detection. ``owner_user_id`` NULL is a global/provider-seeded payee. The raw
+    description stays on the transaction; ``service_type`` powers the
+    duplicate-service ("two music subscriptions") insight."""
+
+    __tablename__ = "finance_merchant"
+    __table_args__ = (
+        Index("ix_finance_merchant_owner", "owner_user_id"),
+        Index("ix_finance_merchant_org", "organization_id"),
+        Index("ix_finance_merchant_normalized", "normalized_name"),
+        Index("ix_finance_merchant_default_cat", "default_category_id"),
+        Index("ix_finance_merchant_deleted", "deleted_at"),
+        Index(
+            "uq_finance_merchant_global",
+            "normalized_name",
+            unique=True,
+            sqlite_where=(
+                Column("owner_user_id").is_(None) & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("owner_user_id").is_(None) & Column("deleted_at").is_(None)
+            ),
+        ),
+        Index(
+            "uq_finance_merchant_user",
+            "owner_user_id",
+            "normalized_name",
+            unique=True,
+            sqlite_where=(
+                Column("owner_user_id").isnot(None) & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("owner_user_id").isnot(None) & Column("deleted_at").is_(None)
+            ),
+        ),
+        Index(
+            "uq_finance_merchant_provider",
+            "source",
+            "provider_merchant_id",
+            unique=True,
+            sqlite_where=Column("provider_merchant_id").isnot(None),
+            postgresql_where=Column("provider_merchant_id").isnot(None),
+        ),
+        CheckConstraint(
+            "source IN ('plaid', 'user', 'system', 'rule', 'snaptrade')",
+            name="ck_finance_merchant_source",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    name: str = Field(max_length=255)
+    normalized_name: str = Field(max_length=255)
+    source: str = Field(max_length=12)
+    provider_merchant_id: str | None = Field(default=None)
+    logo_url: str | None = Field(default=None)
+    website_url: str | None = Field(default=None)
+    default_category_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_category.id"
+    )
+    service_type: str | None = Field(default=None)
+    deleted_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceTag(SQLModel, table=True):
+    """First-class tags (Quicken ``/Class`` axis plus user tags), orthogonal to
+    categories. Always user-owned (no global seeds)."""
+
+    __tablename__ = "finance_tag"
+    __table_args__ = (
+        Index("ix_finance_tag_owner", "owner_user_id"),
+        Index("ix_finance_tag_org", "organization_id"),
+        Index("ix_finance_tag_deleted", "deleted_at"),
+        Index(
+            "uq_finance_tag_owner_name",
+            "owner_user_id",
+            "normalized_name",
+            unique=True,
+            sqlite_where=Column("deleted_at").is_(None),
+            postgresql_where=Column("deleted_at").is_(None),
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    name: str = Field(max_length=64)
+    normalized_name: str = Field(max_length=64)
+    color: str | None = Field(default=None, max_length=16)
+    deleted_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceTransactionTag(SQLModel, table=True):
+    """M2M join transaction <-> tag, at split-line grain when ``split_id`` is
+    set. Composite PK ``(transaction_id, tag_id)`` — a pure join table."""
+
+    __tablename__ = "finance_transaction_tag"
+    __table_args__ = (
+        Index("ix_finance_txntag_tag", "tag_id"),
+        Index("ix_finance_txntag_split", "split_id"),
+        {"schema": _SCHEMA},
+    )
+
+    transaction_id: int = Field(
+        foreign_key=f"{_FK}finance_transaction.id", primary_key=True
+    )
+    tag_id: int = Field(foreign_key=f"{_FK}finance_tag.id", primary_key=True)
+    split_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction_split.id"
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceRule(SQLModel, table=True):
+    """User automation rules (auto-categorize, mark-transfer, rename payee,
+    ignore/flag), priority-ordered, with conditions/actions as JSON. Precedence
+    is provider -> ml -> rule -> user. Reserved until the rules UI ships."""
+
+    __tablename__ = "finance_rule"
+    __table_args__ = (
+        Index("ix_finance_rule_owner", "owner_user_id"),
+        Index("ix_finance_rule_org", "organization_id"),
+        Index("ix_finance_rule_owner_priority", "owner_user_id", "priority"),
+        Index("ix_finance_rule_deleted", "deleted_at"),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    name: str = Field(max_length=128)
+    priority: int = Field(default=100)
+    is_enabled: bool = Field(default=True)
+    conditions: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("conditions", JSON)
+    )
+    actions: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("actions", JSON)
+    )
+    stop_processing: bool = Field(default=False)
+    match_count: int = Field(default=0)
+    last_matched_at: datetime | None = Field(default=None)
+    deleted_at: datetime | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+# ---------------------------------------------------------------------------
+# Group E (investments) — securities, prices, holdings, trades
+# ---------------------------------------------------------------------------
+#
+# ``finance_trade.import_batch_id`` is a plain column (its FK to
+# finance_import_batch is added in the generated migration's alter_tables in
+# FIN-10). Quantities are scaled integers (``quantity_e8`` = units x 1e8);
+# prices are integer minor units x ``price_scale``.
+
+
+class FinanceSecurity(SQLModel, table=True):
+    """Global (un-owned) securities catalog: equities, ETFs, funds, bonds,
+    options, crypto. Per-provider ids reconcile to shared FIGI/CUSIP/ISIN so one
+    instrument merges across users/providers. Taxonomy fields are plain text."""
+
+    __tablename__ = "finance_security"
+    __table_args__ = (
+        Index("ix_finance_security_ticker", "ticker"),
+        Index("ix_finance_security_cusip", "cusip"),
+        Index("ix_finance_security_isin", "isin"),
+        Index("ix_finance_security_provider_secid", "provider_security_id"),
+        Index("ix_finance_security_type", "security_type"),
+        Index(
+            "uq_finance_security_provider",
+            "provider",
+            "provider_security_id",
+            unique=True,
+            sqlite_where=Column("provider_security_id").isnot(None),
+            postgresql_where=Column("provider_security_id").isnot(None),
+        ),
+        Index(
+            "uq_finance_security_figi",
+            "figi",
+            unique=True,
+            sqlite_where=Column("figi").isnot(None),
+            postgresql_where=Column("figi").isnot(None),
+        ),
+        Index(
+            "uq_finance_security_cusip",
+            "cusip",
+            unique=True,
+            sqlite_where=Column("cusip").isnot(None),
+            postgresql_where=Column("cusip").isnot(None),
+        ),
+        Index(
+            "uq_finance_security_isin",
+            "isin",
+            unique=True,
+            sqlite_where=Column("isin").isnot(None),
+            postgresql_where=Column("isin").isnot(None),
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    provider: str | None = Field(default=None)
+    provider_security_id: str | None = Field(default=None)
+    figi: str | None = Field(default=None)
+    cusip: str | None = Field(default=None, max_length=16)
+    isin: str | None = Field(default=None, max_length=16)
+    sedol: str | None = Field(default=None, max_length=16)
+    ticker: str | None = Field(default=None, max_length=32)
+    name: str | None = Field(default=None)
+    security_type: str | None = Field(default=None)
+    exchange_mic: str | None = Field(default=None, max_length=10)
+    exchange_operating_mic: str | None = Field(default=None, max_length=10)
+    country_code: str | None = Field(default=None, max_length=2)
+    currency: str | None = Field(
+        default=None, foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    is_cash_equivalent: bool = Field(default=False)
+    is_crypto: bool = Field(default=False)
+    coingecko_id: str | None = Field(default=None)
+    onchain_contract: str | None = Field(default=None)
+    onchain_chain: str | None = Field(default=None)
+    close_price: int | None = _bigint("close_price")
+    price_scale: int = Field(default=2)
+    close_price_as_of: date | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceSecurityPrice(SQLModel, table=True):
+    """Price time series feeding holding valuation and charts. One price per
+    security/day/source. Sub-cent/crypto precision via ``price_scale``."""
+
+    __tablename__ = "finance_security_price"
+    __table_args__ = (
+        Index(
+            "ix_finance_secprice_security_date", "security_id", "price_date"
+        ),
+        Index(
+            "uq_finance_secprice",
+            "security_id",
+            "price_date",
+            "source",
+            unique=True,
+        ),
+        CheckConstraint(
+            "source IN ('plaid', 'snaptrade', 'exchange_api', 'onchain', "
+            "'coingecko', 'manual', 'market_data')",
+            name="ck_finance_secprice_source",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    security_id: int = Field(foreign_key=f"{_FK}finance_security.id")
+    price_date: date
+    close_price: int = _bigint("close_price", nullable=False, default=0)
+    price_scale: int = Field(default=2)
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    source: str = Field(max_length=16)
+
+
+class FinanceHolding(SQLModel, table=True):
+    """Dated position snapshot per (account, security, as_of_date) — upsert, not
+    append. Current = latest date; historical rows feed allocation-over-time.
+    Quantity is a scaled integer ``quantity_e8`` (units x 1e8)."""
+
+    __tablename__ = "finance_holding"
+    __table_args__ = (
+        Index("ix_finance_holding_owner", "owner_user_id"),
+        Index("ix_finance_holding_account", "account_id"),
+        Index("ix_finance_holding_security", "security_id"),
+        Index("ix_finance_holding_account_date", "account_id", "as_of_date"),
+        Index("ix_finance_holding_deleted", "deleted_at"),
+        Index(
+            "uq_finance_holding",
+            "account_id",
+            "security_id",
+            "as_of_date",
+            unique=True,
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    account_id: int = Field(foreign_key=f"{_FK}finance_account.id")
+    security_id: int = Field(foreign_key=f"{_FK}finance_security.id")
+    as_of_date: date
+    quantity_e8: int = _bigint("quantity_e8", nullable=False, default=0)
+    cost_basis: int | None = _bigint("cost_basis")
+    average_cost: int | None = _bigint("average_cost")
+    price: int | None = _bigint("price")
+    price_scale: int = Field(default=2)
+    institution_value: int | None = _bigint("institution_value")
+    vested_quantity_e8: int | None = _bigint("vested_quantity_e8")
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    source: str | None = Field(default=None)
+    deleted_at: datetime | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceTrade(SQLModel, table=True):
+    """Investment / security-movement events (buy/sell/dividend/reinvest/fee/
+    transfer). Same dual-lane dedup + soft-delete as cash transactions, with an
+    optional link to the cash-leg ``finance_transaction``. ``type`` is a
+    normalized coarse type; ``subtype`` is provider text."""
+
+    __tablename__ = "finance_trade"
+    __table_args__ = (
+        Index("ix_finance_trade_owner_date", "owner_user_id", "trade_date"),
+        Index("ix_finance_trade_account_date", "account_id", "trade_date"),
+        Index("ix_finance_trade_security", "security_id"),
+        Index("ix_finance_trade_transaction", "transaction_id"),
+        Index("ix_finance_trade_connection", "connection_id"),
+        Index("ix_finance_trade_batch", "import_batch_id"),
+        Index("ix_finance_trade_deleted", "deleted_at"),
+        Index(
+            "uq_finance_trade_external",
+            "account_id",
+            "source",
+            "external_id",
+            unique=True,
+            sqlite_where=(
+                Column("external_id").isnot(None) & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("external_id").isnot(None) & Column("deleted_at").is_(None)
+            ),
+        ),
+        Index(
+            "uq_finance_trade_hash",
+            "account_id",
+            "import_hash",
+            unique=True,
+            sqlite_where=(
+                Column("external_id").is_(None)
+                & Column("import_hash").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+            postgresql_where=(
+                Column("external_id").is_(None)
+                & Column("import_hash").isnot(None)
+                & Column("deleted_at").is_(None)
+            ),
+        ),
+        CheckConstraint(
+            "source IN ('plaid', 'snaptrade', 'ofx', 'qfx', 'csv', 'manual', "
+            "'coinbase', 'onchain')",
+            name="ck_finance_trade_source",
+        ),
+        CheckConstraint(
+            "type IN ('buy', 'sell', 'dividend', 'interest', 'fee', 'tax', "
+            "'transfer_in', 'transfer_out', 'deposit', 'withdrawal', "
+            "'reinvest', 'split', 'cancel', 'other')",
+            name="ck_finance_trade_type",
+        ),
+        CheckConstraint(
+            "NOT (external_id IS NOT NULL AND import_hash IS NOT NULL)",
+            name="ck_finance_trade_dedup_lane",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    account_id: int = Field(foreign_key=f"{_FK}finance_account.id")
+    security_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_security.id"
+    )
+    transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    connection_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_connection.id"
+    )
+    # Forward FK (finance_import_batch, FIN-10) — plain column here.
+    import_batch_id: int | None = Field(default=None)
+    source: str = Field(max_length=16)
+    external_id: str | None = Field(default=None)
+    external_id_source: str | None = Field(default=None)
+    import_hash: str | None = Field(default=None, max_length=64)
+    type: str = Field(max_length=16)
+    subtype: str | None = Field(default=None)
+    quantity_e8: int | None = _bigint("quantity_e8")
+    price: int | None = _bigint("price")
+    price_scale: int = Field(default=2)
+    amount: int = _bigint("amount", nullable=False, default=0)
+    raw_amount: int | None = _bigint("raw_amount")
+    fees: int | None = _bigint("fees")
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    trade_date: date
+    settle_date: date | None = Field(default=None)
+    datetime_: datetime | None = Field(
+        default=None, sa_column=Column("datetime", DateTime)
+    )
+    name: str | None = Field(default=None)
+    pending: bool = Field(default=False)
+    raw_payload: dict[str, Any] | None = Field(
+        default=None, sa_column=Column("raw_payload", JSON)
+    )
+    is_removed: bool = Field(default=False)
+    deleted_at: datetime | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+# ---------------------------------------------------------------------------
+# Group F (analytics / import) — recurring streams, budgets, baselines,
+# insights, import pipeline, attachments, changelog
+# ---------------------------------------------------------------------------
+#
+# finance_transaction.recurring_stream_id / import_batch_id and
+# finance_trade.import_batch_id are plain columns on those models; their FK
+# constraints to the tables below are added in the generated migration's
+# alter_tables (all resolved now that these targets exist).
+
+
+class FinanceRecurringStream(SQLModel, table=True):
+    """Detected recurring streams (subscriptions, bills, paychecks) — the
+    "wasting money" engine. Plaid Recurring add-on plus local heuristics.
+    Confidence/maturity, not a boolean (annual charges are invisible for a
+    year). Transactions back-link via ``finance_transaction.recurring_stream_id``
+    (no join table)."""
+
+    __tablename__ = "finance_recurring_stream"
+    __table_args__ = (
+        Index("ix_finance_recurring_owner", "owner_user_id"),
+        Index("ix_finance_recurring_account", "account_id"),
+        Index("ix_finance_recurring_merchant", "merchant_id"),
+        Index("ix_finance_recurring_category", "category_id"),
+        Index("ix_finance_recurring_connection", "connection_id"),
+        Index(
+            "ix_finance_recurring_next", "owner_user_id", "next_expected_date"
+        ),
+        Index("ix_finance_recurring_status", "status"),
+        Index("ix_finance_recurring_deleted", "deleted_at"),
+        Index(
+            "uq_finance_recurring_provider",
+            "connection_id",
+            "provider_stream_id",
+            unique=True,
+            sqlite_where=Column("provider_stream_id").isnot(None),
+            postgresql_where=Column("provider_stream_id").isnot(None),
+        ),
+        Index(
+            "uq_finance_recurring_detected",
+            "owner_user_id",
+            "account_id",
+            "direction",
+            "normalized_payee",
+            unique=True,
+            sqlite_where=Column("provider_stream_id").is_(None),
+            postgresql_where=Column("provider_stream_id").is_(None),
+        ),
+        CheckConstraint(
+            "direction IN ('inflow', 'outflow')",
+            name="ck_finance_recurring_direction",
+        ),
+        CheckConstraint(
+            "frequency IN ('weekly', 'biweekly', 'semi_monthly', 'monthly', "
+            "'bimonthly', 'quarterly', 'semi_annually', 'annually', "
+            "'irregular', 'unknown')",
+            name="ck_finance_recurring_frequency",
+        ),
+        CheckConstraint(
+            "status IN ('early_detection', 'mature', 'inactive', 'cancelled')",
+            name="ck_finance_recurring_status",
+        ),
+        CheckConstraint(
+            "source IN ('plaid', 'derived', 'user')",
+            name="ck_finance_recurring_source",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    account_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_account.id"
+    )
+    merchant_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_merchant.id"
+    )
+    category_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_category.id"
+    )
+    connection_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_connection.id"
+    )
+    provider_stream_id: str | None = Field(default=None)
+    name: str = Field(max_length=255)
+    normalized_payee: str | None = Field(default=None)
+    direction: str = Field(max_length=8)
+    frequency: str = Field(max_length=16)
+    average_amount: int | None = _bigint("average_amount")
+    last_amount: int | None = _bigint("last_amount")
+    expected_amount: int | None = _bigint("expected_amount")
+    amount_is_variable: bool = Field(default=False)
+    amount_tolerance_bps: int | None = Field(default=None)
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    first_date: date | None = Field(default=None)
+    last_date: date | None = Field(default=None)
+    next_expected_date: date | None = Field(default=None)
+    occurrence_count: int = Field(default=0)
+    status: str = Field(default="early_detection", max_length=16)
+    confidence: int | None = Field(default=None)
+    is_subscription: bool = Field(default=False)
+    is_active: bool = Field(default=True)
+    is_user_confirmed: bool = Field(default=False)
+    is_muted: bool = Field(default=False)
+    service_type: str | None = Field(default=None)
+    source: str = Field(max_length=12)
+    deleted_at: datetime | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceBudget(SQLModel, table=True):
+    """Budget definition scoped to a period. Reserved until the budgeting UI
+    ships."""
+
+    __tablename__ = "finance_budget"
+    __table_args__ = (
+        Index("ix_finance_budget_owner", "owner_user_id"),
+        Index("ix_finance_budget_org", "organization_id"),
+        Index("ix_finance_budget_deleted", "deleted_at"),
+        Index(
+            "uq_finance_budget_owner_name_start",
+            "owner_user_id",
+            "name",
+            "start_date",
+            unique=True,
+        ),
+        CheckConstraint(
+            "period IN ('monthly', 'weekly', 'quarterly', 'yearly', 'custom')",
+            name="ck_finance_budget_period",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    name: str = Field(max_length=128)
+    period: str = Field(max_length=16)
+    start_date: date
+    end_date: date | None = Field(default=None)
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    philosophy: str | None = Field(default=None)
+    rollover: bool = Field(default=False)
+    is_active: bool = Field(default=True)
+    deleted_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceBudgetCategory(SQLModel, table=True):
+    """Per-category budgeted amount per ``period_month`` (YYYYMM), with
+    carryover/goal so envelope and flex budgeting never need a new table.
+    Actuals derive live from transactions/splits."""
+
+    __tablename__ = "finance_budget_category"
+    __table_args__ = (
+        Index("ix_finance_budgetcat_owner", "owner_user_id"),
+        Index("ix_finance_budgetcat_budget", "budget_id"),
+        Index("ix_finance_budgetcat_category", "category_id"),
+        Index("ix_finance_budgetcat_month", "period_month"),
+        Index(
+            "uq_finance_budgetcat",
+            "budget_id",
+            "category_id",
+            "period_month",
+            unique=True,
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    budget_id: int = Field(foreign_key=f"{_FK}finance_budget.id")
+    # NULL category = the budget's overall line.
+    category_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_category.id"
+    )
+    period_month: int | None = Field(default=None)
+    allocated_amount: int = _bigint("allocated_amount", nullable=False, default=0)
+    goal_amount: int | None = _bigint("goal_amount")
+    carryover_amount: int = _bigint("carryover_amount", nullable=False, default=0)
+    rollover_enabled: bool = Field(default=False)
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceSpendingBaseline(SQLModel, table=True):
+    """Materialized trailing 3/6/12-month averages per category (and optional
+    merchant) — powers anomaly-vs-your-own-baseline "wasting money" insights.
+    Computed by a job once history matures."""
+
+    __tablename__ = "finance_spending_baseline"
+    __table_args__ = (
+        Index("ix_finance_baseline_owner", "owner_user_id"),
+        Index("ix_finance_baseline_category", "category_id"),
+        Index("ix_finance_baseline_merchant", "merchant_id"),
+        Index(
+            "uq_finance_baseline",
+            "owner_user_id",
+            "category_id",
+            "merchant_id",
+            "window_months",
+            "period_month",
+            unique=True,
+        ),
+        CheckConstraint(
+            "window_months IN (3, 6, 12)", name="ck_finance_baseline_window"
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    category_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_category.id"
+    )
+    merchant_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_merchant.id"
+    )
+    window_months: int
+    period_month: int
+    trailing_avg_amount: int = _bigint(
+        "trailing_avg_amount", nullable=False, default=0
+    )
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    computed_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceInsight(SQLModel, table=True):
+    """Finance-specific insight/alert rows (price_hike, duplicate_service,
+    inactive_subscription, fee_charged, overspend, spending_anomaly,
+    low_yield_cash). ``dedup_key`` prevents regenerating the same insight daily.
+    Reserved — v1 signals emit through the shared insight_event system; this
+    exists for finance dedup idempotency, typed related_* FKs, and AI-readiness
+    (Illiana) when that surface matures."""
+
+    __tablename__ = "finance_insight"
+    __table_args__ = (
+        Index("ix_finance_insight_owner", "owner_user_id"),
+        Index("ix_finance_insight_org", "organization_id"),
+        Index("ix_finance_insight_type", "insight_type"),
+        Index("ix_finance_insight_status", "status"),
+        Index("ix_finance_insight_account", "related_account_id"),
+        Index("ix_finance_insight_transaction", "related_transaction_id"),
+        Index("ix_finance_insight_category", "related_category_id"),
+        Index("ix_finance_insight_stream", "related_stream_id"),
+        Index("ix_finance_insight_owner_read", "owner_user_id", "is_read"),
+        Index(
+            "uq_finance_insight_dedup",
+            "owner_user_id",
+            "dedup_key",
+            unique=True,
+        ),
+        CheckConstraint(
+            "severity IN ('info', 'warning', 'critical')",
+            name="ck_finance_insight_severity",
+        ),
+        CheckConstraint(
+            "status IN ('new', 'seen', 'dismissed', 'actioned')",
+            name="ck_finance_insight_status",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    insight_type: str
+    severity: str = Field(max_length=16)
+    title: str
+    body: str | None = Field(default=None)
+    related_account_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_account.id"
+    )
+    related_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    related_category_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_category.id"
+    )
+    related_stream_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_recurring_stream.id"
+    )
+    detected_amount: int | None = _bigint("detected_amount")
+    currency: str | None = Field(
+        default=None, foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    dedup_key: str
+    period_start: date | None = Field(default=None)
+    period_end: date | None = Field(default=None)
+    data: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("data", JSON)
+    )
+    status: str = Field(default="new", max_length=12)
+    is_read: bool = Field(default=False)
+    dismissed_at: datetime | None = Field(default=None)
+    metadata_: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("metadata", JSON)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceImportProfile(SQLModel, table=True):
+    """Data-driven CSV/OFX column mapping plus header signature (auto-detect
+    Chase-CC vs Chase-checking vs AMEX variants) and sign convention.
+    ``owner_user_id`` NULL is a system seed. Not hardcoded parsers — the
+    difference between "add a data row" and "add a parser + migrate" when AMEX
+    ships yet another layout."""
+
+    __tablename__ = "finance_import_profile"
+    __table_args__ = (
+        Index("ix_finance_importprofile_owner", "owner_user_id"),
+        Index("ix_finance_importprofile_org", "organization_id"),
+        Index("ix_finance_importprofile_institution", "institution_id"),
+        Index("ix_finance_importprofile_deleted", "deleted_at"),
+        Index(
+            "uq_finance_importprofile_owner_name",
+            "owner_user_id",
+            "name",
+            unique=True,
+        ),
+        CheckConstraint(
+            "source_format IN ('csv', 'ofx', 'qfx', 'qif')",
+            name="ck_finance_importprofile_format",
+        ),
+        CheckConstraint(
+            "amount_sign_convention IN ('outflow_negative', 'outflow_positive', "
+            "'split_debit_credit')",
+            name="ck_finance_importprofile_sign",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    organization_id: int | None = Field(default=None)
+    institution_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_institution.id"
+    )
+    name: str = Field(max_length=128)
+    source_format: str = Field(max_length=8)
+    header_signature: list[Any] = Field(
+        default_factory=list, sa_column=Column("header_signature", JSON)
+    )
+    column_mapping: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("column_mapping", JSON)
+    )
+    date_format: str | None = Field(default=None)
+    amount_sign_convention: str = Field(max_length=20)
+    decimal_separator: str | None = Field(default=None, max_length=1)
+    thousands_separator: str | None = Field(default=None, max_length=1)
+    currency: str = Field(
+        default="usd", foreign_key=f"{_FK}finance_currency.code", max_length=16
+    )
+    is_system: bool = Field(default=False)
+    deleted_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceImportBatch(SQLModel, table=True):
+    """One row per ingestion run (a Plaid/SnapTrade sync pass, an uploaded
+    QIF/QFX/OFX/CSV file, or a manual bulk). Reversible unit plus counts and
+    ``file_sha256`` whole-file dedup (blocks identical re-upload before row
+    parsing). Every imported transaction/trade FKs back here."""
+
+    __tablename__ = "finance_import_batch"
+    __table_args__ = (
+        Index("ix_finance_importbatch_owner", "owner_user_id"),
+        Index("ix_finance_importbatch_org", "organization_id"),
+        Index("ix_finance_importbatch_connection", "connection_id"),
+        Index("ix_finance_importbatch_account", "account_id"),
+        Index("ix_finance_importbatch_profile", "import_profile_id"),
+        Index("ix_finance_importbatch_status", "status"),
+        Index(
+            "ix_finance_importbatch_owner_started",
+            "owner_user_id",
+            "started_at",
+        ),
+        Index(
+            "uq_finance_importbatch_file",
+            "owner_user_id",
+            "file_sha256",
+            unique=True,
+            sqlite_where=Column("file_sha256").isnot(None),
+            postgresql_where=Column("file_sha256").isnot(None),
+        ),
+        CheckConstraint(
+            "source_type IN ('plaid_sync', 'snaptrade_sync', 'ofx', 'qfx', "
+            "'qif', 'csv', 'manual')",
+            name="ck_finance_importbatch_source",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'processing', 'committed', 'failed', "
+            "'rolled_back')",
+            name="ck_finance_importbatch_status",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    connection_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_connection.id"
+    )
+    account_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_account.id"
+    )
+    import_profile_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_import_profile.id"
+    )
+    source_type: str = Field(max_length=16)
+    file_name: str | None = Field(default=None, max_length=255)
+    file_sha256: str | None = Field(default=None)
+    sync_cursor_before: str | None = Field(default=None)
+    sync_cursor_after: str | None = Field(default=None)
+    rows_total: int = Field(default=0)
+    rows_inserted: int = Field(default=0)
+    rows_updated: int = Field(default=0)
+    rows_duplicate: int = Field(default=0)
+    rows_error: int = Field(default=0)
+    status: str = Field(default="pending", max_length=16)
+    error: str | None = Field(default=None)
+    started_at: datetime | None = Field(default=None)
+    finished_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceImportBatchRow(SQLModel, table=True):
+    """Staging: one raw parsed record per file row with parse status, match link,
+    and content hash. Powers review-before-commit, reversible batches, and
+    precise dup/error reporting."""
+
+    __tablename__ = "finance_import_batch_row"
+    __table_args__ = (
+        Index("ix_finance_importrow_batch", "import_batch_id"),
+        Index("ix_finance_importrow_owner", "owner_user_id"),
+        Index("ix_finance_importrow_account", "account_id"),
+        Index("ix_finance_importrow_matched_txn", "matched_transaction_id"),
+        Index("ix_finance_importrow_matched_trade", "matched_trade_id"),
+        Index("ix_finance_importrow_hash", "content_hash"),
+        Index(
+            "uq_finance_importrow_batch_num",
+            "import_batch_id",
+            "row_number",
+            unique=True,
+        ),
+        CheckConstraint(
+            "parsed_status IN ('parsed', 'inserted', 'updated', 'duplicate', "
+            "'error', 'matched', 'skipped')",
+            name="ck_finance_importrow_status",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    import_batch_id: int = Field(foreign_key=f"{_FK}finance_import_batch.id")
+    owner_user_id: int = Field()
+    account_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_account.id"
+    )
+    row_number: int
+    raw_line: str | None = Field(default=None)
+    parsed: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("parsed", JSON)
+    )
+    content_hash: str | None = Field(default=None, max_length=64)
+    fitid: str | None = Field(default=None)
+    parsed_status: str = Field(max_length=12)
+    matched_transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    matched_trade_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_trade.id"
+    )
+    reason: str | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceAttachment(SQLModel, table=True):
+    """Receipts/documents per transaction or account (object-store key).
+    Reserved to avoid a later add."""
+
+    __tablename__ = "finance_attachment"
+    __table_args__ = (
+        Index("ix_finance_attachment_owner", "owner_user_id"),
+        Index("ix_finance_attachment_org", "organization_id"),
+        Index("ix_finance_attachment_transaction", "transaction_id"),
+        Index("ix_finance_attachment_account", "account_id"),
+        Index("ix_finance_attachment_deleted", "deleted_at"),
+        Index(
+            "uq_finance_attachment_owner_sha",
+            "owner_user_id",
+            "sha256",
+            unique=True,
+            sqlite_where=Column("sha256").isnot(None),
+            postgresql_where=Column("sha256").isnot(None),
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int = Field()
+    organization_id: int | None = Field(default=None)
+    transaction_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_transaction.id"
+    )
+    account_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_account.id"
+    )
+    file_name: str
+    content_type: str | None = Field(default=None)
+    byte_size: int | None = Field(default=None)
+    storage_key: str
+    sha256: str | None = Field(default=None)
+    deleted_at: datetime | None = Field(default=None)
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceTransactionChangelog(SQLModel, table=True):
+    """Append-only field-level audit of Plaid ``modified[]`` and user edits, kept
+    separate from the mutable transaction row (the queryable row stays an upsert;
+    audit is immutable). Reserved until an audit/undo surface is built."""
+
+    __tablename__ = "finance_transaction_changelog"
+    __table_args__ = (
+        Index("ix_finance_changelog_transaction", "transaction_id"),
+        Index("ix_finance_changelog_owner", "owner_user_id"),
+        Index("ix_finance_changelog_changed", "changed_at"),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    transaction_id: int = Field(foreign_key=f"{_FK}finance_transaction.id")
+    owner_user_id: int = Field()
+    field: str
+    old_value: str | None = Field(default=None)
+    new_value: str | None = Field(default=None)
+    change_source: str
+    sync_cursor: str | None = Field(default=None)
+    changed_at: datetime = Field(default_factory=_utcnow)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
@@ -75,7 +75,7 @@ dependencies = [
     "authlib>=1.7.0",
     "itsdangerous>=2.1.0",
 {%- endif %}
-{%- if include_auth or include_payment or include_insights or include_blog or (include_ai and ai_backend in ["sqlite", "postgres"]) or (include_scheduler and scheduler_backend == "postgres") %}
+{%- if include_auth or include_payment or include_insights or include_blog or include_finance or (include_ai and ai_backend in ["sqlite", "postgres"]) or (include_scheduler and scheduler_backend == "postgres") %}
     "alembic==1.16.5",
 {%- endif %}
 {%- if include_auth or include_ai or include_blog %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
@@ -36,6 +36,44 @@ from app.services.payment.models import (  # noqa: F401
 # Import blog models to register them with SQLModel metadata
 from app.services.blog.models import BlogPost, BlogPostTag, BlogTag  # noqa: F401
 {% endif %}
+{%- if include_finance %}
+# Import finance models to register them with SQLModel metadata
+from app.services.finance.models import (  # noqa: F401
+    FinanceAccount,
+    FinanceAttachment,
+    FinanceBalanceSnapshot,
+    FinanceBudget,
+    FinanceBudgetCategory,
+    FinanceCategory,
+    FinanceCategoryAlias,
+    FinanceConnection,
+    FinanceCurrency,
+    FinanceFxRate,
+    FinanceHolding,
+    FinanceImportBatch,
+    FinanceImportBatchRow,
+    FinanceImportProfile,
+    FinanceInsight,
+    FinanceInstitution,
+    FinanceLiabilityDetail,
+    FinanceMerchant,
+    FinanceNetWorthSnapshot,
+    FinanceRecurringStream,
+    FinanceRule,
+    FinanceSecurity,
+    FinanceSecurityPrice,
+    FinanceSpendingBaseline,
+    FinanceTag,
+    FinanceTrade,
+    FinanceTransaction,
+    FinanceTransactionChangelog,
+    FinanceTransactionSplit,
+    FinanceTransactionTag,
+    FinanceTransfer,
+    FinanceValuation,
+    FinanceWebhookEvent,
+)
+{% endif %}
 {%- if include_scheduler and scheduler_backend != "memory" %}
 # Import scheduler models to register them with SQLModel metadata
 from app.services.scheduler.models import JobExecution  # noqa: F401

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_models.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_models.py
@@ -1,0 +1,2018 @@
+"""Tests for the finance reference-data models (currencies, FX rates).
+
+Plain ``.py`` (not ``.jinja``): the ``import app.services.finance.models``
+only resolves in finance-selected stacks, and those are the only stacks that
+generate the package (non-finance stacks prune this file via the finance
+FileManifest). Runs against the in-memory SQLite session from conftest, which
+enforces foreign keys (``PRAGMA foreign_keys=ON``), so FK/unique/CHECK
+violations surface here exactly as they would on Postgres.
+"""
+
+from datetime import date
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.finance.models import (
+    FinanceConnection,
+    FinanceCurrency,
+    FinanceFxRate,
+    FinanceInstitution,
+    FinanceWebhookEvent,
+)
+
+
+async def _seed_currency(
+    session: AsyncSession, code: str = "usd", *, decimals: int = 2, kind: str = "fiat"
+) -> FinanceCurrency:
+    currency = FinanceCurrency(
+        code=code, name=code.upper(), decimals=decimals, kind=kind
+    )
+    session.add(currency)
+    await session.flush()
+    return currency
+
+
+class TestFinanceCurrency:
+    @pytest.mark.asyncio
+    async def test_round_trips(self, async_db_session: AsyncSession) -> None:
+        await _seed_currency(async_db_session, "usd")
+        await async_db_session.commit()
+
+        row = (
+            await async_db_session.exec(
+                select(FinanceCurrency).where(FinanceCurrency.code == "usd")
+            )
+        ).one()
+        assert row.id is not None
+        assert row.decimals == 2
+        assert row.kind == "fiat"
+        assert row.is_active is True
+
+    @pytest.mark.asyncio
+    async def test_code_is_unique(self, async_db_session: AsyncSession) -> None:
+        # Add both rows, then flush once so the duplicate surfaces at the
+        # assertion (a per-add flush would raise inside the seed helper).
+        async_db_session.add(FinanceCurrency(code="usd", name="USD", decimals=2))
+        async_db_session.add(FinanceCurrency(code="usd", name="USD dup", decimals=2))
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_kind_check_constraint(self, async_db_session: AsyncSession) -> None:
+        async_db_session.add(
+            FinanceCurrency(code="xxx", name="XXX", decimals=2, kind="bogus")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceFxRate:
+    @pytest.mark.asyncio
+    async def test_round_trips_with_fk(self, async_db_session: AsyncSession) -> None:
+        await _seed_currency(async_db_session, "usd")
+        await _seed_currency(async_db_session, "eur")
+        rate = FinanceFxRate(
+            base_currency="usd",
+            quote_currency="eur",
+            rate_date=date(2026, 7, 4),
+            rate_e8=92_000_000,  # 0.92 EUR per USD, scaled by 1e8
+        )
+        async_db_session.add(rate)
+        await async_db_session.commit()
+
+        row = (await async_db_session.exec(select(FinanceFxRate))).one()
+        assert row.rate_e8 == 92_000_000
+        assert row.source == "manual"
+
+    @pytest.mark.asyncio
+    async def test_fk_requires_existing_currency(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceFxRate(
+                base_currency="usd",
+                quote_currency="nope",  # not a currency row
+                rate_date=date(2026, 7, 4),
+                rate_e8=1,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_base_and_quote_must_differ(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceFxRate(
+                base_currency="usd",
+                quote_currency="usd",
+                rate_date=date(2026, 7, 4),
+                rate_e8=100_000_000,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Group A — connections & sync
+# ---------------------------------------------------------------------------
+
+
+async def _seed_institution(
+    session: AsyncSession, provider: str = "plaid", ext_id: str | None = "ins_1"
+) -> FinanceInstitution:
+    inst = FinanceInstitution(
+        provider=provider, provider_institution_id=ext_id, name="Chase"
+    )
+    session.add(inst)
+    await session.flush()
+    return inst
+
+
+class TestFinanceInstitution:
+    @pytest.mark.asyncio
+    async def test_round_trips(self, async_db_session: AsyncSession) -> None:
+        inst = FinanceInstitution(
+            provider="plaid",
+            provider_institution_id="ins_56",
+            name="American Express",
+            supported_products=["transactions", "balance"],
+            oauth_required=True,
+        )
+        async_db_session.add(inst)
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceInstitution))).one()
+        assert row.supported_products == ["transactions", "balance"]
+        assert row.oauth_required is True
+        assert row.uses_tokenized_account_numbers is False
+
+    @pytest.mark.asyncio
+    async def test_provider_check_constraint(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        async_db_session.add(FinanceInstitution(provider="bogus", name="X"))
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_partial_unique_ext_id(self, async_db_session: AsyncSession) -> None:
+        # Same (provider, ext_id) with a non-null ext_id collides...
+        async_db_session.add(
+            FinanceInstitution(
+                provider="plaid", provider_institution_id="ins_dup", name="A"
+            )
+        )
+        async_db_session.add(
+            FinanceInstitution(
+                provider="plaid", provider_institution_id="ins_dup", name="B"
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_null_ext_ids_do_not_collide(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        # ...but the partial index skips NULL ext_ids, so two are allowed.
+        async_db_session.add(
+            FinanceInstitution(
+                provider="manual", provider_institution_id=None, name="A"
+            )
+        )
+        async_db_session.add(
+            FinanceInstitution(
+                provider="manual", provider_institution_id=None, name="B"
+            )
+        )
+        await async_db_session.flush()  # no IntegrityError
+
+
+class TestFinanceConnection:
+    @pytest.mark.asyncio
+    async def test_round_trips(self, async_db_session: AsyncSession) -> None:
+        inst = await _seed_institution(async_db_session)
+        conn = FinanceConnection(
+            owner_user_id=1,
+            institution_id=inst.id,
+            provider="plaid",
+            connection_type="oauth_access_token",
+            provider_item_id="item_abc",
+            capabilities={"read_transactions": True},
+        )
+        async_db_session.add(conn)
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceConnection))).one()
+        assert row.capabilities == {"read_transactions": True}
+        assert row.status == "healthy"
+        assert row.environment == "sandbox"
+
+    @pytest.mark.asyncio
+    async def test_repr_masks_credentials(self, async_db_session: AsyncSession) -> None:
+        conn = FinanceConnection(
+            provider="plaid",
+            connection_type="oauth_access_token",
+            access_token_encrypted="v2:supersecretciphertext",
+        )
+        text = repr(conn)
+        assert "supersecretciphertext" not in text
+        assert "access_token_encrypted" in text and "'***'" in text
+
+    @pytest.mark.asyncio
+    async def test_status_check_constraint(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        async_db_session.add(
+            FinanceConnection(
+                provider="plaid", connection_type="manual", status="banana"
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_partial_unique_provider_item_and_soft_delete(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import _utcnow
+
+        first = FinanceConnection(
+            provider="plaid",
+            connection_type="oauth_access_token",
+            provider_item_id="item_x",
+        )
+        async_db_session.add(first)
+        await async_db_session.flush()
+
+        # A second live connection for the same (provider, item) collides.
+        dup = FinanceConnection(
+            provider="plaid",
+            connection_type="oauth_access_token",
+            provider_item_id="item_x",
+        )
+        async_db_session.add(dup)
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+        await async_db_session.rollback()
+
+        # Soft-deleting the original releases the key (partial index excludes
+        # deleted rows), so a fresh connection can reuse the item id.
+        first = FinanceConnection(
+            provider="plaid",
+            connection_type="oauth_access_token",
+            provider_item_id="item_y",
+        )
+        async_db_session.add(first)
+        await async_db_session.flush()
+        first.deleted_at = _utcnow()
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceConnection(
+                provider="plaid",
+                connection_type="oauth_access_token",
+                provider_item_id="item_y",
+            )
+        )
+        await async_db_session.flush()  # no IntegrityError
+
+
+class TestFinanceWebhookEvent:
+    @pytest.mark.asyncio
+    async def test_round_trips(self, async_db_session: AsyncSession) -> None:
+        event = FinanceWebhookEvent(
+            provider="plaid",
+            webhook_type="TRANSACTIONS",
+            webhook_code="SYNC_UPDATES_AVAILABLE",
+            provider_event_id="evt_1",
+            payload={"item_id": "item_abc"},
+        )
+        async_db_session.add(event)
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceWebhookEvent))).one()
+        assert row.payload == {"item_id": "item_abc"}
+        assert row.status == "received"
+
+    @pytest.mark.asyncio
+    async def test_event_id_is_idempotent(self, async_db_session: AsyncSession) -> None:
+        async_db_session.add(
+            FinanceWebhookEvent(provider="plaid", provider_event_id="evt_dup")
+        )
+        async_db_session.add(
+            FinanceWebhookEvent(provider="plaid", provider_event_id="evt_dup")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Group B — accounts & balances
+# ---------------------------------------------------------------------------
+
+
+async def _seed_account(
+    session: AsyncSession,
+    *,
+    owner: int | None = 1,
+    account_type: str = "checking",
+    classification: str = "asset",
+    provider: str = "plaid",
+    provider_account_id: str | None = None,
+    is_manual: bool = False,
+) -> "object":
+    from app.services.finance.models import FinanceAccount
+
+    await _seed_currency(session, "usd")
+    acct = FinanceAccount(
+        owner_user_id=owner,
+        provider=provider,
+        provider_account_id=provider_account_id,
+        name="Chase Checking",
+        account_type=account_type,
+        classification=classification,
+        is_manual=is_manual,
+        current_balance=842_650,
+    )
+    session.add(acct)
+    await session.flush()
+    return acct
+
+
+class TestFinanceAccount:
+    @pytest.mark.asyncio
+    async def test_round_trips(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceAccount
+
+        await _seed_account(async_db_session)
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceAccount))).one()
+        assert row.current_balance == 842_650
+        assert row.classification == "asset"
+        assert row.is_on_budget is True
+
+    @pytest.mark.asyncio
+    async def test_classification_check(self, async_db_session: AsyncSession) -> None:
+        with pytest.raises(IntegrityError):
+            await _seed_account(async_db_session, classification="banana")
+
+    @pytest.mark.asyncio
+    async def test_account_type_check(self, async_db_session: AsyncSession) -> None:
+        with pytest.raises(IntegrityError):
+            await _seed_account(async_db_session, account_type="spaceship")
+
+    @pytest.mark.asyncio
+    async def test_manual_account_no_connection(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceAccount
+
+        await _seed_account(
+            async_db_session,
+            account_type="property",
+            is_manual=True,
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceAccount))).one()
+        assert row.connection_id is None
+        assert row.is_manual is True
+
+
+class TestFinanceBalanceSnapshot:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceBalanceSnapshot
+
+        acct = await _seed_account(async_db_session)
+        async_db_session.add(
+            FinanceBalanceSnapshot(
+                account_id=acct.id,
+                owner_user_id=1,
+                balance_date=date(2026, 7, 4),
+                balance=842_650,
+            )
+        )
+        await async_db_session.flush()
+        # One balance per account per day.
+        async_db_session.add(
+            FinanceBalanceSnapshot(
+                account_id=acct.id,
+                owner_user_id=1,
+                balance_date=date(2026, 7, 4),
+                balance=999,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_source_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceBalanceSnapshot
+
+        acct = await _seed_account(async_db_session)
+        async_db_session.add(
+            FinanceBalanceSnapshot(
+                account_id=acct.id,
+                balance_date=date(2026, 7, 4),
+                balance=1,
+                source="telepathy",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceNetWorthSnapshot:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceNetWorthSnapshot
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceNetWorthSnapshot(
+                owner_user_id=1,
+                as_of_date=date(2026, 7, 4),
+                total_assets_amount=15_216_220,
+                total_liabilities_amount=310_401,
+                net_worth_amount=14_905_819,
+            )
+        )
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceNetWorthSnapshot(
+                owner_user_id=1, as_of_date=date(2026, 7, 4), net_worth_amount=0
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceValuation:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceValuation
+
+        acct = await _seed_account(
+            async_db_session, account_type="property", is_manual=True
+        )
+        async_db_session.add(
+            FinanceValuation(
+                owner_user_id=1,
+                account_id=acct.id,
+                as_of_date=date(2026, 7, 1),
+                value=50_500_000,
+                source="zillow",
+                source_ref="https://zillow.com/x",
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceValuation))).one()
+        assert row.value == 50_500_000
+        assert row.source == "zillow"
+
+    @pytest.mark.asyncio
+    async def test_source_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceValuation
+
+        acct = await _seed_account(async_db_session, is_manual=True)
+        async_db_session.add(
+            FinanceValuation(
+                account_id=acct.id,
+                as_of_date=date(2026, 7, 1),
+                value=1,
+                source="ouija",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceLiabilityDetail:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_one_to_one(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceLiabilityDetail
+
+        acct = await _seed_account(
+            async_db_session, account_type="credit_card", classification="liability"
+        )
+        async_db_session.add(
+            FinanceLiabilityDetail(
+                owner_user_id=1,
+                account_id=acct.id,
+                liability_type="credit",
+                minimum_payment_amount=3_500,
+                interest_rate_bps=1999,
+                aprs=[{"apr_type": "purchase", "apr_percentage_bps": 1999}],
+            )
+        )
+        await async_db_session.flush()
+        # 1:1 per account.
+        async_db_session.add(
+            FinanceLiabilityDetail(account_id=acct.id, liability_type="credit")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Group C (core) — transactions, splits, transfers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_transaction(
+    session: AsyncSession,
+    *,
+    owner: int | None = 1,
+    source: str = "plaid",
+    external_id: str | None = "ext_1",
+    import_hash: str | None = None,
+    amount: int = -4599,
+    txn_date: date = date(2026, 7, 4),
+    account: "object | None" = None,
+) -> "object":
+    from app.services.finance.models import FinanceTransaction
+
+    if account is None:
+        account = await _seed_account(session)
+    txn = FinanceTransaction(
+        owner_user_id=owner,
+        account_id=account.id,
+        source=source,
+        external_id=external_id,
+        import_hash=import_hash,
+        amount=amount,
+        date_=txn_date,
+    )
+    session.add(txn)
+    await session.flush()
+    return txn
+
+
+class TestFinanceTransaction:
+    @pytest.mark.asyncio
+    async def test_round_trips(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransaction
+
+        acct = await _seed_account(async_db_session)
+        txn = FinanceTransaction(
+            owner_user_id=1,
+            account_id=acct.id,
+            source="plaid",
+            external_id="txn_abc",
+            amount=-4599,  # $45.99 outflow, integer minor units
+            raw_amount=4599,
+            date_=date(2026, 7, 4),
+            datetime_=None,
+            name="Blue Bottle Coffee",
+            location={"city": "Oakland", "region": "CA"},
+            counterparties=[{"name": "Blue Bottle", "type": "merchant"}],
+            raw_payload={"transaction_id": "txn_abc"},
+            metadata_={"note": "morning"},
+        )
+        async_db_session.add(txn)
+        await async_db_session.commit()
+
+        row = (await async_db_session.exec(select(FinanceTransaction))).one()
+        assert row.amount == -4599
+        assert row.raw_amount == 4599
+        assert row.date_ == date(2026, 7, 4)
+        assert row.location == {"city": "Oakland", "region": "CA"}
+        assert row.counterparties == [{"name": "Blue Bottle", "type": "merchant"}]
+        assert row.raw_payload == {"transaction_id": "txn_abc"}
+        assert row.metadata_ == {"note": "morning"}
+        # Defaults.
+        assert row.status == "posted"
+        assert row.dedup_status == "unique"
+        assert row.category_source == "unset"
+        assert row.reconciled_status == "uncleared"
+        assert row.pending is False
+        assert row.currency == "usd"
+
+    @pytest.mark.asyncio
+    async def test_source_check(self, async_db_session: AsyncSession) -> None:
+        with pytest.raises(IntegrityError):
+            await _seed_transaction(async_db_session, source="carrier_pigeon")
+
+    @pytest.mark.asyncio
+    async def test_status_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransaction
+
+        acct = await _seed_account(async_db_session)
+        async_db_session.add(
+            FinanceTransaction(
+                account_id=acct.id,
+                source="plaid",
+                amount=-1,
+                date_=date(2026, 7, 4),
+                status="in_the_mail",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_dedup_lane_forbids_both_ids(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        # A row belongs to exactly one dedup lane: a provider external_id OR an
+        # import_hash, never both (ck_finance_txn_dedup_lane).
+        with pytest.raises(IntegrityError):
+            await _seed_transaction(
+                async_db_session, external_id="ext_1", import_hash="hash_1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_partial_unique_external_and_soft_delete(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceTransaction, _utcnow
+
+        acct = await _seed_account(async_db_session)
+        first = await _seed_transaction(
+            async_db_session, external_id="dup_ext", account=acct
+        )
+
+        # LANE 1: same (account, source, external_id) collides.
+        dup = FinanceTransaction(
+            account_id=acct.id,
+            source="plaid",
+            external_id="dup_ext",
+            amount=-1,
+            date_=date(2026, 7, 4),
+        )
+        async_db_session.add(dup)
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+        await async_db_session.rollback()
+
+        # Soft-deleting the original releases the key (partial index excludes
+        # soft-deleted rows).
+        acct = await _seed_account(async_db_session)
+        first = await _seed_transaction(
+            async_db_session, external_id="reuse_ext", account=acct
+        )
+        first.deleted_at = _utcnow()
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceTransaction(
+                account_id=acct.id,
+                source="plaid",
+                external_id="reuse_ext",
+                amount=-1,
+                date_=date(2026, 7, 4),
+            )
+        )
+        await async_db_session.flush()  # no IntegrityError
+
+    @pytest.mark.asyncio
+    async def test_partial_unique_import_hash(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceTransaction
+
+        acct = await _seed_account(async_db_session)
+        # LANE 2: file imports with no external_id dedup on (account, hash).
+        async_db_session.add(
+            FinanceTransaction(
+                account_id=acct.id,
+                source="csv",
+                external_id=None,
+                import_hash="row_hash",
+                amount=-100,
+                date_=date(2026, 7, 4),
+            )
+        )
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceTransaction(
+                account_id=acct.id,
+                source="csv",
+                external_id=None,
+                import_hash="row_hash",
+                amount=-100,
+                date_=date(2026, 7, 4),
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_null_dedup_keys_do_not_collide(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceTransaction
+
+        acct = await _seed_account(async_db_session)
+        # Both partial indexes skip rows with no external_id and no hash (e.g.
+        # hand-entered), so two such rows coexist.
+        for _ in range(2):
+            async_db_session.add(
+                FinanceTransaction(
+                    account_id=acct.id,
+                    source="manual",
+                    external_id=None,
+                    import_hash=None,
+                    amount=-1,
+                    date_=date(2026, 7, 4),
+                )
+            )
+        await async_db_session.flush()  # no IntegrityError
+
+    @pytest.mark.asyncio
+    async def test_self_fk_pending_link(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransaction
+
+        acct = await _seed_account(async_db_session)
+        posted = await _seed_transaction(
+            async_db_session, external_id="posted_1", account=acct
+        )
+        # A pending row can point at the posted row it will settle into.
+        pending = FinanceTransaction(
+            account_id=acct.id,
+            source="plaid",
+            external_id="pending_1",
+            amount=-4599,
+            date_=date(2026, 7, 4),
+            pending=True,
+            pending_transaction_id=posted.id,
+        )
+        async_db_session.add(pending)
+        await async_db_session.flush()
+        assert pending.pending_transaction_id == posted.id
+
+        # A dangling self-FK is rejected.
+        async_db_session.add(
+            FinanceTransaction(
+                account_id=acct.id,
+                source="plaid",
+                external_id="pending_2",
+                amount=-1,
+                date_=date(2026, 7, 4),
+                pending_transaction_id=999_999,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceTransactionSplit:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransactionSplit
+
+        parent = await _seed_transaction(async_db_session)
+        async_db_session.add(
+            FinanceTransactionSplit(
+                owner_user_id=1,
+                parent_transaction_id=parent.id,
+                amount=-3000,
+                sort_order=0,
+                memo="groceries",
+            )
+        )
+        async_db_session.add(
+            FinanceTransactionSplit(
+                owner_user_id=1,
+                parent_transaction_id=parent.id,
+                amount=-1599,
+                sort_order=1,
+                memo="household",
+            )
+        )
+        await async_db_session.commit()
+        rows = (await async_db_session.exec(select(FinanceTransactionSplit))).all()
+        assert len(rows) == 2
+        assert sum(r.amount for r in rows) == -4599  # sums to parent
+
+    @pytest.mark.asyncio
+    async def test_parent_fk_required(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransactionSplit
+
+        await _seed_account(async_db_session)  # currency, but no such parent txn
+        async_db_session.add(
+            FinanceTransactionSplit(parent_transaction_id=999_999, amount=-1)
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_unique_parent_sort(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransactionSplit
+
+        parent = await _seed_transaction(async_db_session)
+        async_db_session.add(
+            FinanceTransactionSplit(
+                parent_transaction_id=parent.id, amount=-1, sort_order=0
+            )
+        )
+        async_db_session.add(
+            FinanceTransactionSplit(
+                parent_transaction_id=parent.id, amount=-2, sort_order=0
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceTransfer:
+    async def _seed_pair(
+        self, session: AsyncSession
+    ) -> "tuple[object, object, object, object]":
+        from app.services.finance.models import FinanceAccount, FinanceTransaction
+
+        acct1 = await _seed_account(session)  # checking asset (seeds usd)
+        acct2 = FinanceAccount(
+            owner_user_id=1,
+            provider="plaid",
+            name="AMEX",
+            account_type="credit_card",
+            classification="liability",
+        )
+        session.add(acct2)
+        await session.flush()
+        t_from = FinanceTransaction(
+            owner_user_id=1,
+            account_id=acct1.id,
+            source="plaid",
+            external_id="pay_out",
+            amount=-25000,
+            date_=date(2026, 7, 4),
+        )
+        t_to = FinanceTransaction(
+            owner_user_id=1,
+            account_id=acct2.id,
+            source="plaid",
+            external_id="pay_in",
+            amount=25000,
+            date_=date(2026, 7, 4),
+        )
+        session.add(t_from)
+        session.add(t_to)
+        await session.flush()
+        return acct1, acct2, t_from, t_to
+
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransfer
+
+        acct1, acct2, t_from, t_to = await self._seed_pair(async_db_session)
+        transfer = FinanceTransfer(
+            owner_user_id=1,
+            from_account_id=acct1.id,
+            to_account_id=acct2.id,
+            from_transaction_id=t_from.id,
+            to_transaction_id=t_to.id,
+            amount=25000,
+            match_method="auto_amount_date",
+            is_credit_card_payment=True,
+        )
+        async_db_session.add(transfer)
+        await async_db_session.commit()
+
+        row = (await async_db_session.exec(select(FinanceTransfer))).one()
+        assert row.status == "suggested"
+        assert row.is_credit_card_payment is True
+        assert row.amount == 25000
+
+    @pytest.mark.asyncio
+    async def test_match_method_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransfer
+
+        await self._seed_pair(async_db_session)
+        async_db_session.add(FinanceTransfer(match_method="vibes"))
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_from_leg_is_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransfer
+
+        _, _, t_from, t_to = await self._seed_pair(async_db_session)
+        async_db_session.add(
+            FinanceTransfer(from_transaction_id=t_from.id, match_method="user_manual")
+        )
+        await async_db_session.flush()
+        # A transaction leg maps to at most one transfer per direction.
+        async_db_session.add(
+            FinanceTransfer(from_transaction_id=t_from.id, match_method="user_manual")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_legs_must_differ(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransfer
+
+        _, _, t_from, _ = await self._seed_pair(async_db_session)
+        # A transfer cannot have the same transaction on both legs.
+        async_db_session.add(
+            FinanceTransfer(
+                from_transaction_id=t_from.id,
+                to_transaction_id=t_from.id,
+                match_method="user_manual",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Group D (ref) — categories, merchants, tags, rules
+# ---------------------------------------------------------------------------
+
+
+async def _seed_category(
+    session: AsyncSession,
+    *,
+    owner: int | None = None,
+    slug: str = "dining",
+    name: str = "Dining",
+    classification: str = "expense",
+) -> "object":
+    from app.services.finance.models import FinanceCategory
+
+    cat = FinanceCategory(
+        owner_user_id=owner, slug=slug, name=name, classification=classification
+    )
+    session.add(cat)
+    await session.flush()
+    return cat
+
+
+class TestFinanceCategory:
+    @pytest.mark.asyncio
+    async def test_round_trips_with_self_parent(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceCategory
+
+        parent = await _seed_category(
+            async_db_session, slug="food", name="Food & Drink"
+        )
+        child = FinanceCategory(
+            slug="food.dining",
+            name="Dining",
+            classification="expense",
+            parent_id=parent.id,
+            plaid_pfc_detailed="FOOD_AND_DRINK_RESTAURANT",
+        )
+        async_db_session.add(child)
+        await async_db_session.commit()
+        row = (
+            await async_db_session.exec(
+                select(FinanceCategory).where(FinanceCategory.slug == "food.dining")
+            )
+        ).one()
+        assert row.parent_id == parent.id
+        assert row.is_system is False
+
+    @pytest.mark.asyncio
+    async def test_classification_check(self, async_db_session: AsyncSession) -> None:
+        with pytest.raises(IntegrityError):
+            await _seed_category(async_db_session, classification="spending")
+
+    @pytest.mark.asyncio
+    async def test_system_slug_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceCategory
+
+        # Two system seeds (owner NULL) cannot share a slug. Add both, then
+        # flush once so the duplicate surfaces at the assertion.
+        async_db_session.add(
+            FinanceCategory(slug="rent", name="Rent", classification="expense")
+        )
+        async_db_session.add(
+            FinanceCategory(slug="rent", name="Rent 2", classification="expense")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_user_and_system_slug_coexist(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceCategory
+
+        # The system partial index only covers owner NULL, so a user category
+        # can reuse a system slug (scoped to the owner by the user index).
+        async_db_session.add(
+            FinanceCategory(slug="gifts", name="Gifts", classification="expense")
+        )
+        async_db_session.add(
+            FinanceCategory(
+                owner_user_id=7, slug="gifts", name="Gifts", classification="expense"
+            )
+        )
+        async_db_session.add(
+            FinanceCategory(
+                owner_user_id=8, slug="gifts", name="Gifts", classification="expense"
+            )
+        )
+        await async_db_session.flush()  # no IntegrityError
+        # ...but the same user twice does collide.
+        async_db_session.add(
+            FinanceCategory(
+                owner_user_id=7, slug="gifts", name="Dup", classification="expense"
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceCategoryAlias:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_fk(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceCategoryAlias
+
+        cat = await _seed_category(async_db_session, slug="dining")
+        async_db_session.add(
+            FinanceCategoryAlias(
+                category_id=cat.id,
+                alias_text="RESTAURANTS/DINING",
+                normalized_alias="restaurants dining",
+                source="quicken",
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceCategoryAlias))).one()
+        assert row.category_id == cat.id
+        assert row.normalized_alias == "restaurants dining"
+
+    @pytest.mark.asyncio
+    async def test_fk_requires_category(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceCategoryAlias
+
+        async_db_session.add(
+            FinanceCategoryAlias(
+                category_id=999_999,
+                alias_text="x",
+                normalized_alias="x",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_owner_norm_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceCategoryAlias
+
+        cat = await _seed_category(async_db_session, slug="dining")
+        for _ in range(2):
+            async_db_session.add(
+                FinanceCategoryAlias(
+                    owner_user_id=1,
+                    category_id=cat.id,
+                    alias_text="Dining",
+                    normalized_alias="dining",
+                )
+            )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceMerchant:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceMerchant
+
+        cat = await _seed_category(async_db_session, slug="subscriptions")
+        async_db_session.add(
+            FinanceMerchant(
+                owner_user_id=1,
+                name="Spotify",
+                normalized_name="spotify",
+                source="plaid",
+                default_category_id=cat.id,
+                service_type="music_streaming",
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceMerchant))).one()
+        assert row.default_category_id == cat.id
+        assert row.service_type == "music_streaming"
+
+    @pytest.mark.asyncio
+    async def test_source_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceMerchant
+
+        async_db_session.add(
+            FinanceMerchant(name="X", normalized_name="x", source="telepathy")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_user_partial_unique_and_soft_delete(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceMerchant, _utcnow
+
+        first = FinanceMerchant(
+            owner_user_id=1, name="Netflix", normalized_name="netflix", source="user"
+        )
+        async_db_session.add(first)
+        await async_db_session.flush()
+        dup = FinanceMerchant(
+            owner_user_id=1, name="Netflix", normalized_name="netflix", source="user"
+        )
+        async_db_session.add(dup)
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+        await async_db_session.rollback()
+
+        # Soft-delete releases the normalized-name key.
+        first = FinanceMerchant(
+            owner_user_id=1, name="Hulu", normalized_name="hulu", source="user"
+        )
+        async_db_session.add(first)
+        await async_db_session.flush()
+        first.deleted_at = _utcnow()
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceMerchant(
+                owner_user_id=1, name="Hulu", normalized_name="hulu", source="user"
+            )
+        )
+        await async_db_session.flush()  # no IntegrityError
+
+    @pytest.mark.asyncio
+    async def test_provider_partial_unique(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceMerchant
+
+        # Distinct names (so the global index doesn't fire) but the same
+        # (source, provider_merchant_id) collides on the provider index.
+        async_db_session.add(
+            FinanceMerchant(
+                name="Amazon",
+                normalized_name="amazon",
+                source="plaid",
+                provider_merchant_id="mch_amzn",
+            )
+        )
+        async_db_session.add(
+            FinanceMerchant(
+                name="Amazon Prime",
+                normalized_name="amazon prime",
+                source="plaid",
+                provider_merchant_id="mch_amzn",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceTag:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTag, _utcnow
+
+        async_db_session.add(
+            FinanceTag(owner_user_id=1, name="Vacation", normalized_name="vacation")
+        )
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceTag(owner_user_id=1, name="vacation", normalized_name="vacation")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+        await async_db_session.rollback()
+
+        # Soft-deleting frees the name for reuse.
+        tag = FinanceTag(owner_user_id=1, name="Work", normalized_name="work")
+        async_db_session.add(tag)
+        await async_db_session.flush()
+        tag.deleted_at = _utcnow()
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceTag(owner_user_id=1, name="Work", normalized_name="work")
+        )
+        await async_db_session.flush()  # no IntegrityError
+
+
+class TestFinanceTransactionTag:
+    @pytest.mark.asyncio
+    async def test_link_and_composite_pk(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import (
+            FinanceTag,
+            FinanceTransactionTag,
+        )
+
+        txn = await _seed_transaction(async_db_session)
+        tag = FinanceTag(owner_user_id=1, name="Trip", normalized_name="trip")
+        async_db_session.add(tag)
+        await async_db_session.flush()
+
+        async_db_session.add(
+            FinanceTransactionTag(transaction_id=txn.id, tag_id=tag.id)
+        )
+        await async_db_session.flush()
+        # Re-linking the same (transaction, tag) violates the composite PK.
+        async_db_session.add(
+            FinanceTransactionTag(transaction_id=txn.id, tag_id=tag.id)
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_fk_requires_transaction_and_tag(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceTransactionTag
+
+        await _seed_account(async_db_session)
+        async_db_session.add(
+            FinanceTransactionTag(transaction_id=999_999, tag_id=999_999)
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceRule:
+    @pytest.mark.asyncio
+    async def test_round_trip_with_json(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceRule
+
+        async_db_session.add(
+            FinanceRule(
+                owner_user_id=1,
+                name="Rename Amazon",
+                conditions={"payee_contains": "AMZN"},
+                actions={"set_merchant": "Amazon"},
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceRule))).one()
+        assert row.conditions == {"payee_contains": "AMZN"}
+        assert row.actions == {"set_merchant": "Amazon"}
+        assert row.priority == 100
+        assert row.is_enabled is True
+
+
+# ---------------------------------------------------------------------------
+# Group E (investments) — securities, prices, holdings, trades
+# ---------------------------------------------------------------------------
+
+
+async def _seed_security(
+    session: AsyncSession,
+    *,
+    provider: str = "plaid",
+    provider_security_id: str | None = "sec_1",
+    ticker: str = "AAPL",
+    name: str = "Apple Inc.",
+    security_type: str = "equity",
+) -> "object":
+    from app.services.finance.models import FinanceSecurity
+
+    sec = FinanceSecurity(
+        provider=provider,
+        provider_security_id=provider_security_id,
+        ticker=ticker,
+        name=name,
+        security_type=security_type,
+    )
+    session.add(sec)
+    await session.flush()
+    return sec
+
+
+class TestFinanceSecurity:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceSecurity
+
+        sec = FinanceSecurity(
+            provider="plaid",
+            provider_security_id="sec_aapl",
+            figi="BBG000B9XRY4",
+            cusip="037833100",
+            ticker="AAPL",
+            name="Apple Inc.",
+            security_type="equity",
+        )
+        async_db_session.add(sec)
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceSecurity))).one()
+        assert row.price_scale == 2
+        assert row.is_crypto is False
+        assert row.figi == "BBG000B9XRY4"
+
+    @pytest.mark.asyncio
+    async def test_provider_partial_unique(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceSecurity
+
+        async_db_session.add(
+            FinanceSecurity(provider="plaid", provider_security_id="dup", ticker="A")
+        )
+        async_db_session.add(
+            FinanceSecurity(provider="plaid", provider_security_id="dup", ticker="B")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_figi_partial_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceSecurity
+
+        # Distinct provider ids so only the FIGI index fires.
+        async_db_session.add(
+            FinanceSecurity(provider="plaid", provider_security_id="p1", figi="FIGI1")
+        )
+        async_db_session.add(
+            FinanceSecurity(
+                provider="snaptrade", provider_security_id="p2", figi="FIGI1"
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_null_dedup_keys_coexist(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceSecurity
+
+        # Manual securities with no provider/figi/cusip/isin don't collide.
+        for _ in range(2):
+            async_db_session.add(
+                FinanceSecurity(provider="manual", ticker="PRIV", name="Private")
+            )
+        await async_db_session.flush()  # no IntegrityError
+
+
+class TestFinanceSecurityPrice:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceSecurityPrice
+
+        await _seed_currency(async_db_session, "usd")
+        sec = await _seed_security(async_db_session)
+        async_db_session.add(
+            FinanceSecurityPrice(
+                security_id=sec.id,
+                price_date=date(2026, 7, 4),
+                close_price=21_450,  # $214.50
+                source="market_data",
+            )
+        )
+        await async_db_session.flush()
+        # One price per security/day/source.
+        async_db_session.add(
+            FinanceSecurityPrice(
+                security_id=sec.id,
+                price_date=date(2026, 7, 4),
+                close_price=99,
+                source="market_data",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_source_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceSecurityPrice
+
+        await _seed_currency(async_db_session, "usd")
+        sec = await _seed_security(async_db_session)
+        async_db_session.add(
+            FinanceSecurityPrice(
+                security_id=sec.id,
+                price_date=date(2026, 7, 4),
+                close_price=1,
+                source="astrology",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceHolding:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceHolding
+
+        acct = await _seed_account(async_db_session, account_type="brokerage")
+        sec = await _seed_security(async_db_session)
+        async_db_session.add(
+            FinanceHolding(
+                owner_user_id=1,
+                account_id=acct.id,
+                security_id=sec.id,
+                as_of_date=date(2026, 7, 4),
+                quantity_e8=10_00000000,  # 10 shares
+                cost_basis=150_000,
+            )
+        )
+        await async_db_session.flush()
+        # One position per (account, security, day).
+        async_db_session.add(
+            FinanceHolding(
+                owner_user_id=1,
+                account_id=acct.id,
+                security_id=sec.id,
+                as_of_date=date(2026, 7, 4),
+                quantity_e8=1,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_security_fk_required(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceHolding
+
+        acct = await _seed_account(async_db_session, account_type="brokerage")
+        async_db_session.add(
+            FinanceHolding(
+                owner_user_id=1,
+                account_id=acct.id,
+                security_id=999_999,
+                as_of_date=date(2026, 7, 4),
+                quantity_e8=1,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceTrade:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTrade
+
+        acct = await _seed_account(async_db_session, account_type="brokerage")
+        sec = await _seed_security(async_db_session)
+        async_db_session.add(
+            FinanceTrade(
+                owner_user_id=1,
+                account_id=acct.id,
+                security_id=sec.id,
+                source="plaid",
+                external_id="trade_1",
+                type="buy",
+                quantity_e8=5_00000000,  # 5 shares
+                price=21_450,
+                amount=-107_250,  # cash out
+                trade_date=date(2026, 7, 4),
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceTrade))).one()
+        assert row.amount == -107_250
+        assert row.type == "buy"
+        assert row.price_scale == 2
+        assert row.pending is False
+
+    @pytest.mark.asyncio
+    async def test_type_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTrade
+
+        acct = await _seed_account(async_db_session, account_type="brokerage")
+        async_db_session.add(
+            FinanceTrade(
+                owner_user_id=1,
+                account_id=acct.id,
+                source="plaid",
+                type="hodl",
+                trade_date=date(2026, 7, 4),
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_dedup_lane_forbids_both_ids(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceTrade
+
+        acct = await _seed_account(async_db_session, account_type="brokerage")
+        async_db_session.add(
+            FinanceTrade(
+                owner_user_id=1,
+                account_id=acct.id,
+                source="csv",
+                external_id="e1",
+                import_hash="h1",
+                type="buy",
+                trade_date=date(2026, 7, 4),
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_external_partial_unique(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceTrade
+
+        acct = await _seed_account(async_db_session, account_type="brokerage")
+        for _ in range(2):
+            async_db_session.add(
+                FinanceTrade(
+                    owner_user_id=1,
+                    account_id=acct.id,
+                    source="plaid",
+                    external_id="dup_trade",
+                    type="buy",
+                    trade_date=date(2026, 7, 4),
+                )
+            )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Group F (analytics / import) — recurring streams, budgets, baselines,
+# insights, import pipeline, attachments, changelog
+# ---------------------------------------------------------------------------
+
+
+class TestFinanceRecurringStream:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceRecurringStream
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceRecurringStream(
+                owner_user_id=1,
+                name="Netflix",
+                direction="outflow",
+                frequency="monthly",
+                source="plaid",
+                is_subscription=True,
+                average_amount=1599,
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceRecurringStream))).one()
+        assert row.status == "early_detection"
+        assert row.is_active is True
+        assert row.is_subscription is True
+
+    @pytest.mark.asyncio
+    async def test_direction_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceRecurringStream
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceRecurringStream(
+                owner_user_id=1,
+                name="X",
+                direction="sideways",
+                frequency="monthly",
+                source="plaid",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_detected_partial_unique(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceRecurringStream
+
+        acct = await _seed_account(async_db_session)
+        # Locally-detected streams (no provider id) dedup on
+        # (owner, account, direction, normalized_payee).
+        for _ in range(2):
+            async_db_session.add(
+                FinanceRecurringStream(
+                    owner_user_id=1,
+                    account_id=acct.id,
+                    name="Netflix",
+                    normalized_payee="netflix",
+                    direction="outflow",
+                    frequency="monthly",
+                    source="derived",
+                )
+            )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceBudget:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceBudget
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceBudget(
+                owner_user_id=1,
+                name="Monthly",
+                period="monthly",
+                start_date=date(2026, 7, 1),
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceBudget))).one()
+        assert row.is_active is True
+        assert row.rollover is False
+
+    @pytest.mark.asyncio
+    async def test_period_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceBudget
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceBudget(
+                owner_user_id=1,
+                name="X",
+                period="hourly",
+                start_date=date(2026, 7, 1),
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_owner_name_start_unique(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceBudget
+
+        await _seed_currency(async_db_session, "usd")
+        for _ in range(2):
+            async_db_session.add(
+                FinanceBudget(
+                    owner_user_id=1,
+                    name="Monthly",
+                    period="monthly",
+                    start_date=date(2026, 7, 1),
+                )
+            )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceBudgetCategory:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceBudget, FinanceBudgetCategory
+
+        await _seed_currency(async_db_session, "usd")
+        cat = await _seed_category(async_db_session, slug="dining")
+        budget = FinanceBudget(
+            owner_user_id=1,
+            name="Monthly",
+            period="monthly",
+            start_date=date(2026, 7, 1),
+        )
+        async_db_session.add(budget)
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceBudgetCategory(
+                owner_user_id=1,
+                budget_id=budget.id,
+                category_id=cat.id,
+                period_month=202607,
+                allocated_amount=50_000,
+            )
+        )
+        await async_db_session.flush()
+        # One line per (budget, category, month).
+        async_db_session.add(
+            FinanceBudgetCategory(
+                owner_user_id=1,
+                budget_id=budget.id,
+                category_id=cat.id,
+                period_month=202607,
+                allocated_amount=99,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceSpendingBaseline:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceSpendingBaseline
+
+        await _seed_currency(async_db_session, "usd")
+        cat = await _seed_category(async_db_session, slug="dining")
+        async_db_session.add(
+            FinanceSpendingBaseline(
+                owner_user_id=1,
+                category_id=cat.id,
+                window_months=6,
+                period_month=202607,
+                trailing_avg_amount=42_000,
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceSpendingBaseline))).one()
+        assert row.trailing_avg_amount == 42_000
+        assert row.window_months == 6
+
+    @pytest.mark.asyncio
+    async def test_window_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceSpendingBaseline
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceSpendingBaseline(
+                owner_user_id=1,
+                window_months=5,  # only 3/6/12 allowed
+                period_month=202607,
+                trailing_avg_amount=1,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceInsight:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_dedup(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceInsight
+
+        async_db_session.add(
+            FinanceInsight(
+                owner_user_id=1,
+                insight_type="price_hike",
+                severity="warning",
+                title="Netflix went up",
+                dedup_key="price_hike:netflix:202607",
+                data={"old": 1599, "new": 1899},
+            )
+        )
+        await async_db_session.flush()
+        assert (
+            await async_db_session.exec(select(FinanceInsight))
+        ).one().status == "new"
+        # dedup_key is idempotent per owner.
+        async_db_session.add(
+            FinanceInsight(
+                owner_user_id=1,
+                insight_type="price_hike",
+                severity="info",
+                title="dup",
+                dedup_key="price_hike:netflix:202607",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_severity_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceInsight
+
+        async_db_session.add(
+            FinanceInsight(
+                owner_user_id=1,
+                insight_type="x",
+                severity="apocalyptic",
+                title="x",
+                dedup_key="x",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_related_stream_fk(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import (
+            FinanceInsight,
+            FinanceRecurringStream,
+        )
+
+        await _seed_currency(async_db_session, "usd")
+        stream = FinanceRecurringStream(
+            owner_user_id=1,
+            name="Netflix",
+            direction="outflow",
+            frequency="monthly",
+            source="plaid",
+        )
+        async_db_session.add(stream)
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceInsight(
+                owner_user_id=1,
+                insight_type="price_hike",
+                severity="warning",
+                title="hike",
+                dedup_key="k1",
+                related_stream_id=stream.id,
+            )
+        )
+        await async_db_session.flush()  # FK resolves
+
+        async_db_session.add(
+            FinanceInsight(
+                owner_user_id=1,
+                insight_type="price_hike",
+                severity="warning",
+                title="bad",
+                dedup_key="k2",
+                related_stream_id=999_999,
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceImportProfile:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceImportProfile
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceImportProfile(
+                name="Chase CC",
+                source_format="csv",
+                amount_sign_convention="outflow_negative",
+                header_signature=["Transaction Date", "Description", "Amount"],
+                column_mapping={"Amount": "amount", "Description": "name"},
+                is_system=True,
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceImportProfile))).one()
+        assert row.header_signature == [
+            "Transaction Date",
+            "Description",
+            "Amount",
+        ]
+        assert row.column_mapping == {"Amount": "amount", "Description": "name"}
+
+    @pytest.mark.asyncio
+    async def test_format_and_sign_checks(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceImportProfile
+
+        await _seed_currency(async_db_session, "usd")
+        async_db_session.add(
+            FinanceImportProfile(
+                name="Bad",
+                source_format="xlsx",  # not allowed
+                amount_sign_convention="outflow_negative",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceImportBatch:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceImportBatch
+
+        async_db_session.add(
+            FinanceImportBatch(
+                owner_user_id=1,
+                source_type="csv",
+                file_name="chase.csv",
+                file_sha256="abc123",
+                rows_total=42,
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceImportBatch))).one()
+        assert row.status == "pending"
+        assert row.rows_total == 42
+
+    @pytest.mark.asyncio
+    async def test_status_check(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceImportBatch
+
+        async_db_session.add(
+            FinanceImportBatch(owner_user_id=1, source_type="csv", status="exploded")
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_file_sha_partial_unique(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceImportBatch
+
+        # Same (owner, file_sha256) blocks an identical re-upload.
+        for _ in range(2):
+            async_db_session.add(
+                FinanceImportBatch(
+                    owner_user_id=1,
+                    source_type="csv",
+                    file_sha256="same_file_hash",
+                )
+            )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceImportBatchRow:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_unique(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import (
+            FinanceImportBatch,
+            FinanceImportBatchRow,
+        )
+
+        batch = FinanceImportBatch(owner_user_id=1, source_type="csv")
+        async_db_session.add(batch)
+        await async_db_session.flush()
+        async_db_session.add(
+            FinanceImportBatchRow(
+                import_batch_id=batch.id,
+                owner_user_id=1,
+                row_number=1,
+                parsed={"amount": -4599},
+                parsed_status="parsed",
+            )
+        )
+        await async_db_session.flush()
+        # One row per (batch, row_number).
+        async_db_session.add(
+            FinanceImportBatchRow(
+                import_batch_id=batch.id,
+                owner_user_id=1,
+                row_number=1,
+                parsed_status="parsed",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_batch_fk_required(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceImportBatchRow
+
+        async_db_session.add(
+            FinanceImportBatchRow(
+                import_batch_id=999_999,
+                owner_user_id=1,
+                row_number=1,
+                parsed_status="parsed",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceAttachment:
+    @pytest.mark.asyncio
+    async def test_round_trip_and_partial_unique(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.models import FinanceAttachment
+
+        txn = await _seed_transaction(async_db_session)
+        async_db_session.add(
+            FinanceAttachment(
+                owner_user_id=1,
+                transaction_id=txn.id,
+                file_name="receipt.pdf",
+                storage_key="s3://bucket/receipt.pdf",
+                sha256="deadbeef",
+            )
+        )
+        await async_db_session.flush()
+        # Same (owner, sha256) dedups identical content.
+        async_db_session.add(
+            FinanceAttachment(
+                owner_user_id=1,
+                file_name="receipt-copy.pdf",
+                storage_key="s3://bucket/receipt-copy.pdf",
+                sha256="deadbeef",
+            )
+        )
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestFinanceTransactionChangelog:
+    @pytest.mark.asyncio
+    async def test_round_trip(self, async_db_session: AsyncSession) -> None:
+        from app.services.finance.models import FinanceTransactionChangelog
+
+        txn = await _seed_transaction(async_db_session)
+        async_db_session.add(
+            FinanceTransactionChangelog(
+                transaction_id=txn.id,
+                owner_user_id=1,
+                field="category_id",
+                old_value=None,
+                new_value="42",
+                change_source="user",
+            )
+        )
+        await async_db_session.commit()
+        row = (await async_db_session.exec(select(FinanceTransactionChangelog))).one()
+        assert row.field == "category_id"
+        assert row.change_source == "user"

--- a/copier.yml
+++ b/copier.yml
@@ -322,9 +322,32 @@ insights_per_user:
   default: false
   when: "{{ include_insights and include_auth }}"
 
+include_finance:
+  type: bool
+  help: "Include finance service (account aggregation, net worth, Quicken/CSV import)?"
+  default: false
+
+finance_plaid:
+  type: bool
+  help: "Include Plaid connectivity (banks, cards, brokerages)?"
+  default: true
+  when: "{{ include_finance }}"
+
+finance_snaptrade:
+  type: bool
+  help: "Include SnapTrade connectivity (Fidelity and other brokerages)?"
+  default: true
+  when: "{{ include_finance }}"
+
+finance_import:
+  type: bool
+  help: "Include Quicken/OFX/CSV file import?"
+  default: true
+  when: "{{ include_finance }}"
+
 # Internal computed values (using Jinja2)
 _has_additional_components: "{{ include_scheduler or include_redis or include_worker or include_database or include_cache or include_ingress or include_observability }}"
-_include_migrations: "{{ include_auth or include_payment or include_insights or include_blog or (include_ai and ai_backend in ['sqlite', 'postgres']) }}"
+_include_migrations: "{{ include_auth or include_payment or include_insights or include_blog or include_finance or (include_ai and ai_backend in ['sqlite', 'postgres']) }}"
 
 # Component-specific dependencies (computed)
 _scheduler_deps: "{% if include_scheduler %}apscheduler>=3.10.0{% endif %}"

--- a/docs/plans/finance-service/finance-research/00-codebase-conventions.md
+++ b/docs/plans/finance-service/finance-research/00-codebase-conventions.md
@@ -1,0 +1,50 @@
+# aegis-pulse codebase conventions the finance schema MUST follow
+
+**Stack:** SQLModel (>=0.0.14) on SQLAlchemy 2.0, Postgres (asyncpg async / psycopg2 sync). Alembic 1.16.5 migrations. FastAPI backend, taskiq+redis worker, APScheduler scheduler, Typer CLI. The generated finance template's tests run on in-memory SQLite with FK enforcement ON (via `PRAGMA foreign_keys=ON`), so FK/CHECK/partial-unique violations surface in unit tests; Postgres-only behavior (dedicated schemas, cross-schema FKs) still needs live-Postgres validation.
+
+**Where models live:** per-service package `app/services/<svc>/models.py` bound to the single `SQLModel.metadata`. Finance goes in `app/services/finance/models.py`. New models MUST be imported in `alembic/env.py`'s import block or they won't be seen by autogenerate.
+
+**Primary keys:** `id: int | None = Field(default=None, primary_key=True)` — integer autoincrement. NO UUIDs anywhere. Composite PKs only for pure join tables (`(a_id, b_id)`).
+
+**Timestamps:** NO shared mixin. Each model inlines naive-UTC columns via a helper:
+```python
+def utcnow_naive() -> datetime:
+    return datetime.now(UTC).replace(tzinfo=None)
+created_at: datetime = Field(default_factory=utcnow_naive)
+updated_at: datetime = Field(default_factory=utcnow_naive)
+```
+Naive UTC is deliberate (SQLite/Postgres portability). Soft-delete: `deleted_at: datetime | None = Field(default=None, index=True)` + a partial unique index that excludes soft-deleted rows.
+
+**Money:** integer smallest-currency-unit (cents), NOT Decimal/float. `amount: int` + `currency: str = Field(max_length=3, default="usd")`. There is ZERO Decimal/Numeric money usage in the codebase — match this. (Aggregate fields named like `total_x_cents: int`.)
+
+**Enums:** stored as `String` + a `CheckConstraint`, NEVER native PG enum (SQLite parity + "adding a value is a normal migration"). Idiom:
+```python
+class BlogStatus(StrEnum): DRAFT="draft"; PUBLISHED="published"; ARCHIVED="archived"
+status: BlogStatus = Field(default=BlogStatus.DRAFT,
+    sa_column=Column("status", String(16), nullable=False, index=True))
+__table_args__ = (CheckConstraint("status IN ('draft','published','archived')", name="ck_blog_post_status"),)
+```
+NOTE: for taxonomies Plaid keeps EXPANDING (account type/subtype, PFC), store as plain TEXT with NO check constraint — only use CheckConstraint for small closed sets we own (status/direction/classification/source).
+
+**FKs:** simple form `field: int = Field(foreign_key="other.id", index=True)` — EVERY FK indexed. When ON DELETE / use_alter needed, drop to raw Column with a NAMED ForeignKey:
+```python
+sa_column=Column("x_id", Integer, ForeignKey("other.id", name="fk_thistable_x_id", ondelete="SET NULL", use_alter=True), nullable=True)
+```
+
+**Indices / constraints in `__table_args__`:** composite/partial via `sqlalchemy.Index("ix_<table>_<cols>", ...)`; unique tuples via `UniqueConstraint(..., name="uq_<...>")`; checks via `CheckConstraint(..., name="ck_<table>_<col>")`. Partial unique indices use `postgresql_where=` (verified only on live PG).
+
+**Naming:** explicit `__tablename__` = singular snake_case (`payment_transaction`, `blog_post`). Columns snake_case. Index `ix_<table>_<col>`, unique `uq_...`, check `ck_...`, fk `fk_...`. `metadata` is reserved by SQLModel → use Python attr `metadata_` mapped to DB column `"metadata"`.
+
+**JSON:** `col: dict[str, Any] = Field(default_factory=dict, sa_column=Column("col", JSON))`; nullable JSON lists via `sa_column=Column(JSON, nullable=True)`. Use JSON/JSONB for raw provider payloads and variable nested data (location, counterparties) — do NOT explode into nullable columns.
+
+**Ownership / tenancy:** every user-scoped row carries `owner_user_id: int = Field(foreign_key="user.id", index=True)` and a nullable `organization_id: int | None = Field(default=None, foreign_key="organization.id", index=True)` (org infra exists but is NOT active yet — reads are owner-based; include the column now, don't depend on it).
+
+**Encrypted secrets:** AES-256-GCM via `app.core.encryption.encrypt_secret(plaintext, *, context=...)` / `decrypt_secret(..., context=...)`. Ciphertext stored in a plain `str` column; encrypt/decrypt happen in the SERVICE layer, not the model. The AAD `context` binds ciphertext to its row, e.g. `f"plaid_connection:{id}:access_token"`. Add any new encrypted-column table to the key-rotation CLI `app/cli/security.py::_run`. Model `__repr__` should mask secret columns.
+
+**Service pattern:** `class FinanceService: def __init__(self, db: AsyncSession) -> None: self.db = db`. Queries via `sqlmodel.select` + `await self.db.exec(...)`. Writes call `self.db.add(...)` + `await self.db.flush()` — services do NOT commit; the request-scoped `get_async_db` dependency commits. Per-service `deps.py`: `async def get_finance_service(db: AsyncSession = Depends(get_async_db)) -> FinanceService: return FinanceService(db)`.
+
+**Idempotent UPSERT (the dedup mechanism):** Postgres `insert(Model).values(...).on_conflict_do_update(index_elements=[...], set_={...})` (or `on_conflict_do_nothing`) keyed on the natural UNIQUE key — this is how existing ingest (pypi_daily) dedups. Every dedup unique key must be a real UNIQUE constraint/partial-unique index.
+
+**Migration:** declared as a `ServiceMigrationSpec` in `aegis/core/migration_generator.py` and rendered into an `alembic/versions/00X_<service>.py` file with an **auto-assigned** revision ID (e.g. `001_finance.py`) so the chain is valid for any `include_*` combination; a reversible `downgrade()` is generated unless the spec is explicitly forward-only. Do NOT hand-write revision IDs/filenames.
+
+**Reuse note:** the existing `app/services/insights/` service already ships `insight_source`, `insight_record`, `insight_event`, `goal` tables and a rule-based anomaly-event system (country-spike events). "Wasting money" insights can emit `insight_event`-style rows (rule-based, ships without AI) AND/OR feed the future Illiana AI layer (a `finance_context.py` provider). The AI layer (Illiana) is NOT in this project yet (`include_ai: false`) — design finance data to be AI-ready but don't depend on Illiana existing.

--- a/docs/plans/finance-service/finance-research/01-domain-brief.md
+++ b/docs/plans/finance-service/finance-research/01-domain-brief.md
@@ -1,0 +1,178 @@
+# Research Brief: Personal-Finance Aggregator Schema
+
+**Purpose:** Input to the schema design phase for a Plaid-backed aggregator (Empower/Quicken-class) added to the existing Python/SQLModel/Postgres app. Synthesized from Plaid API docs, Chase/AMEX connectivity, Quicken/OFX/CSV import formats, and four reference schemas (Firefly III, Actual Budget, Maybe Finance, GnuCash).
+
+**Guiding constraints (from this codebase):** encrypt tokens with the existing AES-GCM helper; `owner_id` (+ nullable `organization_id`, org-tenancy port pending) on every user-scoped table; the pytest DB is SQLite with FK enforcement OFF, so DB-level FK/constraint behavior must be verified against live Postgres, not asserted in tests. The user explicitly does **not** want to add tables later — err toward shipping the full set now.
+
+---
+
+## 1. Connection model
+
+Plaid's object hierarchy is **Item (one login at one institution) → Accounts → Transactions**. Model it, but make the connection layer **aggregator-polymorphic** (not Plaid-only) because of the 2025 JPMorgan-fee / CFPB-1033 uncertainty and the likely need for a Teller/SimpleFIN/manual fallback for AMEX.
+
+**Per Item (connection), must store server-side:**
+- `provider` (plaid | teller | simplefin | manual_import) + `provider_item_id` (Plaid `item_id`) — `item_id` is the stable per-connection key, **UNIQUE**. Linking the same bank twice = two Items.
+- `access_token` — the secret, **encrypt at rest**, never exposed to client. Does not expire; revoked only via `/item/remove`.
+- `institution_id`, `webhook_url`, `environment` ('sandbox' | 'production' — Items can't move between environments; **there is no 'development' env**, decommissioned 2024-06-20).
+- `transactions_cursor` — the `/transactions/sync` `next_cursor`, stored **per Item**, opaque base64 ≤256 chars. This is the resumable ingestion pointer.
+- `consent_expiration_time` — **NULLABLE**; usually null in US. **Do NOT hardcode a 90-day re-auth cadence** (that's an EU/PSD2 rule; Plaid explicitly calls the universal-90-day assumption a misconception). Each US institution sets its own policy. A successful Link update-mode run **resets** this value.
+- Health/status fields (see below), `last_synced_at`, `created_at`, `updated_at`, `removed_at` (soft-delete for `/item/remove` teardown — critical because Transactions/Investments/Liabilities **bill monthly per Item** as long as a valid token exists).
+
+**Connection health (separate from connection identity):** track `status` (healthy | login_required | pending_expiration | pending_disconnect | consent_expired | revoked | error), `last_error_code` (e.g. `ITEM_LOGIN_REQUIRED`, `OAUTH_CONSENT_EXPIRED`), `status_since`, `needs_user_action` (bool), `last_successful_sync_at`. Drive the "re-login" UI off `needs_user_action`, **not** raw error strings. Remediation is Link **update mode** (create a `link_token` from the existing `access_token`); the `access_token` stays the same after a successful update.
+
+**Ephemeral tokens** (`link_token` ~4h / 30m in update mode, `public_token` 30m) are transient — keep them out of the durable connection row (or in a short-lived table). The durable secret is `access_token` + `item_id`.
+
+**Chase/AMEX OAuth reality (institution capability flags matter):**
+- **Both require bank-hosted OAuth** — no credential storage. You **must** register an allowlisted HTTPS `redirect_uri` in the Plaid dashboard and pass it in the `link_token`; **it cannot contain query params**. Chase supports app-to-app on mobile.
+- **Chase returns Tokenized Account Numbers (TANs)** — the account/routing number is a token, not the real DDA. Store a `uses_tokenized_account_numbers` flag so nothing downstream treats it as a real routing number.
+- **Capability asymmetry is real and must be a stored `supported_products` set:**
+  - **Chase:** Auth, Balance, Transactions, Identity, **Liabilities**, Investments — fully supported.
+  - **AMEX:** **Assets, Balance, Transactions ONLY.** No Liabilities, no Auth/Identity/Investments. So APR / statement-balance / minimum-payment / next-due-date columns will be **null for AMEX** and populated for Chase. AMEX charge cards also often have **no meaningful credit `limit`**. All liability/limit columns must be nullable and gated on `supported_products`.
+- Treat **AMEX connection flakiness as a real operational risk** (reported "perpetual MFA"; possibly legacy-path artifact but design around it). This is the main argument for first-class **manual file import** as a fallback connection type.
+
+**Webhooks:** an idempotent ingest log keyed by `item_id`. Key event is `TRANSACTIONS / SYNC_UPDATES_AVAILABLE` → enqueue a per-Item sync job (dedupe concurrent jobs per `item_id`). `ITEM / ERROR` (e.g. `ITEM_LOGIN_REQUIRED`), `PENDING_EXPIRATION` (~7 days out), `PENDING_DISCONNECT`, `USER_PERMISSION_REVOKED` flip `needs_user_action`.
+
+**Sync loop invariant:** wrap the whole `has_more` loop **plus** the cursor advance in one DB transaction. Never persist a cursor for a batch you didn't fully apply — a mid-loop failure must re-run from the last committed cursor.
+
+---
+
+## 2. Transaction model
+
+**Ledger decision (locked recommendation): single-entry** — one signed row per financial event on one account. This matches the Plaid/CSV/OFX import shape 1:1 (an importer gets ONE signed row + a balance, never the contra leg). Recover double-entry's two correctness wins with an explicit **transfers** link table and a **transaction_splits** child table. This mirrors Actual and Maybe. Strict GnuCash double-entry would force synthesizing a balancing "expense account" leg for every imported row — rejected.
+
+**Money:** store as **integer minor units** (parity with Plaid amounts) OR `NUMERIC(19,4)` — **never float.** Recommend integer minor units + a per-currency `minor_unit_scale`. Flag this decision (§6).
+
+**Sign convention — the sharp edge:** Plaid `amount` is **POSITIVE = outflow (money leaving), NEGATIVE = inflow.** OFX `TRNAMT` and Chase use accounting convention (**outflow negative**). AMEX CSV is the **inverse of Chase** (charges positive, payments negative). **Normalize sign to one canonical convention at ingest** (per-profile `amount_sign_convention` flag for CSV), and store the normalized signed amount. Pick one house rule and document it (recommend: outflow negative, matching OFX/accounting intuition).
+
+**Canonical transaction fields (union of Plaid + OFX/QIF + CSV):**
+- Identity/dedup: `provider_transaction_id` (Plaid `transaction_id` or OFX `FITID`), `import_hash` (content hash for id-less rows), `import_batch_id`.
+- Money: `amount` (signed, normalized), `currency` (ISO 4217), `base_amount` + `base_currency` + `fx_rate` for reporting rollups.
+- Dates: **`date` (posted/settled)** and **`authorized_date` (nullable — prefer for user-facing ordering)**; optional `datetime`/`authorized_datetime` timestamps.
+- Descriptors: `original_description` (raw institution `name` / OFX `NAME`), `merchant_id` (Plaid-enriched `merchant_name`, normalized), `imported_payee`, `memo`/notes, `check_number`, `payment_channel` (online | in store | other).
+- Category: **flatten Plaid PFC to `pfc_primary`, `pfc_detailed`, `pfc_confidence_level`** (raw capture) + a `category_id` FK to your own owned category tree (see §3). The legacy Plaid `category[]`/`category_id` is deprecated — do not model it as primary.
+- Lifecycle: `status` (pending | posted), `pending` (bool), `pending_provider_id` (Plaid `pending_transaction_id`, self-referential — links the pending row to its posted successor).
+- Structure/flags: `is_transfer`, `transfer_id`, `is_split` (→ `category_id` NULL when split), `recurring_stream_id`, `excluded_from_reports`, `cleared`, `reconciled`.
+- Provenance: `raw_json` (JSONB) — **always persist the raw payload**. Future-proofs against new Plaid fields, lets you re-derive columns without re-fetching (avoids re-billing), and aids debugging.
+- Nested-but-variable: `location` and `counterparties` as **JSONB** (don't explode into nullable columns).
+
+**Dedup strategy (two-tier, this is the core correctness mechanism):**
+1. **External-id path:** `UNIQUE(account_id, provider_transaction_id) WHERE provider_transaction_id IS NOT NULL` (partial). Covers Plaid `transaction_id` and OFX/QFX `FITID`. **FITID is unique only WITHIN an account at one institution — never globally**, so the key is the `(account_id, external_id)` tuple, never the id alone. Makes re-imports idempotent (`ON CONFLICT DO NOTHING/UPDATE`).
+2. **Content-hash fallback** for id-less formats (**QIF and all CSV have no stable id**): `UNIQUE(account_id, import_hash) WHERE provider_transaction_id IS NULL` (partial). Hash over normalized `account_id + posted_date(ISO) + signed_amount_minor_units + normalized_payee + normalized_memo + check_number + within-day ordinal`. Normalize aggressively (uppercase, collapse whitespace, strip punctuation) before hashing.
+3. **Cross-source reconciliation pass:** an id-less CSV/QIF row and a later Plaid row for the *same real transaction* would otherwise both land. On ingest of an id-less row (or a new Plaid row), fuzzy-match existing rows by `(account_id, date ±few days, exact amount, fuzzy payee)`; on a confident match, **MERGE** (attach the Plaid external-id/enrichment to the pre-existing imported row, mark reconciled) rather than insert. Store `dedup_status`/`source_precedence` so Plaid (authoritative) supersedes a hand-imported placeholder.
+
+**Pending vs posted:** a pending txn and its posted counterpart have **DIFFERENT** `transaction_id`s; the posted row carries `pending_transaction_id`. Via `/transactions/sync` the pending row typically arrives in `removed[]` and the posted in `added[]`. Dedup on `transaction_id` alone double-counts — collapse via `pending_provider_id`.
+
+**Transfers:** explicit `transfers` join table pairing the two legs (`from_transaction_id`/`to_transaction_id`, both `UNIQUE` so a leg belongs to one transfer only) + `is_transfer=true` on both legs so income/expense aggregations filter them out and net worth doesn't double-count. QIF encodes transfers as a bracketed `L[Account]` value — link to the counterpart account, **not** a category.
+
+**Splits:** `transaction_splits` child table (`parent_transaction_id`, `amount`, `category_id`, `memo`, `sort_order`); app-enforced `SUM(splits.amount) = transaction.amount`, and parent `category_id` NULL when split (so reporting never double-counts). **Dedup/content-hash at the PARENT grain** so a multi-leg QIF transaction is one idempotent unit, not N. (Cleaner than Actual's self-referential parent/child rows because the money movement stays a single account row.)
+
+---
+
+## 3. Reference data
+
+**Accounts taxonomy** — store `type`/`subtype` as **TEXT, not enum/CHECK** (Plaid adds new subtypes). Plaid top-level types: `depository | credit | loan | investment | other`, each with a large, growing subtype set (depository: checking/savings/hsa/cd/money market/…; investment: 401k/ira/roth/brokerage/hsa/529/crypto/…). Keep a normalized internal `account_type` for signing (checking, savings, credit_card, loan, investment, brokerage, crypto, property, vehicle, cash, other_asset, other_liability) plus `classification` (asset | liability) **stored** for fast net-worth signing. Balances group (`current`, `available`, `credit_limit`) all nullable. `UNIQUE(connection_id, provider_account_id)`. Keep `persistent_account_id` (stable across relinks) for reconnect reconciliation. `is_manual`, `is_on_budget`, `is_closed`, soft-delete.
+
+**Categories — own the tree, seed from Plaid PFC (recommendation: adopt PFC as the seed, not the runtime authority):** self-referencing `categories` (`parent_id`, 2-level to mirror Plaid **primary/detailed**), with `plaid_primary`/`plaid_detailed` columns for auto-mapping incoming PFC, plus `classification` (income | expense | transfer), `is_system`, `is_hidden`. Seed the tree from Plaid's **16 primary + 104 detailed** PFC (published CSV; v2 default for integrations enabled on/after 2025-12-03) but own the table so users rename/hide/add without provider lock-in. Add a **`category_alias`/mapping** table so free-text category strings from QIF/Chase/AMEX map onto canonical ids; unmatched → 'uncategorized'. Preserve Quicken's orthogonal `/Class` axis as a separate **tags** table.
+
+**Merchants/payees:** `merchants` with `owner_id` (NULL = global/provider-seeded), `name`, `normalized_name`, `source` (plaid | user | system | rule), `provider_merchant_id`, `logo_url`, `website_url`. `UNIQUE(owner_id, normalized_name)` for user merchants; `UNIQUE(source, provider_merchant_id)` for provider merchants. Keep the **raw description string on the transaction** separately so re-normalization is always possible.
+
+**Currencies:** `currencies` (ISO 4217 code PK, name, symbol, `minor_unit_scale`). Seed USD. Every monetary column carries a currency FK — USD-only today shouldn't paint us into a corner. Plaid populates exactly one of `iso_currency_code` / `unofficial_currency_code` (crypto/non-standard) — capture both. `exchange_rates` (`from_currency`, `to_currency`, `rate_date`, `rate`; `UNIQUE(from, to, rate_date)`) for historical net-worth conversion.
+
+**Securities:** shared/global `securities` (`ticker`, `name`, `security_type` equity/etf/mutual_fund/bond/option/crypto/cash/fixed_income/other, `exchange_mic`, `exchange_operating_mic`, `country_code`, `currency`, `provider_security_id`, `cusip`/`isin`/`sedol`). `UNIQUE(ticker, exchange_operating_mic)` case-insensitive; `UNIQUE(provider_security_id)` partial. Referenced by holdings AND trades (many accounts share one `security_id`).
+
+**Import mapping (data-driven, not hardcoded parsers):** `import_profiles` (`header_signature` ordered column list for auto-detecting Chase-CC vs Chase-checking vs each AMEX CSV variant, `column_mapping` JSONB → canonical fields, `date_format`, `amount_sign_convention`, decimal/thousands handling). **Chase ships ≥2 layouts** (credit-card: Transaction Date/Post Date/Description/Category/Type/Amount/Memo; checking: Details/Posting Date/Description/Amount/Type/Balance/Check#). **AMEX ships multiple unversioned layouts** detected by column order, with inverted sign. Auto-select profile by matching the uploaded header row.
+
+---
+
+## 4. Investments & net-worth-over-time
+
+Ship investment tables **now** even if launch is Transactions-only (see §6) — the user does not want a later migration, and investments are where the schema materially expands.
+
+- **`securities`** — shared reference (above).
+- **`security_prices`** — time series: `security_id`, `price_date`, `close_price`, `currency`. `UNIQUE(security_id, price_date, currency)`. Feeds market value.
+- **`holdings`** — position snapshot per `(account_id, security_id, as_of_date)`: `quantity`, `cost_basis`, `average_cost`, `price`, `market_value`, `vested_quantity`, `currency`. `UNIQUE(account_id, security_id, as_of_date, currency)`. Holdings are **snapshots, not immutable events** — upsert, don't append. Current = latest date; historical rows feed the net-worth chart.
+- **`trades`** (investment transactions — the security-movement event type): `account_id`, `transaction_id` (nullable link to the cash leg), `security_id`, `trade_type` (buy/sell/dividend/reinvest/transfer_in/transfer_out/fee/split), `trade_date`, `quantity`, `price`, `amount`, `fees`, `currency`, `provider_investment_transaction_id`. `UNIQUE(account_id, provider_investment_transaction_id)` partial. Plaid `/investments/transactions/get`.
+- **`account_valuations`** — manual/anchor balance statements for illiquid or manually-tracked accounts (property, vehicle, crypto, cash) **and reconciliations**: `account_id`, `as_of_date`, `value`, `currency`, `source` (manual | reconciliation | provider). `UNIQUE(account_id, as_of_date)`. This is how non-transactional assets get on the net-worth chart and how you correct drift between imported balance and summed transactions.
+- **`account_balances`** — **MATERIALIZED daily snapshot cache** (`account_id`, `balance_date`, `balance`, `cash_balance`, `holdings_value`, `currency`; `UNIQUE(account_id, balance_date, currency)`). Recomputed by a background job from transactions + valuations + holdings.
+
+**Net-worth-over-time is a snapshot, NOT derived live.** Field standard across Maybe/Personal-Capital: one balance row per account per day, recomputed in a background job. Live derivation fails for imported accounts (you get current balance + a partial transaction window, never full history). Net-worth chart = `SELECT balance_date, SUM(balance) GROUP BY balance_date` against the cache. (Watch the worker-OOM history — keep the recompute job's per-request payloads bounded.)
+
+**Liabilities** (Chase yes, AMEX no) — per-account detail refreshed on each pull (upsert, not append), keyed by `plaid_account_id`. Either one `liability_details` table + JSONB or three (`credit`/`mortgage`/`student`). Credit APRs are a nested array → child `credit_aprs(account_id, apr_type, apr_percentage, balance_subject_to_apr, interest_charge_amount)`. Store `next_payment_due_date`, `minimum_payment_amount`, `last_statement_balance`, `interest_rate` as typed columns (they drive UI) — all nullable, all gated on `supported_products` including liabilities.
+
+**Recurring streams** (subscription / "wasting money" insights) — Plaid Recurring Transactions add-on (works best with ≥180 days history): `recurring_streams` with `merchant_id`, `category_id`, `direction` (inflow | outflow), `frequency`, `average_amount`, `last_amount`, `first_date`, `last_date`, `next_expected_date`, `status`, `is_subscription`, `provider_stream_id`. `transactions.recurring_stream_id` back-links occurrences. Fold user-scheduled bills (rent) in via a `source` flag rather than a separate schedules table.
+
+---
+
+## 5. Recommended table list (consolidated, ship all now)
+
+**Connections & sync**
+- `institutions` — aggregator-agnostic institution metadata + capability flags (`supported_products`, `oauth_required`, `uses_tokenized_account_numbers`, `uses_app_to_app`). `UNIQUE(provider, provider_institution_id)`.
+- `connections` (Plaid Items) — one per institution login; encrypted `access_token`, `provider_item_id` (UNIQUE), `sync_cursor`, `environment`, `consent_expiration_time`, `removed_at`.
+- `connection_status` — credential health separate from identity (status enum, `last_error_code`, `needs_user_action`, `last_successful_sync_at`). (May fold into `connections` if you prefer one row per connection.)
+- `webhook_events` — idempotent webhook log keyed by `item_id` (`webhook_type`, `webhook_code`, `raw` JSONB, `received_at`, `processed_at`).
+
+**Accounts & balances**
+- `accounts` — one per provider account; type/subtype TEXT, classification, balances, `persistent_account_id`, `UNIQUE(connection_id, provider_account_id)`, soft-delete.
+- `account_balances` — materialized daily net-worth snapshot cache.
+- `account_valuations` — manual/anchor/reconciliation balance statements.
+- `liability_details` (+ `credit_aprs` child, or JSONB) — per-account APR/statement/due-date detail, upserted per pull.
+
+**Transactions**
+- `transactions` — core single-entry ledger; two-tier dedup unique indices; `raw_json` JSONB.
+- `transaction_splits` — parent/child category legs.
+- `transaction_tags` — M2M `(transaction_id, tag_id)`.
+- `transfers` — pairs the two legs of a transfer.
+- `recurring_streams` — subscription/recurring insights.
+
+**Investments**
+- `securities` — shared security reference.
+- `security_prices` — price time series.
+- `holdings` — daily position snapshots (cost basis + market value).
+- `trades` — investment/security-movement events.
+
+**Reference data**
+- `categories` — owned 2-level tree seeded from Plaid PFC, with `plaid_primary`/`plaid_detailed`.
+- `category_aliases` — free-text → canonical category mapping.
+- `merchants` — provider + user-scoped merchant/payee normalization.
+- `tags` — Quicken `/Class` axis and user tags.
+- `currencies` — ISO 4217 + minor-unit scale.
+- `exchange_rates` — historical FX for base-currency rollups.
+
+**Import & rules**
+- `import_batches` (import runs) — one per uploaded file / sync run; `source_type`, `file_sha256`, counts, status, rollback unit.
+- `import_batch_rows` (staging) — raw parsed record per row, `parsed_status`, `matched_transaction_id`, reason — powers review-before-commit + precise dup/error reporting.
+- `import_profiles` — data-driven CSV/OFX column mappings + header signatures + sign convention.
+- `rules` — data-driven auto-categorization / merchant assignment / transfer detection (`conditions` JSONB, `actions` JSONB, priority, enabled).
+
+**Budgets & extras**
+- `budgets` — period definition (`period_type`, `start_date`, `end_date`, currency).
+- `budget_categories` — per-category budgeted amounts + `period_month` (YYYYMM) + `carryover_amount` + `goal_amount` (envelope budgeting never needs a new table).
+- `attachments` — receipts/documents per transaction (ship now to avoid a later table).
+
+**Cross-cutting:** every table gets `created_at`/`updated_at`, a soft-delete column (`deleted_at`), `owner_id`, and nullable `organization_id` (org-tenancy port pending).
+
+---
+
+## 6. Key decisions (with recommendations)
+
+| Decision | Recommendation | Why |
+|---|---|---|
+| **Single vs double-entry** | **Single-entry** + `transfers` link table + `transaction_splits`. | Matches Plaid/CSV/OFX import shape 1:1; avoids synthesizing a contra leg per row; simpler queries. Mirrors Actual/Maybe. |
+| **Money representation** | **Integer minor units** + per-currency `minor_unit_scale` in `currencies`. | Parity with Plaid amounts, exact arithmetic, no float drift. (`NUMERIC(19,4)` acceptable if cross-currency math simplicity is valued more.) |
+| **Net-worth balances** | **Materialized daily snapshot** (`account_balances`), recomputed by a background job. | Live derivation fails for imported accounts (partial history); makes charting a trivial `GROUP BY date`. Keep recompute payloads bounded (OOM history). |
+| **Plaid PFC adoption** | **Adopt as seed, own the runtime tree.** Store raw `pfc_primary`/`pfc_detailed`/`confidence` on the transaction AND map to owned `categories`. | Gets Plaid's 16/104 taxonomy for free without provider lock-in; users can rename/hide/add. |
+| **Sign convention** | **Normalize at ingest to one house rule** (recommend outflow-negative); per-profile `amount_sign_convention` for CSV. | Plaid (outflow +), OFX/Chase (outflow −), AMEX (inverted) all disagree — normalize once, store signed. |
+| **Dedup key** | **Two-tier:** `UNIQUE(account_id, provider_transaction_id)` partial + `UNIQUE(account_id, import_hash)` partial, plus a fuzzy cross-source merge pass. | FITID/Plaid-id idempotency where available; content-hash for QIF/CSV; merge prevents Plaid+manual double-landing. FITID is per-account-only, never global. |
+| **Investments now or later** | **Build securities/prices/holdings/trades now**, even if launch is Transactions-only. | User forbids later table additions; investments are the biggest schema expansion. Gate *fetching* on enabled Plaid products, not on table existence. |
+| **Aggregator coupling** | **Aggregator-polymorphic connection layer** (Plaid | teller | simplefin | manual). | 2025 JPMorgan fees + CFPB-1033 rewrite make Chase-via-Plaid cost/availability unsettled; AMEX flakiness needs a manual fallback. Swap providers without a schema rewrite. |
+| **Manual import** | **First-class connection type**, not a side feature. | Only path with zero third-party dependency; guaranteed fallback (Chase CSV/QFX/QBO; AMEX CSV/QFX/OFX). |
+| **Re-auth cadence** | **Store per-Item `consent_expiration_time` (nullable); never hardcode 90 days.** | 90-day is EU/PSD2, not universal US Plaid behavior; US institutions vary; update-mode resets it. |
+| **Disconnect/teardown** | **Soft-delete + call `/item/remove` + record `removed_at`**; decide retention separately (open Q). | Subscription products bill monthly per live Item — must be able to stop billing while optionally retaining history. |
+| **Splits/transfer invariants** | **Enforce in the application service layer** (splits sum to parent, transfer legs net to zero). | pytest DB is SQLite with FK OFF — DB-level CHECK/trigger behavior can't be asserted in tests; verify against live Postgres. |
+
+**Unresolved product decisions to surface before/with schema design (don't block on them, but flag):**
+- Which Plaid products at launch (Transactions only vs +Investments/+Liabilities) — drives per-Item subscription cost exposure, not table existence.
+- Retention on disconnect: keep historical transactions or purge? (Affects FK-cascade vs soft-retain on `connections` delete.)
+- Base currency & FX policy: single per-user base currency + snapshot `fx_rate` at txn time vs convert-on-read. Both need `exchange_rates`; changes whether `base_amount` is stored or computed.
+- Cross-source merge aggressiveness: silently supersede a manual row with Plaid vs surface as a user-confirmable duplicate. Looser matching prevents dupes but risks merging two genuinely distinct same-day/same-amount transactions.
+- Whether the cash side of a buy/sell shows in spending reports (link `trades.transaction_id` to a real cash-account row vs keep `trades` self-contained).

--- a/docs/plans/finance-service/finance-research/02-product-insights-brief.md
+++ b/docs/plans/finance-service/finance-research/02-product-insights-brief.md
@@ -1,0 +1,172 @@
+# Product Insights & Hard-Won Lessons
+### A field brief for building your first personal-finance aggregator (Plaid + Quicken import, Chase/AMEX, "wasting money" insights)
+
+---
+
+## 0. The one-paragraph orientation
+
+You are building three products stapled together: a **net-worth tracker** (a *snapshot/persistence* problem, not a math problem), a **transaction ledger + importer** (a *dedup and mutability* problem), and an **insight engine** (a *merchant-normalization* problem before it is an *AI* problem). The headline features are all trivial arithmetic; every ounce of difficulty is in the plumbing beneath them — history you had to be capturing since day one, IDs that aren't stable, signs that flip per source, and a bank that silently edits the past. Get the schema right first, because almost every hard bug here is a schema decision you can't retrofit.
+
+---
+
+## 1. Feature landscape — table stakes vs differentiators
+
+| Category | Table stakes (users leave if missing) | Differentiators (what people pay for) | Where the real work hides |
+|---|---|---|---|
+| **Net-worth tracking** | Net-worth-over-time line = Σ(assets) − Σ(liabilities); linked + **manual** accounts; per-account drill-down | Investment Checkup / allocation analysis across *all* accounts; fee analyzer; "You Index" vs S&P; Zillow/depreciation valuation of manual assets; IRR on illiquid assets | The trend line is **stored snapshots**, not recomputed math. If you didn't snapshot from day one, history is *unrecoverable*. |
+| **Budgeting** | Categorized transactions; budget-vs-actual; monthly rollup | Philosophy (YNAB zero-based envelopes vs Monarch flex-buckets vs Simplifi top-down "available to spend"); anomaly-vs-*your-own*-baseline alerts; cash-flow forecast | Two different "overspending" surfaces: budget-vs-actual (a ledger compare) **and** anomaly-vs-baseline (needs rolling 3/6/12-mo averages). |
+| **Subscription / "wasting money"** | Detected recurring list; upcoming bills; price-change alerts | Duplicate-service detection; free-trial-converted; forgotten-annual; fee/interest detection; **bill negotiation/cancellation** (the actual revenue) | Every insight is a *cheap SQL query* over one good `recurring_series` table. The table is the whole game. |
+| **Investments** | Holdings list; current value; allocation pie | Cost basis / tax lots; Form 8949; capital-gains estimator; TWR vs IRR performance | Accurate lots need **full transaction history + corporate actions** — data aggregators don't reliably give you. This is a separate, harder tier. |
+| **Connectivity** | Auto-sync of transactions + balances; manual file import | Broad institution coverage; reconnection UX; multi-currency | Aggregation is a **permanent maintenance tax**, not a one-time integration. Model connection *health* as a first-class entity. |
+
+**Opinion:** For a v1 solo build, ship *net-worth + categorized cash-flow + subscription insights* and treat *tax-grade cost basis* as an explicit non-goal (label it "approximate"). Sharesight/Quicken exist because that tier is a product unto itself.
+
+---
+
+## 2. Things you probably don't know (highest-value non-obvious insights)
+
+**1. Credit-card-payment double-counting is the #1 credibility bug.** A $500 card payment appears **twice**: an outflow on checking and an inflow on the card. Naively summing outflows counts the $500 payment *on top of* the $500 of purchases it paid off — Mint was infamous for reporting ~2× real annual spending. Fix: detect + pair both legs, tag a shared `transfer_group_id`, exclude both from cash-flow/income. **Net worth is immune** (one account down, one liability down, cancels) — only spending/income totals get wrecked.
+
+**2. "Is this a transfer" is genuinely hard, not an equal-and-opposite match.** Amounts differ (partial payments, a $2 fee, FX); legs land days apart or across a sync boundary; two unrelated $50 charges create false positives; you may only have *one* side linked (then it *is* real spending — don't hide it); and Venmo-to-a-friend looks identical to an internal move but is real cash-flow out. Build a **confidence score** (amount closeness + date proximity + provider category + recurring counterparty), require *both* accounts to belong to the same user before auto-hiding, and **suggest-and-confirm** below a high threshold rather than silently zeroing money.
+
+**3. Pending → posted is a DELETE + INSERT, not an update.** Plaid *removes* the pending row and *inserts* a new posted row with a **different** `transaction_id`, linked only by `pending_transaction_id`. Amounts change (restaurant pending *without* tip → posts *with* tip) and dates move 1–5 (up to 14) days. If you key dedup on amount+date+name, the tip breaks it and you show the coffee twice. Key on the stable provider id + the pending linkage.
+
+**4. Phantom pendings never post.** Gas $1/$100 pre-auths, hotel/rental deposits, voided charges show up pending then just *drop off* (Plaid `removed` array) — funds released, no posted counterpart. Never build durable history (net-worth snapshots, budget actuals) on pending rows or you manufacture spending that never happened.
+
+**5. Your store cannot be append-only-immutable — the bank edits the past.** Banks retroactively fix descriptions/amounts/categories and **delete** transactions (fraud reversals). Plaid ships this as `modified` and `removed` arrays against a persisted **sync cursor**. Engineers instinctively reach for event-sourcing and then can't apply edits, so balances drift permanently and deleted fraud stays visible forever. Model transactions as **mutable upserts + soft-delete**; put any audit need in a *separate* changelog table.
+
+**6. Sign conventions are inverted and flip per source.** Plaid: **positive = money OUT** (counterintuitive), and it *inverts again* for investment accounts (a sale is negative). OFX/QFX: trust the `TRNAMT` **sign**, not the `TRNTYPE` label — and many banks (Capital One, BofA cards) ship the sign *reversed* so charges import as payments. CSV is chaos (signed col vs separate debit/credit cols). Normalize to **one documented internal convention** at ingest, store `raw_amount` + `signed_amount`, and unit-test every importer with a known debit and known credit.
+
+**7. Manual assets ARE net worth, and they're structurally identical to synced accounts.** A house, car, private company, collectibles are never aggregatable but are a huge share of true wealth. For the net-worth chart, both a synced account and a manual asset reduce to "a dated value" — unify them into one value-history time series (`source = sync|manual`). Manual assets add a **staleness** concept (nobody re-values their house), so add `last_valued_at` + `is_stale` + `stale_after_days`.
+
+**8. Net-worth-over-time is a persistence problem you can't retrofit.** Aggregators hand you a *current* balance, never history; Plaid's transaction lookback wall (default 90d, initial ~30d, max 730d, capped by the institution) means you *cannot* walk backward to reconstruct it. The only way to get a real trend is a **scheduled snapshot job** writing one balance row per account per day starting at link time — independent of whether the user ever opens the app. This is the single most consequential, most easily-missed decision in the whole app.
+
+**9. Balance ≠ Σ(transactions), ever.** You only fetched N days; pending affects available-vs-current differently; the bank has a starting point you never saw. **Trust the provider's reported balance as authoritative**; if you need a running balance, seed a synthetic **starting-balance/adjustment entry** = `reported_balance − Σ(known_txns)`. New builders assume balance = running sum and then can't explain a $400 disagreement with the bank.
+
+**10. Connection breakage is the steady-state, not an incident.** MFA re-auth breaks on nearly every login for some users; institutions rotate APIs; accounts get stuck "loading"; transactions live in permanent pending limbo. Chase specifically is *flaky on Plaid* and needs frequent re-auth. Surface **reauth as a product state** (`needs_reauth`), and on a failed sync **carry forward last-known balance** rather than dropping the account and cratering the net-worth line.
+
+**11. Subscription "unused" detection is a euphemism you must not over-promise.** Bank data *cannot* see whether you use Netflix. Rocket Money's "inactive" list is really "a known recurring series that stopped charging." "Unused" just presents *all* detected subscriptions and lets the human decide. And recurring detection is a **merchant-normalization problem before it's ML** — feed raw bank descriptions into cadence clustering and the same service shows up as 3 merchants and never clusters. You need ≥3 occurrences to confirm a series (so annual charges are invisible for a year → model a *confidence/maturity* field, not a boolean), you must actively *exclude* habitual spend (groceries/gas/coffee/Amazon), and variable bills (utilities) need an `is_variable` flag + tolerance band or they false-positive on both detection *and* price-hike alerts.
+
+**12. The Mint shutdown is a spec, not trivia.** Mint died Nov 2023 because free ad/referral monetization on a budgeting app is structurally weak. Intuit migrated users to Credit Karma and carried over **none** of their history, custom categories, budgets, goals, or recurring labels — a one-way, irreversible strand. The exodus (Monarch/YNAB/Copilot/Rocket Money — all *subscription*-priced) was driven by people with years of data trapped. Lessons: **(a)** decide monetization before schema (funnel vs subscription changes what you optimize); **(b)** treat the user's history/categories/rules as **theirs from day one** — build export/import early; **(c)** historical snapshots are user data you can *never regenerate* — treat them as append-only and sacred (acquisition rewrites like Empower's caused literal data loss).
+
+**13. The Plaid access/cost reality for a solo dev.** Plaid's "free tier" is a **demo, not a runway**: ~10 Production Items and ~200 live calls *per product*, and **failed calls also burn quota** — so one flaky Chase reconnect silently drains it. Beyond that it's pay-as-you-go (~$0.10–0.60/call), Growth needs a 12-month commit, Enterprise is $1k–10k+/mo, and full production requires a business-use-case *approval* a hobby project won't clear. Prior art: **Maybe Finance (funded team) explicitly refused to ship self-hosted Plaid**, citing OAuth complexity + pricing + per-user cost — telling self-hosters to bring their own keys. That is a strong signal *against* Plaid-first.
+
+**14. IRR vs TWR is a schema fork you pick before any UI.** Money-weighted IRR needs *dated cash flows*; time-weighted return needs *period balances*. Illiquid/manual assets → IRR; index comparison → TWR. And performance numbers **never match the brokerage** — Empower's "You Index" is current holdings "extrapolated backward," an *approximation*, precisely because true return needs clean dated cash flows aggregators don't deliver. This is expectation-management, not a math bug — label it approximate in the UI.
+
+**15. Cross-source dedup has no shared ID.** Plaid `transaction_id` and OFX `FITID` are *per-source*. Re-linking a broken bank mints a **new Plaid Item → new ids for the same history**, so a naive sync duplicates everything. Within a source, dedup on the stable id; across sources you have only fuzzy signals (account + amount + date window + normalized payee) — **suggest a merge, let the user confirm**, never destructively auto-collapse.
+
+---
+
+## 3. Connectivity recommendation
+
+**Verdict: file-import-first, with a pluggable multi-provider sync layer bolted on. Do NOT be Plaid-first.**
+
+The reasoning, specific to *Chase + AMEX*:
+
+- **Direct OFX / bill-pay is dead for your two banks.** Direct Connect (the only two-way, bill-pay method) is gone: Chase migrated everything to download-only EWC+; AMEX dropped OFX entirely (~Aug 2024). Chase killed raw OFX Direct Connect in Oct 2022; AMEX's endpoint returns 403/503. Self-hosted `ofxtools` for Chase requires a per-device `CLIENTUID` + a secure-message-link + SMS/email code within a 7-day window, and many banks 403 anything not impersonating "Quicken for Windows." **Treat OFX Direct Connect as an at-most best-effort power-user importer, never a backbone.**
+- **Enterprise aggregators (MX/Finicity/Akoya) are unobtainable solo** — all sales-led with signed data-recipient agreements. They're future plug-in slots only.
+- **The EU "free open-banking" everyone recommends (Nordigen/GoCardless) is closed to new signups (mid-2025) and never covered US banks.** Irrelevant to you.
+
+**Recommended provider ladder for a US solo dev wanting Chase + AMEX:**
+
+1. **Manual/file import (CSV / OFX / QFX / QIF)** — the guaranteed, zero-approval, privacy-preserving *floor*. Build this excellently first; it's also your Quicken-migration path (see below).
+2. **SimpleFIN Bridge (~$15/yr)** — the cheapest real auto-sync obtainable with **zero approval**. Read-only, credentials never touch your server (a single-use token → long-lived Access URL; MX holds the bank relationship). Covers Chase/AMEX. Tradeoff: ~once-daily refresh, ~90 days history. **This is your best default auto-sync.**
+3. **Teller.io (100 free live US connections)** — richer/real-time, self-serve, covers Chase/BofA/Citi/Cap One/AMEX. But it's reverse-engineered against banks' mobile APIs + requires **mTLS client certs**, so it *breaks* when a bank changes behavior — never your only path.
+4. **Plaid as an optional bring-your-own-keys premium provider** — mirror exactly what Maybe Finance did. Don't make your product depend on it.
+
+**Quicken import surface (Chase/AMEX users migrating off Quicken):** you will *never* parse the `.QDF` (undocumented OLE compound file behind paid software). The real artifacts are **QFX/OFX > CSV > QIF**, ranked by fidelity. QFX carries `FITID` (real dedup key) + balances + cleared status; QIF is officially lossy (drops lots, tax lines, reminders, memorized payees, budgets, often correct balances, and has *no* stable id so it duplicates on re-import). Ignore the `INTU.BID` header (it only gates files to a paid Quicken subscription). Document that the user must run Quicken's own Export first.
+
+**The fallback path (always present):** every provider adapter emits into one **normalized internal transaction shape**; if a live provider breaks, the user drops back to file import with zero data-model change. Manual file-import-only is also a genuine **privacy differentiator** — a real segment of users refuses aggregators outright.
+
+---
+
+## 4. "Wasting money" insight playbook
+
+Every insight below is a *specific query* over `recurring_series` + `transactions` + `spending_baselines` — not AI magic. The engine's value is in the tables; the "AI" is mostly the merchant-normalization + per-user categorization model underneath.
+
+| Insight | Detectable signal | Data it needs | Gotchas |
+|---|---|---|---|
+| **Recurring / subscription detection** | Group txns into a "stream" when normalized merchant + amount + cadence align; ≥3 occurrences = "mature," 1–2 = "early_detection" | Normalized `merchant_id`; cadence bucket; `occurrence_count`; `confidence/status` | Merchant normalization first. **Exclude** groceries/gas/coffee/Amazon or the list fills with false positives. |
+| **Price-hike** | `last_amount` materially > running/expected `avg_amount` on the same series | `expected_amount` + `last_amount` per series; a **tolerance band** | Variable bills (utilities) must be flagged `is_variable` or they false-alarm every cycle. |
+| **Unused / inactive subscription** | A known series with **no charge in the last cadence window** (that's all bank data can prove) | `next_expected_date`, `last_charge_date`, cadence | You *cannot* detect actual usage. Frame as "here are all your subscriptions, you decide." |
+| **Duplicate services** | >1 *active* series in the same **service category** (Spotify + Apple Music) | merchant → `service_type` taxonomy (music/video/gym…) on top of merchant matching | Needs a service-type layer; merchant match alone won't catch two different merchants. |
+| **Free-trial-converted / forgotten annual** | First real charge after a $0/trial pattern; a single large annual charge on a mature-but-sparse cadence | series history + occurrence dates | Annual charges are invisible until the 3rd year — use `early_detection` to surface probable ones sooner. |
+| **Fee / interest detection** | Category/merchant match on overdraft, interest, late-fee, foreign-transaction-fee lines | category taxonomy incl. fee categories | FX fees arrive as their *own* separate line days after the foreign charge. |
+| **Category overspend (budget-vs-actual)** | Category actual > allocated for the period | `category_budgets` (allocated per period) | Distinct from anomaly detection below. |
+| **Spending anomaly (vs your own baseline)** | This month's category (or merchant) spend is X% above your trailing 3/6/12-mo average | `spending_baselines` (rolled trailing averages) | This is what "you're wasting money" usually *means*; most naive builds lack the baseline entirely. Simplifi uses a 12-mo average. |
+| **Low-yield cash** | Large balance sitting in a checking/low-APY account | account balances + account type + a reference APY | Actionable, high-trust, and free once you have balances. |
+
+**Categorization precedence is a hard contract, not an implementation detail:** `provider/base category` → `per-user ML prediction (suppressed if low-confidence)` → `deterministic user rules (highest priority, always win)`. Run auto-categorization *before* user rules. Get this backwards and user corrections get silently overwritten — a trust-killer. Use a **per-user** model (Copilot's approach — "AMZN" is groceries for one person, business supplies for another), with a cold-start fallback to the provider category until ~30 reviewed transactions exist, and a corrections store that feeds *only* that user's model.
+
+**Rules engine to copy (Lunch Money):** conditions on payee (contains/starts/exact), notes, category, amount type (debit/credit), amount range (between/>/</=), day-of-month range (with wrap), account; actions set payee/notes/category, add tags, link recurring, split, mark reviewed, notify, delete (one-off only); **priority-ordered**; and setting up a recurring item **auto-spawns a matching rule** so future transactions auto-link.
+
+**Free bonus:** cash-flow forecasting is nearly free once `recurring_series` has `next_expected_date` + `expected_amount`: `projected_balance(t) = current_balance + Σ(expected inflows ≤ t) − Σ(expected outflows ≤ t) − planned_spend`. Same table that powers subscription detection. Allow a **few-days tolerance** on `next_expected_date` or date-drift ("monthly" landing on the 1st, then 3rd, then 28th) will churn false "stopped"/"new" series every month.
+
+---
+
+## 5. Schema implications (feed straight into schema design)
+
+Consolidated from every reality above. Columns are grouped by concern.
+
+### Transactions (mutable upsert, NOT append-only immutable)
+- **Dedup keys:** `source` ENUM(plaid, ofx, qfx, csv, qif, manual, simplefin, teller), `external_id` (nullable — Plaid `transaction_id` / OFX `FITID`), `external_id_source`, `source_account_id`/`external_account_id`. **Unique constraint on `(account_id, external_id) WHERE external_id IS NOT NULL`** — scoped *per account*, never global (Firefly #10914). Plus `content_hash` and a fuzzy fingerprint (`posted_date + amount + normalized_payee + account`) for QIF/CSV rows and cross-source matching.
+- **Pending lifecycle:** `pending` BOOLEAN; `pending_transaction_id` (self-FK) linking a posted row to the pending it supersedes; `superseded_by`/`resolved` status so a resolved pending doesn't render or double-count.
+- **Soft-delete / mutability:** `is_removed` + `removed_at` (honor Plaid `removed` + bank deletions); apply `modified` as an in-place patch. Optional separate append-only `transaction_changelog` (field, old, new, changed_at, sync_cursor) for audit.
+- **Amount & currency:** `raw_amount` (as source delivered, sign and all) **+** `signed_amount` in ONE documented internal convention (e.g. positive = inflow to account); `currency_code` (`iso_currency_code` XOR `unofficial_currency_code`); `original_currency`/`original_amount` vs `settled_amount` when a foreign charge posts in home currency.
+- **Dates:** `authorized_date` (date-only, when swiped — use for spending analytics) **and** `posted_date`/`booked_date` (date-only, when money moved — use for balances/reconciliation); optional `authorized_datetime`/`posted_datetime`. Store the **user's timezone** on the user/account for correct day/month bucketing.
+- **Transfers:** `transfer_group_id` (shared by both legs), `is_transfer`/`excluded_from_cashflow` BOOLEAN, `transfer_confidence` score, `transfer_source` ENUM(auto, user_confirmed, provider_category).
+- **Refunds/reversals:** `related_transaction_id`/`refund_of` (link without auto-netting; refunds must *reduce category spend*, not register as income).
+- **Reconciliation status:** 3-state ENUM `UNCLEARED` (blank) / `CLEARED` ('c') / `RECONCILED` ('R') — **not a boolean**; treat RECONCILED as locked.
+- **Categorization:** `category_id`, `category_source` ENUM(provider, ml, rule, user) so a user correction is never overwritten; `is_reviewed`; `normalized_merchant_id` (distinct from `raw_description`); `recurring_series_id` (nullable).
+- **Raw payload:** `raw_payload` JSONB to re-derive fields later.
+- **Tenancy:** `owner_user_id` now (`organization_id` when orgs go live — parked per project memory).
+
+### Categories, tags, splits
+- **Categories:** hierarchical (`parent_id` self-ref or path), `income_expense` flag, optional `tax_line`/`tax_form` (arrives blank from QIF).
+- **Tags:** first-class entity, many-to-many **at the split-line level**, not just per transaction.
+- **Splits:** child `transaction_line` rows (category, amount, tag, memo per line) with the invariant that lines sum to the parent. A single-category-per-transaction schema *cannot* represent real Quicken data.
+
+### Accounts & balances
+- `account_type`/`account_subtype` (checking, savings, credit, loan, investment) + `is_liability` — because sign meaning and "increase = you owe more" flip for liability/investment accounts.
+- `current_balance` AND `available_balance`, `balance_currency`, `balance_as_of` timestamp — provider-reported, **authoritative** (never derived from summing transactions).
+- Explicit **starting/opening-balance** synthetic entry per account (= `reported_balance − Σ(known_txns)`) so a running balance reconciles; plus a "reconcile / enter current balance" adjustment path.
+- `first_seen`/`linked_at` so the UI can honestly say "history starts here."
+- Institution metadata (name, masked account number, connection method) for per-account re-import scoping.
+
+### Net-worth engine
+- **`account_balance_snapshot` (append-only, immutable):** `account_id`, `snapshot_date`, `balance`, `currency`, `source` ENUM(sync, manual). **One row per account per snapshot cadence — this ONE table powers the entire net-worth chart.** Populate from a **scheduled job**, not on user visit. Corrections = new rows, never in-place edits (editing a past value cascades through every chart/IRR calc).
+- **Do NOT store net worth as a single mutable scalar.** Derive it: `Σ(latest snapshot per account as-of date) − liabilities`.
+- On a failed sync: **carry forward last-known balance** (or mark an explicit gap); never drop the account.
+
+### Manual assets (unified with accounts)
+- `manual_asset`: `type` ENUM(real_estate, vehicle, crypto_wallet, private_equity, collectible, cash, other), `currency`, `valuation_source` ENUM(manual, zillow, price_feed, depreciation_schedule) + optional `source_ref` (Zillow URL/address), `last_valued_at`, `is_stale` + `stale_after_days`. Its snapshots flow into the *same* `account_balance_snapshot` shape with `source = manual`.
+
+### Investments (advanced tier — mark approximate)
+- `holding`: account_id, security_id, quantity, cost_basis, as_of_date (snapshot quantity+price over time if you want allocation history).
+- `security`/`instrument` reference: ticker, name, asset_class, sector, expense_ratio, currency — plus `price_history` (security_id, date, close). Required for benchmark comparison, allocation checkup, fee analysis; a dataset you must source/maintain.
+- `tax_lot`: holding_id, acquire_date, quantity, cost_basis_per_share, `disposal_method` ENUM(FIFO/LIFO/HIFO/LOFO/avg/specific) — only feasible with transaction ingestion; a `placeholder` transaction type for missing-history reconciling entries; an `action` field (buy/sell/reinvest/div/ESPP). Warn users lot identity is often lost in exports.
+- `cash_flow_entry` (for IRR on illiquid/manual): asset_id, date, direction(in|out), amount, currency — separate from market transactions.
+- Record a **performance methodology** per view (TWR from period balances vs IRR from dated cash flows); if you only snapshot balances, accept "You Index"-style backward-extrapolated approximation and label it.
+
+### Insight / recurring / budgeting engine
+- **`merchants`** (the prerequisite): raw-description alias map → `merchant_id`, `merchant_name` (clean), `logo_url`, `website`, `default_category`, `service_type` (music_streaming, video_streaming, gym…).
+- **`recurring_series`:** id, user_id, account_id, merchant_id, direction, `cadence` ENUM(weekly/biweekly/semimonthly/monthly/bimonthly/quarterly/semiannual/annual), `expected_amount`, `last_amount`, `amount_is_variable`, `amount_tolerance`, `first_seen_date`, `last_charge_date`, `next_expected_date`, `occurrence_count`, `status` ENUM(early_detection/mature/inactive/cancelled), `confidence_score`, category_id. Plus a `recurring_series_transactions` join table.
+- **`rules`:** id, user_id, `priority` (lower runs first), conditions structure, actions structure; enforce precedence base-category → ML → rules.
+- **`category_corrections`/`ml_feedback`:** user_id, transaction_id, predicted_category, corrected_category, feature_snapshot (name, amount, day_of_week, account); gate per-user model activation at ~30 reviewed.
+- **`category_budgets`:** user_id, category_id (or bucket), period, allocated_amount, rollover_enabled, rollover_balance (supports zero-based *or* flex).
+- **`spending_baselines`** (materialized): user_id, category_id (+ optional merchant_id), trailing_avg over 3/6/12 mo — powers anomaly insights.
+- **`insights`/`alerts`:** user_id, `type` (price_hike / duplicate_service / free_trial_converted / forgotten_annual / inactive_subscription / fee_charged / large_transaction / overspend_category / spending_anomaly / low_yield_cash), related_series_id or transaction_id, detected_amount, message, status (new/dismissed/actioned), created_at.
+
+### Connections & security
+- **`connection`/`item` (first-class, separate from Account):** `provider` ENUM(manual, csv, ofx, plaid, simplefin, teller, gocardless, enable_banking, mx, finicity, akoya), `status` ENUM(healthy/reauth_required/error/loading), `credential_ref` (encrypted — shape differs per provider: Plaid access_token / SimpleFIN Access URL / Teller mTLS cert ref), `last_successful_sync_at`, `last_error_code`, `needs_reauth`, `refresh_cadence`, `sync_cursor` (Plaid, for idempotent added/modified/removed), `days_requested` (set to max history up front — can't be cheaply extended later). An Account must be able to **migrate to a new Connection without losing transaction history** (re-linking is routine).
+- **Token storage:** `encrypted_access_token` (AES-256, KMS envelope / app-layer), server-side only, **never in client payloads or logs**, access-logged, with a rotation/invalidation path (Plaid `/item/access_token/invalidate`). **No bank username/password fields anywhere.** Access tokens don't expire and are silent standing read access to someone's entire financial life — more dangerous than a password.
+- **Import ledger / tombstones:** `import_run` id on each transaction (reversible batches, idempotent rollback); tombstones so user deletions **persist across re-syncs** (avoid Firefly #10090 / Actual "reimport deleted" resurrection).
+- **FX:** `fx_rates` (base, quote, rate, as_of_date); convert at *display* time against dated rates, not once at ingest; decide explicitly whether historical net-worth uses rate-at-time or today's rate (they produce different history).
+
+### Two rules to tattoo on the schema
+1. **The provider's reported balance is authoritative; transactions are the itemization.** Never compute displayed balance by summing transactions.
+2. **Snapshots and the changelog are append-only and sacred; the queryable transaction row is a mutable upsert.** Corrections are new rows, never in-place edits to history.
+
+---
+
+*Relevant file paths: none — this brief is the deliverable, returned inline.*

--- a/docs/plans/finance-service/finance-research/03-stocks-crypto-connectivity-brief.md
+++ b/docs/plans/finance-service/finance-research/03-stocks-crypto-connectivity-brief.md
@@ -1,0 +1,94 @@
+# Stocks & Crypto Connectivity
+
+**Bottom line:** No single provider covers everything a solo dev can self-serve into. Plaid is the easiest to start (free Trial, real data, includes Investments) but Fidelity through Plaid is unreliable and possibly broken. SnapTrade is the best brokerage-specialist for a solo dev (self-serve, free tier, covers Fidelity via Akoya underneath). Crypto exchanges mostly need their own read-only keys or a crypto aggregator. Build one provider-polymorphic connection layer now so you can mix Plaid + SnapTrade + direct keys + manual without new tables later.
+
+---
+
+## 1. Does Plaid cover it?
+
+**What Plaid Investments gives you (and gives you well):** a clean split you should mirror in your schema.
+- **Accounts** (type=investment, subtype=401k/ira/roth/brokerage/hsa/529) with balances.
+- **A shared securities catalog** keyed by Plaid `security_id` (name, ticker, CUSIP/ISIN, type, close price, plus `option_contract` and `fixed_income` sub-objects).
+- **Holdings** = one row per (account_id x security_id): quantity, institution price + as-of date, value, and nullable `cost_basis`.
+- **Investment transactions** (up to 24 months), paginated, buy/sell/dividend/fee/transfer types.
+
+**Access for a solo dev is genuinely good.** Sandbox is free/unlimited. Since April 15 2026 there is an **auto-approved, self-serve free Trial plan**: real Production data, up to 10 live Items, and it explicitly includes Investments + Investments Refresh and most OAuth institutions with no sales call. That is enough for a personal tool. Past 10 Items needs the full Production application (approved in a couple business days), after which Investments bills as a **recurring per-Item monthly subscription** (Holdings and Transactions are two separate subscriptions; calling the transactions endpoint silently starts both; Refresh is billed per request). Plaid never publishes the dollar figures.
+
+**The Fidelity problem (this is the big one).** Fidelity ended screen-scraping in Oct 2023, routes aggregators through Akoya / "Fidelity Access," and publicly stated Dec 29 2025 "Fidelity does not utilize Plaid." Plaid's docs still describe a Fidelity access grant (auto ~8 weeks after Production approval, or request via support on pay-as-you-go), so some path may persist, but user-facing Fidelity links through Plaid Link are widely reported as flaky/failing. **Treat Fidelity via Plaid as high-risk / possibly unavailable, and never let a Fidelity failure block onboarding.** 401k at Fidelity NetBenefits is even less certain.
+
+**Coverage gaps to design around:**
+- **Crypto is narrow.** Plaid Investments reads only Gemini / Robinhood / SoFi-style exchanges. **Coinbase, Kraken, Binance are NOT aggregated for holdings** (Coinbase uses Plaid only for bank/ACH Auth). If crypto matters, Plaid is not your crypto solution.
+- **Cost basis and lot-level tax data are the weakest part** of the model everywhere: `cost_basis`, the per-lot `lots` array, and `vested_*` exist in the schema but are nullable and inconsistently populated. Net-worth/allocation views work fine on balances+holdings+prices; anything tax-oriented needs data-present checks + manual fallback.
+- **Unmapped securities** (sweep/money-market funds, proprietary mutual funds) may lack a clean ticker/CUSIP and carry `unofficial_currency_code`. Handle them.
+- **Forward risk:** a live 2025-2026 fight (JPMorgan, Fidelity, Schwab charging aggregators) means big-custodian coverage and per-connection economics may degrade or shift onto you.
+
+---
+
+## 2. The specialists — when each beats Plaid
+
+| Provider | Solo-dev obtainable? | When it beats Plaid |
+|---|---|---|
+| **SnapTrade** | **YES, fully self-serve.** Dashboard signup, credentials issued immediately, free tier (1 connected user + ~20 broker connections + trading), then pay-as-you-go. No approval gate, no minimum. | Brokerage depth. One API normalizes positions/balances/transactions/cost-basis across ~20+ US/Canada brokers, **including Fidelity (rides Akoya underneath)** and Robinhood equities via a sanctioned OAuth integration. Optional trading. This is the realistic backbone if you outgrow Plaid or need Fidelity reliably. |
+| **Akoya** | **NO** (enterprise/FI-only). Sandbox is self-serve, but production needs a legal entity, data-sharing contracts, third-party risk review, SOC2/NIST posture. Explicitly "designed for commercial entities, not individual consumers." | It is the *pipe* under Fidelity and Schwab. You reach it *through* SnapTrade, never directly. Not a solo-dev option. |
+| **Yodlee / MX / Finicity** | **NO** (sales-gated, no self-serve production tier). | Decent investment-data quality (esp. Yodlee/Finicity), but access is the blocker. Skip for an indie build. |
+
+**SnapTrade pricing (transparent, indie-friendly):** free = 1 connected user. Real-time = **$2/user/mo** (first 5 free), trading included. Daily read-only = **$1/user/mo** (first 5 free), trading excluded, manual sync $0.05/op. Billed **per connected end-user, not per brokerage** (multiple brokers for one user don't double-bill). For a pure portfolio tracker, pick the $1 daily read-only tier.
+
+**One gap SnapTrade has:** **Vanguard** is effectively absent from SnapTrade and typically needs **Plaid** (or Yodlee/Akoya) as a secondary aggregator. So Plaid and SnapTrade are complementary, not either/or.
+
+---
+
+## 3. Direct broker APIs
+
+**The short list that actually exists for an individual** (great for a self-hosted single-user tool, poor for multi-tenant):
+
+- **Interactive Brokers Client Portal Web API** — free with a funded IBKR Pro account, read + trade. Catch: needs a **per-user local Client Portal Gateway** (a small Java process running), which does not fit cloud SaaS cleanly.
+- **Coinbase (via Coinbase Developer Platform)** — official read-only crypto key path. Note the **Feb 2025 change**: legacy retail keys were expired; you now mint keys through CDP with **Ed25519/JWT auth** (a pre-2025 HMAC integration will break). Read scope = `wallet:accounts:read`.
+- **Charles Schwab Trader API - Individual** (successor to the retired TD Ameritrade API) — free, read + trade, self-register, but gated by a **multi-day approval + Data Accessor Agreement**. Old TDA wrappers are dead.
+- **E*TRADE API** — free "individual key" tied to your own accounts only, read + trade, OAuth 1.0a, production-key approval step.
+- **Robinhood Crypto Trading API** — official, but **crypto only**.
+
+**The long list that does NOT exist for an individual:**
+- **Fidelity** — no first-party retail dev API. Only via consumer-permissioned aggregation (Fidelity Access on Akoya), surfaced through **SnapTrade** or (unreliably) Plaid.
+- **Vanguard** — no developer portal at all. Aggregator-only; realistically **Plaid**.
+- **Robinhood equities/options** — no official API. Unofficial reverse-engineered libs (robin_stocks, etc.) are **ToS-risky (account-closure risk) — never ship them.** Use SnapTrade's sanctioned Robinhood OAuth.
+
+**Key limitation:** all three direct brokers (IBKR/Schwab/E*TRADE) issue **single-user "individual keys"** that only serve the key owner's own accounts. Serving other people needs vendor/commercial key tiers (more approval). For anything past your own accounts, an aggregator is less friction than N direct integrations.
+
+---
+
+## 4. Crypto & the manual fallback — the realistic path
+
+**Two legitimate crypto read paths, both solo-dev accessible:**
+1. **Self-mint read-only exchange keys** (you're the account owner, no approval): Coinbase "View" (now via CDP/Ed25519), Kraken "Query Funds," Binance.US "Enable Reading," Gemini auditor-scoped. Read-only = balances + history, cannot trade or withdraw. Support IP-whitelisting and key rotation/revocation.
+2. **A crypto aggregator** to collapse N integrations: **Vezgo** (instant free self-service keys, ~300 exchanges/wallets/chains, read-only) is the most solo-dev-friendly. For on-chain address reads, **Zerion** has the most generous no-card free tier (~60k calls/mo); Zapper / GoldRush(Covalent) / Moralis also have free tiers; a block explorer covers single-chain reads for free.
+
+**On-chain wallets are a distinct credential shape** — a public address string with **no secret**. Do not force them through the api-key model.
+
+**Manual entry is the universal fallback and belongs in the schema regardless.** Every reference app (Kubera, Empower, Monarch, Simplifi, Maybe) ships three crypto on-ramps: read-only API key, public wallet address, and manual entry. Manual is also the *only* way to represent real estate, vehicles, collectibles, private/illiquid holdings, **and the graceful degradation path for any Fidelity/crypto source that won't connect.**
+
+**Model valuations as periodic, source-tagged, point-in-time snapshots** — `(asset_id, as_of_date, value, source)` where source ∈ {manual, zillow, kbb, exchange_api, onchain, plaid, snaptrade}. Net-worth-over-time is derived from the series of snapshots, not a single mutable balance. Maybe finance's immutable-Entry/Valuation → materialized-balance-cache pattern is the clean reference. Automated valuations (crypto ~8h, Zillow weekly) are just scheduled refreshes writing into the same table as a human typing a number.
+
+---
+
+## 5. Recommendation for THIS build
+
+**Ship Plaid-first, behind a provider-polymorphic connection layer.** Concretely:
+
+1. **Start on Plaid's free Trial (10 Items).** It's the fastest path to real data, includes Investments, and is the one realistic self-serve route to **Vanguard**. Attempt Fidelity through it, but **assume it may not work** and wire the manual/CSV fallback for Fidelity from day one. Design onboarding around OAuth redirects and the 1-2 minute initial-sync delay, with a per-institution "supported?" capability check.
+
+2. **Build the abstraction so SnapTrade, Akoya-via-SnapTrade, direct keys, and manual all drop in with zero new tables.** The whole point: a solo dev can only *get approved for* Plaid (self-serve), SnapTrade (self-serve), direct broker keys for *your own* accounts (gated but obtainable), Coinbase/exchange read-only keys (instant), and manual (no third party). Everything else (Akoya direct, Yodlee, MX, Finicity) is enterprise-gated and off the table. The layer must route Fidelity → SnapTrade when Plaid fails, Vanguard → Plaid, crypto → exchange key/aggregator, and anything unsupported → manual.
+
+3. **The schema this requires (confirmed):**
+
+   - **`connections`** with a **type discriminator** so the read paths coexist: `provider` (plaid | snaptrade | coinbase | ibkr | schwab | etrade | vezgo | manual) and `connection_type` (oauth_access_token | api_key_secret | onchain_address | aggregator_token | manual). A **generic per-connection credential store, encrypted at rest** (reuse the codebase's AES-GCM rotation), holding whichever of {access_token} OR {api_key + secret + optional passphrase} OR {address string} applies — plus metadata: label, granted scopes (enforce/record read-only intent), last_synced_at, status, sync watermark, `cost_basis_available` flag.
+   - **A per-connection capability matrix** rather than assuming uniformity: `{read_positions, read_balances, read_transactions, read_cost_basis, trade_equities, trade_options, trade_crypto}`. Persist granted scope; enforce least privilege (store read-only vs trade-enabled tokens separately); keep any trading surface optional and gated behind explicit consent.
+   - **`accounts` + shared `securities` catalog + `holdings` (account x security) + `transactions`** — mirror Plaid's split, since SnapTrade normalizes to the same shape. Store `security_id` but reconcile on CUSIP/ISIN/ticker and expect it to change on corporate actions. Canonicalize the transaction taxonomy on ingest (every provider names buys/sells/dividends/transfers differently).
+   - **`manual_accounts` / other-assets** — universal fallback for Fidelity-that-won't-connect, real estate, vehicles, collectibles, private holdings.
+   - **`valuations`** — periodic, source-tagged, point-in-time `(asset_id, as_of_date, value, source)`; net-worth history derived from the series; one write path shared by manual, exchange, on-chain, and automated sources.
+
+4. **Treat everything tax-related as optional/nullable** (cost_basis, lots, vested, realized gain/loss). Make the net-worth/allocation view work on balances+holdings+prices alone; gate tax features behind data-present checks.
+
+5. **Cost discipline:** Plaid bills per-Item per-month per-subscription (transactions doubles it via the implicit Holdings sub) — cache deliberately, use Refresh sparingly, delete stale Items to stop the meter. SnapTrade bills per active user (pick $1 daily read-only for a tracker). Direct/exchange keys are free.
+
+**Honest summary of what you can actually get today, no sales calls:** Plaid Trial (10 live Items, includes Investments, real data), SnapTrade free tier then $1-2/user/mo, Coinbase/Kraken/Binance/Gemini read-only keys (instant), Vezgo/Zerion free crypto aggregation, and IBKR/Schwab/E*TRADE keys for your *own* accounts (obtainable but with approval latency). What you cannot get: Akoya/Yodlee/MX/Finicity production, a Fidelity or Vanguard first-party retail API, or an official Robinhood equities API. Plan around those four "no"s and the Fidelity-via-Plaid coin-flip, and the build is very achievable solo.

--- a/docs/plans/finance-service/finance-schema-canonical.md
+++ b/docs/plans/finance-service/finance-schema-canonical.md
@@ -1,0 +1,1324 @@
+# Finance Service — Canonical Schema (v1)
+
+> The single load-bearing artifact for the finance aggregator. 33 tables ship up front; the
+> owner's #1 rule is **never add a finance table later**, so reserved-but-empty tables ship
+> now and get populated when their feature lands.
+>
+> **TARGET = aegis-stack template service (`include_finance`).** This schema is authored TWICE
+> in the template, and both must agree (there is precedent + a parity discipline for this):
+> 1. **Runtime models** — `app/services/finance/models.py` in the template tree (a `.jinja` where
+>    provider-conditional blocks are needed), bound to `SQLModel.metadata`, imported behind
+>    `{% if include_finance %}` in `alembic/env.py.jinja` so SQLite `create_all` + autogenerate see them.
+> 2. **The migration** — NOT a hand-written `031_finance.py`. In aegis-stack, migrations are
+>    **generated from declarative Python specs** (`aegis/core/migration_generator.py`): a
+>    `FINANCE_MIGRATION = ServiceMigrationSpec(service_name="finance", tables=[TableSpec(...) × 33],
+>    alter_tables=[...], schema="finance")`. **Revision IDs are auto-assigned** (sequential, in
+>    service-toggle order) so the chain stays valid for any `include_*` combination — do NOT hardcode
+>    a revision number. Each table below maps to a `TableSpec`; each index → `IndexSpec` (partial
+>    uniques use `where=`, rendered as BOTH `sqlite_where` + `postgresql_where`); each check →
+>    `CheckConstraintSpec`; each FK → `ForeignKeySpec` (`ondelete=`, and `ref_schema="auth"` for the
+>    cross-schema `owner_user_id → auth.user.id` FK, mirroring `payment.payment_customer → auth.user`);
+>    the one circular FK (`finance_transaction.transfer_group_id ↔ finance_transfer.id`) is an
+>    `AlterTableSpec` applied after both tables exist (the `use_alter` equivalent).
+>
+> **Dual-engine:** the template targets **sqlite OR postgres**. Everything below is expressed to work
+> on both — partial-unique indexes (both engines support `CREATE INDEX ... WHERE`), CHECK constraints,
+> and `insert(...).on_conflict_do_update(...)` (dialect-dispatched: `sqlite.insert` vs `postgresql.insert`
+> in the service layer). Finance tables live in a Postgres `finance` schema (ignored on SQLite).
+>
+> Conventions are locked by `finance-research/00-codebase-conventions.md` and obeyed verbatim:
+> `int` autoincrement PKs (no UUID); money = `int` minor units + a `currency` code; naive-UTC
+> timestamps via `utcnow_naive()`; enums = `String` + `CheckConstraint` for small OWNED closed sets,
+> plain `TEXT` (no check) for growing provider taxonomies; JSON via `sa_column`; every user-scoped row
+> carries `owner_user_id` + nullable `organization_id`; every FK indexed (currency FK is the one
+> documented exception — see §0.4). `owner_user_id`/`organization_id` FKs exist only when `include_auth`
+> (finance declares auth a required service).
+
+---
+
+## 0. Modeling decisions (the stance, and why)
+
+Each decision follows the adversarial critique's recommendation. Deviations are stated explicitly.
+
+### 0.1 Single-entry, not double-entry
+**Chosen: single-entry.** One signed, sign-normalized row per financial event in `finance_transaction`,
+plus an explicit `finance_transfer` pairing table and a `finance_transaction_split` child table.
+Design 2's `finance_posting` / sum-to-zero ledger is **rejected**: 95% of rows are imported
+(Plaid/OFX/CSV deliver ONE signed row + a balance, never the contra leg), a sum-to-zero invariant
+cannot be a SQL `CHECK` across sibling rows anyway (so it lives in the service either way), and
+every report would have to join through postings. Transfers and splits recover double-entry's two
+correctness wins without shaping the whole ledger around them.
+
+### 0.2 Money = int minor units; fractional quantities/rates/prices = scaled integers
+**Chosen: `int` minor units everywhere for cash**, and **scaled integers** (never `Decimal`/`Numeric`)
+for the three things cents can't hold:
+- share/crypto **quantity** → `quantity_e8` (`int`, units × 1e8),
+- **FX rate** → `rate_e8` (`int`, rate × 1e8),
+- security **price** → `price` (`int` minor units) + a `price_scale` exponent (default = currency
+  `decimals`, larger for sub-cent/crypto).
+
+The `Numeric(38,18)`/`Numeric(28,12)` columns in Designs 2 and 4 are a real convention violation
+("ZERO Decimal/Numeric money usage in the codebase — match this"), not a principled exception.
+Scaled integers stay integer-deterministic and convention-clean.
+
+### 0.3 Balances/net-worth = MATERIALIZED, never derived live
+**Chosen: materialize both grains.** A per-account daily `finance_balance_snapshot` (upsert;
+carry-forward on failed sync) **and** a per-user daily `finance_net_worth_snapshot` rollup
+(cash/investments/other subtotals). A background job recomputes both; the headline chart is one
+indexed range scan (`SELECT as_of_date, net_worth_amount ... WHERE owner_user_id=? ORDER BY as_of_date`),
+never a fold over dozens of accounts (mind the worker-OOM history — keep recompute payloads bounded).
+Imported accounts give only a current balance + partial history, so last March's balance is
+**unreconstructable** from transactions — the snapshot is a persistence problem you cannot retrofit.
+The provider-reported balance on `finance_account` is authoritative; transactions are the itemization,
+never summed to a displayed balance.
+
+### 0.4 Holdings = DATED snapshot, not current-only upsert
+**Chosen: `UNIQUE(account_id, security_id, as_of_date)`.** Current value reads the latest date;
+historical rows feed allocation-over-time. Design 1/2/4's current-only `UNIQUE(account_id, security_id)`
+throws away allocation history you can never retrofit — the exact net-worth-history trap applied to
+positions. (Currency is intentionally NOT in the holding dedup key: one position per security per
+day; a position does not fork by currency.)
+
+### 0.5 Plaid PFC — adopt as seed, own the runtime tree
+**Chosen:** store raw `pfc_primary` / `pfc_detailed` as plain `TEXT` (no check — PFC keeps expanding)
+on `finance_transaction`, AND map to an OWNED 2-level `finance_category` tree seeded from PFC's
+16 primary / 104 detailed. `finance_category_alias` maps free-text QIF/Chase/AMEX/PFC strings onto
+canonical categories; unmatched → the seeded `uncategorized` row. `category_source` precedence is a
+hard contract: `provider → ml → rule → user`, and **re-sync must never clobber a user override**
+(`is_user_categorized=true` freezes `category_id`).
+
+### 0.6 Transfers, splits, pending — the three correctness traps
+- **Transfer / credit-card-payment double-count** (the #1 credibility bug): `finance_transfer`
+  pairs two legs (`from_transaction_id`/`to_transaction_id`, each PARTIAL-UNIQUE so a leg joins at
+  most one transfer), sets `is_transfer=true` + `excluded_from_reports=true` on both legs, carries a
+  `confidence` score and `match_method`. Cash-flow/income aggregates filter `is_transfer=false`; net
+  worth is naturally immune. **Suggest-and-confirm below a high confidence threshold** — never
+  silently zero money (Venmo-to-a-friend and one-sided legs are real spend).
+- **Splits:** `finance_transaction_split` child rows; parent `is_split=true` and parent `category_id`
+  NULL when split; service enforces `SUM(split.amount) == parent.amount`. Content-hash dedup stays at
+  the PARENT grain so a multi-leg QIF row is one idempotent unit.
+- **Pending → posted** (a DELETE+INSERT with different ids): the posted row carries
+  `pending_provider_id` (Plaid `pending_transaction_id`) and a self-FK `pending_transaction_id`; on
+  arrival the pending predecessor is soft-deleted (`deleted_at`, `is_removed=true`). **Mutable upsert +
+  soft-delete, never append-only-immutable** — banks edit and delete the past (`modified` → in-place
+  patch, `removed` → tombstone that survives re-sync). `raw_amount` + `raw_sign_convention` preserve
+  the source's original so a mis-read sign is a re-derivation, not data loss.
+
+### 0.7 Provider-polymorphic connection = ONE fat row
+**Chosen:** one `finance_connection` row with credentials as INLINE encrypted columns
+(`access_token_encrypted`, `api_key_encrypted`, `api_secret_encrypted`, `api_passphrase_encrypted`,
+`refresh_token_encrypted`, plaintext `wallet_address`), a JSON `capabilities` matrix, and inline
+`status`/health. This mirrors direct codebase precedent — the `Project` model already stores
+`github_token` + `plausible_api_key` inline-encrypted on one row. Design 3's separate
+credential + capability + link_session tables are over-normalized for a solo build; a JSONB
+capability matrix is queryable enough for v1. Ephemeral Plaid `link_token`/`public_token`
+(~4h/30m) go in **Redis**, not a durable encrypted table.
+
+### 0.8 "Wasting money" insights — reuse `insight_event` now, ship `finance_insight` RESERVED
+**Chosen:** emit v1 rule-based signals (recurring/subscription, price-hike, fee/interest, category
+overspend, spending anomaly) through the EXISTING `app/services/insights/` `insight_event` machinery
+(the country-spike rule pattern) — ships without AI (`include_ai: false`). Ship `finance_insight`
+**reserved** for finance-specific `dedup_key` idempotency + typed `related_*` FKs when that surface
+matures and is AI-ready for Illiana. Do NOT build ML tables (`category_correction`) — no ML layer
+exists.
+
+### 0.9 Currency PK shape + width
+**Chosen:** `int` autoincrement `id` PK + `UNIQUE(code)`, and **`code` widened to `str(16)`** so
+crypto tickers (USDC, USDT, MATIC) fit. Design 2/4's string-code PK deviates from the int-PK rule;
+Design 1/3's `str(3)` cannot hold crypto tickers though crypto is in scope. `code` is stored/seeded
+**lowercase** (`usd`, `btc`) to match the convention example. Every money column carries a
+`currency: str(16)` FK to `finance_currency.code`.
+
+### 0.10 Deliberate FK-index exception
+Convention says "every FK indexed." The **`currency` FK is the one documented exception** — it is
+low-cardinality (a handful of distinct codes) and indexing it is near-useless. `currency` FKs are
+declared `ON DELETE RESTRICT` and **left unindexed** by policy, applied uniformly across all tables.
+Every OTHER FK — including all self-FKs (`pending_transaction_id`, `canonical_transaction_id`,
+`transfer_group_id`, `reverses_transaction_id`, `parent_id`) and the trailing FK of every join
+table — carries an explicit `ix_`.
+
+---
+
+## 1. Table catalog
+
+Legend: **[v1]** = populated at launch · **[reserved]** = shipped now, empty until its feature lands.
+All tables are `finance_`-prefixed (avoids collision with the shared `SQLModel.metadata` namespace —
+`insight_*`, `blog_*`, `payment_*`, and future services). All money columns are `int` minor units;
+all `*_at` are naive-UTC (`utcnow_naive()`); all `metadata_` map to a DB column named `"metadata"`.
+
+Standard trailing columns on every table (omitted from the per-column lists below to reduce noise):
+`created_at: datetime` and, where the row is mutable, `updated_at: datetime`, both
+`default_factory=utcnow_naive`.
+
+---
+
+## GROUP A — Connections & Sync
+
+### `finance_institution` [v1]
+Provider-agnostic institution directory (Chase, AMEX, Fidelity, Vanguard, Robinhood, Coinbase).
+Shared/global reference — NOT user-scoped. Carries the capability flags the domain brief mandates.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | autoincrement |
+| provider | str(16) String+Check | which aggregator surfaced it (a row per provider view of an institution) |
+| provider_institution_id | text | nullable; Plaid `ins_xxx` / SnapTrade brokerage id. Growing → TEXT. Dedup component |
+| name | str(128) | "Chase", "American Express" |
+| domain | str(255) | nullable; primary web domain (cross-provider identity hint) |
+| logo_url | text | nullable |
+| primary_color | str(16) | nullable hex |
+| url | text | nullable |
+| country | str(2) | nullable; ISO-3166 alpha-2 |
+| oauth_required | bool | default false; Chase + AMEX are true (bank-hosted OAuth) |
+| uses_tokenized_account_numbers | bool | default false; Chase TANs — don't treat as real routing # |
+| uses_app_to_app | bool | default false; Chase mobile |
+| supported_products | json | list, e.g. `["transactions","balance","liabilities","investments"]`; AMEX = assets/balance/transactions only |
+| metadata_ | json | `Column("metadata", JSON)`; raw provider institution blob |
+
+- **FKs:** none.
+- **Indices:** `ix_finance_institution_provider (provider)`, `ix_finance_institution_name (name)`.
+- **Unique:** `uq_finance_institution_provider_extid UNIQUE(provider, provider_institution_id) WHERE provider_institution_id IS NOT NULL` (partial).
+- **Checks:** `ck_finance_institution_provider: provider IN ('plaid','snaptrade','coinbase','exchange_key','onchain','manual')`.
+
+### `finance_connection` [v1]
+Provider-polymorphic connection (Plaid Item | SnapTrade authorization | exchange api-key | on-chain
+wallet | manual). ONE fat row: inline AES-GCM-encrypted credential columns + JSON capability matrix +
+inline health/status + the Plaid item-level sync cursor. **Register the encrypted columns in the
+key-rotation CLI** (§6.3); `__repr__` masks them.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | AAD context base: `finance_connection:{id}:{column}` |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| institution_id | int? FK finance_institution.id | nullable, indexed; SET NULL |
+| provider | str(16) String+Check | polymorphic discriminator |
+| connection_type | str(20) String+Check | credential shape: `oauth_access_token`\|`api_key_secret`\|`onchain_address`\|`aggregator_token`\|`manual` |
+| provider_item_id | text | nullable; Plaid `item_id` / SnapTrade `authorizationId`. Stable per-connection dedup key. Growing → TEXT |
+| label | str(255) | nullable; user label ("Chase (personal)") |
+| environment | str(16) String+Check | `sandbox`\|`production`; Items can't move between envs |
+| access_token_encrypted | text | nullable CIPHERTEXT (Plaid access_token / SnapTrade userSecret). Masked in `__repr__` |
+| api_key_encrypted | text | nullable CIPHERTEXT (exchange key) |
+| api_secret_encrypted | text | nullable CIPHERTEXT (exchange secret) |
+| api_passphrase_encrypted | text | nullable CIPHERTEXT (Coinbase-style passphrase) |
+| refresh_token_encrypted | text | nullable CIPHERTEXT (OAuth refresh) |
+| wallet_address | text | nullable PLAINTEXT public on-chain address (not a secret) |
+| wallet_chain | text | nullable; `ethereum`/`bitcoin`/`solana`. Growing → TEXT |
+| capabilities | json | `Column("capabilities", JSON)`; matrix `{read_transactions,read_balances,read_investments,read_liabilities,read_cost_basis,trade_*: bool}` |
+| status | str(24) String+Check | connection health |
+| status_detail | text | nullable; provider error message |
+| last_error_code | text | nullable; `ITEM_LOGIN_REQUIRED` etc. Growing → TEXT |
+| needs_user_action | bool | default false, indexed; drive reauth UI off THIS, not raw error strings |
+| sync_cursor | text | nullable; Plaid `/transactions/sync` `next_cursor` (item-level, opaque ≤256). Idempotent re-sync |
+| days_requested | int? | nullable; max history requested up front — **cannot be cheaply extended later** |
+| consent_expiration_at | datetime? | nullable; Plaid consent/OAuth expiry. Do NOT hardcode 90d |
+| last_successful_sync_at | datetime? | nullable; carry-forward balance source on failure |
+| last_sync_attempt_at | datetime? | nullable |
+| removed_at | datetime? | nullable; `/item/remove` teardown (stops per-Item monthly billing) |
+| deleted_at | datetime? | nullable, indexed; soft-delete |
+| metadata_ | json | `Column("metadata", JSON)` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `institution_id → finance_institution.id` SET NULL (idx).
+- **Indices:** `ix_finance_connection_owner (owner_user_id)`, `ix_finance_connection_org (organization_id)`, `ix_finance_connection_institution (institution_id)`, `ix_finance_connection_needs_action (needs_user_action)`, `ix_finance_connection_deleted (deleted_at)`, `ix_finance_connection_owner_status (owner_user_id, status)`.
+- **Unique:** `uq_finance_connection_provider_item UNIQUE(provider, provider_item_id) WHERE provider_item_id IS NOT NULL AND deleted_at IS NULL` (partial); `uq_finance_connection_wallet UNIQUE(owner_user_id, provider, wallet_address) WHERE wallet_address IS NOT NULL` (partial).
+- **Checks:** `ck_finance_connection_provider: provider IN ('plaid','snaptrade','coinbase','exchange_key','onchain','manual')`; `ck_finance_connection_type: connection_type IN ('oauth_access_token','api_key_secret','onchain_address','aggregator_token','manual')`; `ck_finance_connection_environment: environment IN ('sandbox','production')`; `ck_finance_connection_status: status IN ('healthy','login_required','pending_expiration','pending_disconnect','consent_expired','revoked','error','loading','manual')`.
+
+### `finance_webhook_event` [v1]
+Idempotent inbound provider-webhook log; drives per-Item sync enqueue and is the replay/debug buffer.
+Dedups on `provider_event_id` so a re-delivered webhook is a no-op.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| connection_id | int? FK finance_connection.id | nullable, indexed; may arrive before Item mapped. CASCADE |
+| provider | str(16) String+Check | |
+| provider_item_id | text | nullable, indexed; Plaid `item_id` correlator |
+| webhook_type | text | `TRANSACTIONS`, `ITEM`, `HOLDINGS`. Growing → TEXT |
+| webhook_code | text | `SYNC_UPDATES_AVAILABLE` etc. Growing → TEXT |
+| provider_event_id | text | nullable; idempotency dedup key |
+| payload | json | `Column("payload", JSON)`; raw body |
+| status | str(16) String+Check | `received`\|`processed`\|`ignored`\|`error` |
+| error | text | nullable |
+| received_at | datetime | default `utcnow_naive` |
+| processed_at | datetime? | nullable |
+
+- **FKs:** `connection_id → finance_connection.id` CASCADE (idx).
+- **Indices:** `ix_finance_webhook_connection (connection_id)`, `ix_finance_webhook_item (provider_item_id)`, `ix_finance_webhook_status_received (status, received_at)`.
+- **Unique:** `uq_finance_webhook_event UNIQUE(provider, provider_event_id) WHERE provider_event_id IS NOT NULL` (partial).
+- **Checks:** `ck_finance_webhook_provider: provider IN ('plaid','snaptrade','coinbase')`; `ck_finance_webhook_status: status IN ('received','processed','ignored','error')`.
+
+---
+
+## GROUP B — Accounts & Balances
+
+### `finance_account` [v1]
+One row per provider account AND per manual asset (`is_manual=true` covers real estate/vehicle/
+crypto/private). Provider-reported balance is authoritative. Normalized `account_type` +
+`classification` are STORED for fast net-worth signing; Plaid `type`/`subtype` are plain TEXT.
+`connection_id` NULL ⇒ manual.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| connection_id | int? FK finance_connection.id | nullable, indexed; NULL=manual. CASCADE |
+| institution_id | int? FK finance_institution.id | nullable, indexed; SET NULL |
+| provider | str(16) String+Check | denormalized source |
+| provider_account_id | text | nullable; Plaid/SnapTrade account id (stable within Item). Growing → TEXT. Dedup key |
+| persistent_account_id | text | nullable, indexed; **stable across relinks** — a re-linked Item mints a new `provider_account_id`; this prevents duplicate accounts + a broken net-worth line |
+| name | str(255) | display name |
+| official_name | str(255) | nullable |
+| mask | str(8) | nullable; last-4 |
+| type | text | Plaid top-level `depository`/`credit`/`loan`/`investment`/`other`. Growing → TEXT |
+| subtype | text | nullable; Plaid subtype (checking/savings/hsa/401k/roth/brokerage/crypto/mortgage/...). Growing → TEXT |
+| account_type | str(24) String+Check | normalized internal type for signing/UI |
+| classification | str(12) String+Check | `asset`\|`liability`; STORED for net-worth sign |
+| currency | str(16) FK finance_currency.code | native currency; RESTRICT (unindexed) |
+| current_balance | int? | nullable; provider-reported, authoritative |
+| available_balance | int? | nullable |
+| credit_limit | int? | nullable; NULL for AMEX charge cards |
+| balance_as_of | datetime? | nullable; freshness of current balance |
+| is_manual | bool | default false |
+| is_hidden | bool | default false; exclude from net worth |
+| is_closed | bool | default false |
+| is_on_budget | bool | default true |
+| linked_at | datetime? | nullable; "history starts here" |
+| last_synced_at | datetime? | nullable |
+| deleted_at | datetime? | nullable, indexed; soft-delete |
+| metadata_ | json | `Column("metadata", JSON)`; real-estate address / VIN for manual assets |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `connection_id → finance_connection.id` CASCADE (idx); `institution_id → finance_institution.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_account_owner (owner_user_id)`, `ix_finance_account_org (organization_id)`, `ix_finance_account_connection (connection_id)`, `ix_finance_account_institution (institution_id)`, `ix_finance_account_persistent (persistent_account_id)`, `ix_finance_account_deleted (deleted_at)`, `ix_finance_account_owner_type (owner_user_id, account_type)`, `ix_finance_account_owner_classification (owner_user_id, classification)`.
+- **Unique:** `uq_finance_account_provider UNIQUE(connection_id, provider_account_id) WHERE provider_account_id IS NOT NULL AND deleted_at IS NULL` (partial).
+- **Checks:** `ck_finance_account_type: account_type IN ('checking','savings','credit_card','loan','investment','brokerage','crypto','property','vehicle','cash','other_asset','other_liability')`; `ck_finance_account_classification: classification IN ('asset','liability')`; `ck_finance_account_provider: provider IN ('plaid','snaptrade','coinbase','exchange_key','onchain','manual')`.
+
+### `finance_liability_detail` [v1]
+1:1 per credit/loan account — statement balance, minimum payment, due dates, APR array. Chase
+Liabilities is in launch scope; **AMEX fields are NULL** (gated on `supported_products`). APR array
+is a JSON column (not a child table — APR-by-type is not a relational query). Upserted per pull.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| account_id | int FK finance_account.id | indexed, UNIQUE (1:1); CASCADE |
+| liability_type | text | `credit`\|`mortgage`\|`student`. Growing → TEXT |
+| last_statement_balance | int? | nullable |
+| last_statement_issue_date | date? | nullable |
+| last_payment_amount | int? | nullable |
+| last_payment_date | date? | nullable |
+| minimum_payment_amount | int? | nullable |
+| next_payment_due_date | date? | nullable |
+| origination_date | date? | nullable (loans) |
+| origination_principal | int? | nullable (loans) |
+| outstanding_balance | int? | nullable |
+| interest_rate_bps | int? | nullable; basis points (avoids Decimal) |
+| ytd_interest_paid | int? | nullable |
+| ytd_principal_paid | int? | nullable |
+| loan_term_months | int? | nullable |
+| is_overdue | bool? | nullable |
+| aprs | json | `Column("aprs", JSON)`; list of `{apr_type, apr_percentage_bps, balance_subject_to_apr, interest_charge_amount}` — Plaid APR array folded into JSON |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| raw | json | `Column("raw", JSON)`; full Plaid liabilities payload |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `account_id → finance_account.id` CASCADE (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_liability_owner (owner_user_id)`, `ix_finance_liability_account (account_id)`.
+- **Unique:** `uq_finance_liability_account UNIQUE(account_id)`.
+- **Checks:** none (all growing/typed).
+
+### `finance_balance_snapshot` [v1]
+THE net-worth-over-time primitive: materialized daily balance per account, recomputed/upserted by a
+background job (carried-forward on days with no provider update). `owner_user_id` denormalized for
+per-user timeline scans.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| account_id | int FK finance_account.id | indexed; CASCADE. Dedup key with `balance_date` |
+| owner_user_id | int FK user.id | indexed; CASCADE. Denormalized |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| balance_date | date | the day this balance represents |
+| balance | int | net balance that day (asset +, liability magnitude by convention) |
+| available_balance | int? | nullable |
+| cash_balance | int? | nullable; investment cash portion |
+| holdings_value | int? | nullable; market value of positions |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| base_currency_value | int? | nullable; converted to user base currency via `finance_fx_rate` (filled when multi-currency active) |
+| source | str(16) String+Check | how obtained |
+| is_estimated | bool | default false; true for carried-forward/interpolated gap fill |
+
+- **FKs:** `account_id → finance_account.id` CASCADE (idx); `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_balsnap_account_date (account_id, balance_date)`, `ix_finance_balsnap_owner_date (owner_user_id, balance_date)`.
+- **Unique:** `uq_finance_balsnap UNIQUE(account_id, balance_date)`.
+- **Checks:** `ck_finance_balsnap_source: source IN ('sync','provider','computed','carried_forward','manual')`.
+
+### `finance_net_worth_snapshot` [v1]
+Per-user daily net-worth rollup so the headline chart is O(1). Recomputed by the same job that fills
+`finance_balance_snapshot`, aggregating accounts + holdings + manual-asset valuations.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| as_of_date | date | rollup day |
+| total_assets_amount | int | sum of asset accounts |
+| total_liabilities_amount | int | sum of liability accounts (stored positive magnitude) |
+| net_worth_amount | int | assets − liabilities |
+| cash_amount | int? | nullable; depository subtotal |
+| investments_amount | int? | nullable; investment subtotal |
+| other_assets_amount | int? | nullable; manual assets subtotal |
+| currency | str(16) FK finance_currency.code | reporting currency; RESTRICT (unindexed) |
+| breakdown | json | `Column("breakdown", JSON)`; per-account-type subtotals |
+| is_estimated | bool | default false; true if any input was estimated/stale |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_networth_owner_date (owner_user_id, as_of_date)`, `ix_finance_networth_org_date (organization_id, as_of_date)`.
+- **Unique:** `uq_finance_networth UNIQUE(owner_user_id, as_of_date, currency)`.
+- **Checks:** none.
+
+### `finance_valuation` [v1]
+Source-tagged dated-value time series unifying manual/off-aggregator assets (real estate, vehicles,
+crypto marks, private holdings) as "a dated value" with staleness tracking. Feeds the balance-snapshot
+recompute for non-transactional assets. One value per account/day/source.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE. Denormalized |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| account_id | int FK finance_account.id | indexed; CASCADE. The manual-asset account being valued |
+| as_of_date | date | date the value is asserted for |
+| value | int | asset value that day |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| source | str(16) String+Check | valuation source |
+| source_ref | text | nullable; Zillow URL/zpid, wallet address, VIN |
+| is_estimate | bool | default false; AVM/estimate vs confirmed |
+| fetched_at | datetime? | nullable; when the source produced it (staleness clock) |
+| is_stale | bool | default false; set by staleness job |
+| stale_after_days | int? | nullable; per-asset freshness budget |
+| note | text | nullable |
+| metadata_ | json | `Column("metadata", JSON)` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `account_id → finance_account.id` CASCADE (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_valuation_owner_date (owner_user_id, as_of_date)`, `ix_finance_valuation_account_date (account_id, as_of_date)`, `ix_finance_valuation_source (source)`.
+- **Unique:** `uq_finance_valuation UNIQUE(account_id, as_of_date, source)`.
+- **Checks:** `ck_finance_valuation_source: source IN ('manual','zillow','kbb','exchange_api','onchain','plaid','snaptrade','coingecko','reconciliation')`.
+
+---
+
+## GROUP C — Transactions & Categorization
+
+### `finance_transaction` [v1]
+The core single-entry cash ledger (depository + credit + charge). Mutable upsert + soft-delete.
+Dual-lane deterministic dedup (provider-id OR content-hash), lossless cross-source collapse, pending
+linkage, transfer pairing, refunds, splits. `raw_payload` always persisted (re-derive without re-billing).
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| account_id | int FK finance_account.id | indexed; CASCADE. Dedup-scope root |
+| connection_id | int? FK finance_connection.id | nullable, indexed; SET NULL. Provenance |
+| import_batch_id | int? FK finance_import_batch.id | nullable, indexed; SET NULL. Reversible batch |
+| source | str(16) String+Check | dedup discriminator + LANE-1 key part |
+| external_id | text | nullable; Plaid `transaction_id` / OFX `FITID` / SnapTrade id. **LANE-1 dedup, account-scoped (FITID never global)**. Growing → TEXT |
+| external_id_source | text | nullable; which id namespace (`plaid`\|`fitid`\|`snaptrade`) |
+| import_hash | str(64) | nullable; sha256 content hash for id-less rows (QIF/CSV/manual). **LANE-2 dedup** |
+| within_day_ordinal | int | default 0; disambiguates identical same-day/amount/payee rows — **assigned within a deterministic sort (date, amount, normalized_payee, memo), NEVER file order** (so an overlapping re-export doesn't shift every hash) |
+| dedup_status | str(16) String+Check | cross-source collapse marker; default `unique` |
+| canonical_transaction_id | int? FK finance_transaction.id (self) | nullable, indexed; SET NULL. Duplicate → its primary |
+| source_precedence | int | default 0; higher wins on collapse (plaid/snaptrade=100 > ofx=70 > qif=50 > csv=40 > manual=30) |
+| amount | int | **SIGN-NORMALIZED**: negative=outflow/spend, positive=inflow (house rule) |
+| raw_amount | int? | nullable; exactly as the source delivered (audit / re-derivation) |
+| raw_sign_convention | text | nullable; how `raw_amount` was signed: `plaid`\|`ofx`\|`amex`\|`natural` |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| unofficial_currency_code | text | nullable; crypto/non-standard (Plaid) |
+| date | date | posted/settled date (OFX `DTPOSTED` / Plaid `date`) |
+| authorized_date | date? | nullable; when swiped — prefer for spending analytics |
+| datetime_ | datetime? | `Column("datetime")`; nullable precise timestamp |
+| name | text | cleaned display name/description |
+| original_description | text | nullable; raw bank memo (OFX `NAME`/`MEMO`, CSV description) — kept so re-normalization is always possible |
+| merchant_id | int? FK finance_merchant.id | nullable, indexed; SET NULL |
+| merchant_name | text | nullable; Plaid-enriched merchant string |
+| merchant_entity_id | text | nullable, indexed; Plaid stable merchant entity id |
+| memo | text | nullable; part of content hash |
+| check_number | str(32) | nullable; OFX `CHECKNUM`; part of content hash |
+| payment_channel | text | nullable; `online`/`in store`/`other`. Growing → TEXT |
+| pfc_primary | text | nullable; raw Plaid PFC primary (16). Growing → TEXT |
+| pfc_detailed | text | nullable; raw Plaid PFC detailed (104). Growing → TEXT |
+| pfc_confidence_level | text | nullable |
+| category_id | int? FK finance_category.id | nullable, indexed; SET NULL. Effective category (NULL when `is_split`) |
+| category_source | str(12) String+Check | precedence guard; user override never clobbered |
+| is_user_categorized | bool | default false; freezes `category_id` against re-sync |
+| is_reviewed | bool | default false |
+| pending | bool | default false, indexed |
+| pending_provider_id | text | nullable; Plaid `pending_transaction_id` (posted row → its pending) |
+| pending_transaction_id | int? FK finance_transaction.id (self) | nullable, indexed; SET NULL. Internal pending predecessor |
+| status | str(12) String+Check | `pending`\|`posted`\|`removed` |
+| is_transfer | bool | default false, indexed; excluded from cash-flow |
+| transfer_group_id | int? FK finance_transfer.id | nullable, indexed; SET NULL, `use_alter=True` (breaks circular dep) |
+| transfer_pair_transaction_id | int? FK finance_transaction.id (self) | nullable, indexed; SET NULL. Direct other leg |
+| is_split | bool | default false |
+| excluded_from_reports | bool | default false |
+| is_reversal | bool | default false; refund/reversal |
+| reverses_transaction_id | int? FK finance_transaction.id (self) | nullable, indexed; SET NULL. Original charge this reverses (link, don't auto-net) |
+| recurring_stream_id | int? FK finance_recurring_stream.id | nullable, indexed; SET NULL. Back-ref (a txn belongs to ≤1 stream — no join table) |
+| reconciled_status | str(12) String+Check | 3-state: `uncleared`\|`cleared`\|`reconciled` (reconciled = locked) |
+| location | json | `Column("location", JSON, nullable=True)`; Plaid location — don't explode |
+| counterparties | json | `Column("counterparties", JSON, nullable=True)` |
+| raw_payload | json | `Column("raw_payload", JSON, nullable=True)`; full provider blob |
+| is_removed | bool | default false; Plaid `removed[]` / bank deletion |
+| removed_at | datetime? | nullable |
+| deleted_at | datetime? | nullable, indexed; soft-delete tombstone survives re-sync |
+| metadata_ | json | `Column("metadata", JSON)` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `account_id → finance_account.id` CASCADE (idx); `connection_id → finance_connection.id` SET NULL (idx); `import_batch_id → finance_import_batch.id` SET NULL (idx); `merchant_id → finance_merchant.id` SET NULL (idx); `category_id → finance_category.id` SET NULL (idx); `canonical_transaction_id → finance_transaction.id` SET NULL (idx, self); `pending_transaction_id → finance_transaction.id` SET NULL (idx, self); `transfer_group_id → finance_transfer.id` SET NULL, `use_alter=True` (idx); `transfer_pair_transaction_id → finance_transaction.id` SET NULL (idx, self); `reverses_transaction_id → finance_transaction.id` SET NULL (idx, self); `recurring_stream_id → finance_recurring_stream.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_txn_owner_date (owner_user_id, date)`, `ix_finance_txn_account_date (account_id, date)`, `ix_finance_txn_owner_cat_date (owner_user_id, category_id, date)`, `ix_finance_txn_merchant (merchant_id)`, `ix_finance_txn_merchant_entity (merchant_entity_id)`, `ix_finance_txn_category (category_id)`, `ix_finance_txn_connection (connection_id)`, `ix_finance_txn_batch (import_batch_id)`, `ix_finance_txn_recurring (recurring_stream_id)`, `ix_finance_txn_transfer_group (transfer_group_id)`, `ix_finance_txn_canonical (canonical_transaction_id)`, `ix_finance_txn_pending_link (pending_transaction_id)`, `ix_finance_txn_pair (transfer_pair_transaction_id)`, `ix_finance_txn_reverses (reverses_transaction_id)`, `ix_finance_txn_pending (pending)`, `ix_finance_txn_is_transfer (is_transfer)`, `ix_finance_txn_deleted (deleted_at)`.
+- **Unique:** `uq_finance_txn_external UNIQUE(account_id, source, external_id) WHERE external_id IS NOT NULL AND deleted_at IS NULL` (partial, LANE 1); `uq_finance_txn_hash UNIQUE(account_id, import_hash) WHERE external_id IS NULL AND import_hash IS NOT NULL AND deleted_at IS NULL` (partial, LANE 2).
+- **Checks:** `ck_finance_txn_source: source IN ('plaid','snaptrade','ofx','qfx','qif','csv','manual','coinbase','onchain','simplefin','teller')`; `ck_finance_txn_status: status IN ('pending','posted','removed')`; `ck_finance_txn_dedup_status: dedup_status IN ('unique','primary','duplicate','linked')`; `ck_finance_txn_category_source: category_source IN ('provider','ml','rule','user','unset')`; `ck_finance_txn_reconciled: reconciled_status IN ('uncleared','cleared','reconciled')`; **`ck_finance_txn_dedup_lane: NOT (external_id IS NOT NULL AND import_hash IS NOT NULL)`** (a row occupies exactly one dedup lane — stops it evading both partial-uniques).
+
+### `finance_transaction_split` [v1]
+Child category legs of a split transaction. Service enforces `SUM(amount)==parent.amount`; parent
+`category_id` NULL + `is_split=true` when split so reporting never double-counts. Content-hash dedup
+stays at the parent grain.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| parent_transaction_id | int FK finance_transaction.id | indexed; CASCADE |
+| category_id | int? FK finance_category.id | nullable, indexed; SET NULL |
+| merchant_id | int? FK finance_merchant.id | nullable, indexed; SET NULL |
+| amount | int | signed portion (same convention); sums to parent |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| memo | text | nullable |
+| sort_order | int | default 0; deterministic ordering |
+| note | text | nullable |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `parent_transaction_id → finance_transaction.id` CASCADE (idx); `category_id → finance_category.id` SET NULL (idx); `merchant_id → finance_merchant.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_split_parent (parent_transaction_id)`, `ix_finance_split_owner (owner_user_id)`, `ix_finance_split_category (category_id)`, `ix_finance_split_merchant (merchant_id)`.
+- **Unique:** `uq_finance_split_parent_sort UNIQUE(parent_transaction_id, sort_order)`.
+- **Checks:** none.
+
+### `finance_transfer` [v1]
+Pairs the two legs of a transfer (the credit-card-payment double-count fix). Each leg PARTIAL-UNIQUE so
+it joins at most one transfer. Suggest-and-confirm below a high confidence threshold.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| from_account_id | int? FK finance_account.id | nullable, indexed; SET NULL |
+| to_account_id | int? FK finance_account.id | nullable, indexed; SET NULL |
+| from_transaction_id | int? FK finance_transaction.id | nullable, indexed; CASCADE. Outflow leg. Partial-UNIQUE |
+| to_transaction_id | int? FK finance_transaction.id | nullable, indexed; CASCADE. Inflow leg. Partial-UNIQUE |
+| amount | int? | nullable; abs transfer amount (legs may differ on fee/FX) |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| transfer_date | date? | nullable |
+| transfer_group_key | text | nullable, indexed; shared key across legs |
+| is_credit_card_payment | bool | default false; net card payments out of spend |
+| match_method | str(20) String+Check | `auto_amount_date`\|`plaid_transfer`\|`user_manual`\|`rule` |
+| confidence | int? | nullable 0-100 |
+| status | str(12) String+Check | `suggested`\|`confirmed`\|`rejected` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `from_account_id → finance_account.id` SET NULL (idx); `to_account_id → finance_account.id` SET NULL (idx); `from_transaction_id → finance_transaction.id` CASCADE (idx); `to_transaction_id → finance_transaction.id` CASCADE (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_transfer_owner (owner_user_id)`, `ix_finance_transfer_from_account (from_account_id)`, `ix_finance_transfer_to_account (to_account_id)`, `ix_finance_transfer_from_txn (from_transaction_id)`, `ix_finance_transfer_to_txn (to_transaction_id)`, `ix_finance_transfer_group_key (transfer_group_key)`.
+- **Unique:** `uq_finance_transfer_from UNIQUE(from_transaction_id) WHERE from_transaction_id IS NOT NULL` (partial); `uq_finance_transfer_to UNIQUE(to_transaction_id) WHERE to_transaction_id IS NOT NULL` (partial).
+- **Checks:** `ck_finance_transfer_method: match_method IN ('auto_amount_date','plaid_transfer','user_manual','rule')`; `ck_finance_transfer_status: status IN ('suggested','confirmed','rejected')`; `ck_finance_transfer_distinct: from_transaction_id IS NULL OR to_transaction_id IS NULL OR from_transaction_id <> to_transaction_id`.
+
+### `finance_category` [v1]
+Owned 2-level category tree seeded from Plaid PFC (16 primary / 104 detailed), user-editable.
+`owner_user_id` NULL = system/global seed. Self-referencing hierarchy.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int? FK user.id | nullable, indexed; NULL = system seed. CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| parent_id | int? FK finance_category.id (self) | nullable, indexed; SET NULL |
+| name | str(128) | display |
+| slug | str(96) | stable key; dedup with owner |
+| classification | str(12) String+Check | `income`\|`expense`\|`transfer` |
+| plaid_pfc_primary | text | nullable; for PFC auto-map. Growing → TEXT |
+| plaid_pfc_detailed | text | nullable. Growing → TEXT |
+| icon | str(64) | nullable |
+| color | str(16) | nullable hex |
+| is_system | bool | default false; seed row, not user-deletable |
+| is_archived | bool | default false |
+| sort_order | int | default 0 |
+| tax_line | text | nullable; reserved (Quicken tax lines arrive blank) |
+| metadata_ | json | `Column("metadata", JSON)` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `parent_id → finance_category.id` SET NULL (idx, self).
+- **Indices:** `ix_finance_category_owner (owner_user_id)`, `ix_finance_category_parent (parent_id)`, `ix_finance_category_pfc (plaid_pfc_detailed)`.
+- **Unique:** `uq_finance_category_system_slug UNIQUE(slug) WHERE owner_user_id IS NULL` (partial); `uq_finance_category_user_slug UNIQUE(owner_user_id, slug) WHERE owner_user_id IS NOT NULL` (partial).
+- **Checks:** `ck_finance_category_classification: classification IN ('income','expense','transfer')`.
+
+### `finance_category_alias` [v1]
+Free-text category string (QIF/Chase/AMEX/Plaid PFC) → canonical category. N:1 lookup keyed on
+normalized text; unmatched → seeded `uncategorized`.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int? FK user.id | nullable, indexed; NULL = global seed. CASCADE |
+| category_id | int FK finance_category.id | indexed; CASCADE |
+| alias_text | text | raw free-text string |
+| normalized_alias | text | indexed; lookup key |
+| source | text | `plaid_pfc`\|`quicken`\|`chase`\|`amex`\|`user`. Growing → TEXT |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `category_id → finance_category.id` CASCADE (idx).
+- **Indices:** `ix_finance_catalias_owner (owner_user_id)`, `ix_finance_catalias_category (category_id)`, `ix_finance_catalias_normalized (normalized_alias)`.
+- **Unique:** `uq_finance_catalias_owner_norm UNIQUE(owner_user_id, normalized_alias)`.
+- **Checks:** none.
+
+### `finance_merchant` [v1]
+Normalized payee directory — THE prerequisite for recurring/subscription detection. `owner_user_id`
+NULL = global/provider-seeded. Raw description stays on the transaction. `service_type` enables
+duplicate-service insights.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int? FK user.id | nullable, indexed; NULL = global. CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| name | str(255) | clean display |
+| normalized_name | str(255) | indexed; dedup key |
+| source | str(12) String+Check | `plaid`\|`user`\|`system`\|`rule`\|`snaptrade` |
+| provider_merchant_id | text | nullable; Plaid `merchant_entity_id`. Growing → TEXT |
+| logo_url | text | nullable |
+| website_url | text | nullable |
+| default_category_id | int? FK finance_category.id | nullable, indexed; SET NULL |
+| service_type | text | nullable; `music_streaming`\|`video_streaming`\|`gym`... (duplicate-service insight). Growing → TEXT |
+| deleted_at | datetime? | nullable, indexed; soft-delete |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `default_category_id → finance_category.id` SET NULL (idx).
+- **Indices:** `ix_finance_merchant_owner (owner_user_id)`, `ix_finance_merchant_org (organization_id)`, `ix_finance_merchant_normalized (normalized_name)`, `ix_finance_merchant_default_cat (default_category_id)`, `ix_finance_merchant_deleted (deleted_at)`.
+- **Unique:** `uq_finance_merchant_global UNIQUE(normalized_name) WHERE owner_user_id IS NULL AND deleted_at IS NULL` (partial); `uq_finance_merchant_user UNIQUE(owner_user_id, normalized_name) WHERE owner_user_id IS NOT NULL AND deleted_at IS NULL` (partial); `uq_finance_merchant_provider UNIQUE(source, provider_merchant_id) WHERE provider_merchant_id IS NOT NULL` (partial).
+- **Checks:** `ck_finance_merchant_source: source IN ('plaid','user','system','rule','snaptrade')`.
+
+### `finance_tag` [v1]
+First-class tags (Quicken `/Class` axis + user tags), orthogonal to categories.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| name | str(64) | display |
+| normalized_name | str(64) | dedup key |
+| color | str(16) | nullable hex |
+| deleted_at | datetime? | nullable, indexed |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx).
+- **Indices:** `ix_finance_tag_owner (owner_user_id)`, `ix_finance_tag_org (organization_id)`, `ix_finance_tag_deleted (deleted_at)`.
+- **Unique:** `uq_finance_tag_owner_name UNIQUE(owner_user_id, normalized_name) WHERE deleted_at IS NULL` (partial).
+- **Checks:** none.
+
+### `finance_transaction_tag` [v1]
+M2M join transaction ↔ tag, at split-line grain when `split_id` set. Composite PK (pure join table).
+
+| column | type | notes |
+|---|---|---|
+| transaction_id | int FK finance_transaction.id | PK part; CASCADE |
+| tag_id | int FK finance_tag.id | PK part; CASCADE |
+| split_id | int? FK finance_transaction_split.id | nullable, indexed; CASCADE. Tag at line level |
+| created_at | datetime | default |
+
+- **PK:** `(transaction_id, tag_id)`.
+- **FKs:** `transaction_id → finance_transaction.id` CASCADE (idx via PK lead); `tag_id → finance_tag.id` CASCADE (idx — trailing FK needs its own); `split_id → finance_transaction_split.id` CASCADE (idx).
+- **Indices:** `ix_finance_txntag_tag (tag_id)`, `ix_finance_txntag_split (split_id)`.
+- **Unique:** PK covers it.
+- **Checks:** none.
+
+### `finance_rule` [reserved]
+User automation rules (auto-categorize, mark-transfer, rename payee, ignore/flag), priority-ordered,
+conditions/actions as JSON. Precedence `provider → ml → rule → user`; setting up a recurring item
+auto-spawns a rule. Reserved until the rules UI ships.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| name | str(128) | |
+| priority | int | default 100, indexed; lower runs first |
+| is_enabled | bool | default true |
+| conditions | json | `Column("conditions", JSON)`; payee contains/starts/exact, amount range, day-of-month, account |
+| actions | json | `Column("actions", JSON)`; set category/payee/tags, link recurring, split, mark reviewed, delete (one-off) |
+| stop_processing | bool | default false |
+| match_count | int | default 0 |
+| last_matched_at | datetime? | nullable |
+| deleted_at | datetime? | nullable, indexed |
+| metadata_ | json | `Column("metadata", JSON)` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx).
+- **Indices:** `ix_finance_rule_owner (owner_user_id)`, `ix_finance_rule_org (organization_id)`, `ix_finance_rule_owner_priority (owner_user_id, priority)`, `ix_finance_rule_deleted (deleted_at)`.
+- **Unique:** none.
+- **Checks:** none (conditions/actions are JSON-validated in the service).
+
+---
+
+## GROUP D — Investments
+
+### `finance_security` [v1]
+Global (un-owned) securities catalog: equities, ETFs, funds, bonds, options, crypto. Per-provider ids
+reconciled to shared FIGI/CUSIP/ISIN so one instrument merges across users/providers. `security_type`
+is plain TEXT.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| provider | text | nullable; `plaid`\|`snaptrade`\|`coinbase`\|`manual`\|`market_data` |
+| provider_security_id | text | nullable; Plaid `security_id`. Dedup key (partial unique) |
+| figi | text | nullable; OpenFIGI. Cross-provider dedup key |
+| cusip | str(16) | nullable; dedup key |
+| isin | str(16) | nullable; dedup key |
+| sedol | str(16) | nullable |
+| ticker | str(32) | nullable, indexed; NOT unique (multi-exchange) |
+| name | text | nullable |
+| security_type | text | `equity`\|`etf`\|`mutual_fund`\|`bond`\|`option`\|`cryptocurrency`\|`cash`\|`fixed_income`\|`derivative`\|`other`. Growing → TEXT |
+| exchange_mic | str(10) | nullable |
+| exchange_operating_mic | str(10) | nullable; dedup component |
+| country_code | str(2) | nullable |
+| currency | str(16)? FK finance_currency.code | nullable; quote currency; RESTRICT (unindexed) |
+| is_cash_equivalent | bool | default false; sweep/MMF |
+| is_crypto | bool | default false |
+| coingecko_id | text | nullable; crypto price-source id |
+| onchain_contract | text | nullable; token contract address |
+| onchain_chain | text | nullable |
+| close_price | int? | nullable; cached latest institution price (minor units × `price_scale`) |
+| price_scale | int | default 2; scale exponent for `close_price` |
+| close_price_as_of | date? | nullable |
+| metadata_ | json | `Column("metadata", JSON)`; option contract, fixed_income sub-objects |
+
+- **FKs:** `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_security_ticker (ticker)`, `ix_finance_security_cusip (cusip)`, `ix_finance_security_isin (isin)`, `ix_finance_security_provider_secid (provider_security_id)`, `ix_finance_security_type (security_type)`.
+- **Unique:** `uq_finance_security_provider UNIQUE(provider, provider_security_id) WHERE provider_security_id IS NOT NULL` (partial); `uq_finance_security_figi UNIQUE(figi) WHERE figi IS NOT NULL` (partial); `uq_finance_security_cusip UNIQUE(cusip) WHERE cusip IS NOT NULL` (partial); `uq_finance_security_isin UNIQUE(isin) WHERE isin IS NOT NULL` (partial).
+- **Checks:** none (all growing taxonomy).
+
+### `finance_security_price` [v1]
+Price time series feeding holding valuation and charts. One price per security/day/source. Sub-cent/
+crypto precision via `price_scale`.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| security_id | int FK finance_security.id | indexed; CASCADE |
+| price_date | date | close date |
+| close_price | int | close price (minor units × `price_scale`) |
+| price_scale | int | default 2; divisor exponent (larger for crypto/sub-cent) |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| source | str(16) String+Check | price source |
+
+- **FKs:** `security_id → finance_security.id` CASCADE (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_secprice_security_date (security_id, price_date)`.
+- **Unique:** `uq_finance_secprice UNIQUE(security_id, price_date, source)`.
+- **Checks:** `ck_finance_secprice_source: source IN ('plaid','snaptrade','exchange_api','onchain','coingecko','manual','market_data')`.
+
+### `finance_holding` [v1]
+**DATED position snapshot** per `(account, security, as_of_date)` — upsert, not append. Current =
+latest date; historical rows feed allocation-over-time. Quantity as scaled integer `quantity_e8`.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| account_id | int FK finance_account.id | indexed; CASCADE |
+| security_id | int FK finance_security.id | indexed; RESTRICT |
+| as_of_date | date | snapshot date; dedup key |
+| quantity_e8 | int | units × 1e8 (fractional shares + crypto) |
+| cost_basis | int? | nullable; total cost basis |
+| average_cost | int? | nullable; per-unit average cost |
+| price | int? | nullable; institution price/unit (minor units × `price_scale`) |
+| price_scale | int | default 2; scale for `price` |
+| institution_value | int? | nullable; provider-reported market value |
+| vested_quantity_e8 | int? | nullable |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| source | text | `plaid`\|`snaptrade`\|`manual`. Growing → TEXT |
+| deleted_at | datetime? | nullable, indexed; position closed |
+| metadata_ | json | `Column("metadata", JSON)`; vested/unvested, lot detail |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `account_id → finance_account.id` CASCADE (idx); `security_id → finance_security.id` RESTRICT (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_holding_owner (owner_user_id)`, `ix_finance_holding_account (account_id)`, `ix_finance_holding_security (security_id)`, `ix_finance_holding_account_date (account_id, as_of_date)`, `ix_finance_holding_deleted (deleted_at)`.
+- **Unique:** `uq_finance_holding UNIQUE(account_id, security_id, as_of_date)`.
+- **Checks:** none.
+
+### `finance_trade` [v1]
+Investment/security-movement events (buy/sell/dividend/reinvest/fee/transfer) — Plaid
+`/investments/transactions` / SnapTrade activities. Same dual-lane dedup + soft-delete as cash
+transactions; optional link to the cash-leg `finance_transaction`. `type` normalized (owned enum),
+`subtype` provider TEXT.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| account_id | int FK finance_account.id | indexed; CASCADE |
+| security_id | int? FK finance_security.id | nullable, indexed; SET NULL (cash-only fee/interest) |
+| transaction_id | int? FK finance_transaction.id | nullable, indexed; SET NULL. Paired cash leg |
+| connection_id | int? FK finance_connection.id | nullable, indexed; SET NULL |
+| import_batch_id | int? FK finance_import_batch.id | nullable, indexed; SET NULL |
+| source | str(16) String+Check | LANE-1 key part |
+| external_id | text | nullable; provider investment txn id / OFX INVTRAN FITID. LANE-1 dedup (account-scoped) |
+| external_id_source | text | nullable |
+| import_hash | str(64) | nullable; id-less content hash. LANE-2 dedup |
+| type | str(16) String+Check | normalized coarse type |
+| subtype | text | nullable; provider detailed subtype. Growing → TEXT |
+| quantity_e8 | int? | nullable; units × 1e8 (signed: negative on sell) |
+| price | int? | nullable; per-unit price (minor units × `price_scale`) |
+| price_scale | int | default 2 |
+| amount | int | signed total cash impact (normalized: negative=cash out/buy, positive=cash in) |
+| raw_amount | int? | nullable; as source delivered |
+| fees | int? | nullable |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| trade_date | date | |
+| settle_date | date? | nullable |
+| datetime_ | datetime? | `Column("datetime")`; nullable |
+| name | text | nullable; provider description |
+| pending | bool | default false |
+| raw_payload | json | `Column("raw_payload", JSON, nullable=True)` |
+| is_removed | bool | default false |
+| deleted_at | datetime? | nullable, indexed; soft-delete |
+| metadata_ | json | `Column("metadata", JSON)`; on-chain tx hash, gas |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `account_id → finance_account.id` CASCADE (idx); `security_id → finance_security.id` SET NULL (idx); `transaction_id → finance_transaction.id` SET NULL (idx); `connection_id → finance_connection.id` SET NULL (idx); `import_batch_id → finance_import_batch.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_trade_owner_date (owner_user_id, trade_date)`, `ix_finance_trade_account_date (account_id, trade_date)`, `ix_finance_trade_security (security_id)`, `ix_finance_trade_transaction (transaction_id)`, `ix_finance_trade_connection (connection_id)`, `ix_finance_trade_batch (import_batch_id)`, `ix_finance_trade_deleted (deleted_at)`.
+- **Unique:** `uq_finance_trade_external UNIQUE(account_id, source, external_id) WHERE external_id IS NOT NULL AND deleted_at IS NULL` (partial); `uq_finance_trade_hash UNIQUE(account_id, import_hash) WHERE external_id IS NULL AND import_hash IS NOT NULL AND deleted_at IS NULL` (partial).
+- **Checks:** `ck_finance_trade_source: source IN ('plaid','snaptrade','ofx','qfx','csv','manual','coinbase','onchain')`; `ck_finance_trade_type: type IN ('buy','sell','dividend','interest','fee','tax','transfer_in','transfer_out','deposit','withdrawal','reinvest','split','cancel','other')`; `ck_finance_trade_dedup_lane: NOT (external_id IS NOT NULL AND import_hash IS NOT NULL)`.
+
+---
+
+## GROUP E — Budgets / Recurring / Insights
+
+### `finance_recurring_stream` [v1]
+Detected recurring streams (subscriptions, bills, paychecks) — the "wasting money" engine. Plaid
+Recurring add-on + local heuristic detection. Confidence/maturity, not a boolean (annuals invisible
+for a year). Transactions back-link via `finance_transaction.recurring_stream_id` (no join table).
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| account_id | int? FK finance_account.id | nullable, indexed; CASCADE |
+| merchant_id | int? FK finance_merchant.id | nullable, indexed; SET NULL |
+| category_id | int? FK finance_category.id | nullable, indexed; SET NULL |
+| connection_id | int? FK finance_connection.id | nullable, indexed; SET NULL. Dedup with `provider_stream_id` |
+| provider_stream_id | text | nullable; Plaid recurring `stream_id`. Growing → TEXT. Dedup key |
+| name | str(255) | stream label ("Netflix", "Payroll") |
+| normalized_payee | text | nullable; dedup key for locally-detected streams |
+| direction | str(8) String+Check | `inflow`\|`outflow` |
+| frequency | str(16) String+Check | cadence |
+| average_amount | int? | nullable |
+| last_amount | int? | nullable; price-hike compare |
+| expected_amount | int? | nullable |
+| amount_is_variable | bool | default false; utilities — suppress false price alarms |
+| amount_tolerance_bps | int? | nullable |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| first_date | date? | nullable |
+| last_date | date? | nullable |
+| next_expected_date | date? | nullable, indexed; powers cash-flow forecast |
+| occurrence_count | int | default 0; ≥3 = mature |
+| status | str(16) String+Check | maturity/lifecycle |
+| confidence | int? | nullable 0-100 |
+| is_subscription | bool | default false; wasting-money surface flag |
+| is_active | bool | default true |
+| is_user_confirmed | bool | default false |
+| is_muted | bool | default false |
+| service_type | text | nullable; duplicate-service detection. Growing → TEXT |
+| source | str(12) String+Check | `plaid`\|`derived`\|`user` |
+| deleted_at | datetime? | nullable, indexed |
+| metadata_ | json | `Column("metadata", JSON)` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `account_id → finance_account.id` CASCADE (idx); `merchant_id → finance_merchant.id` SET NULL (idx); `category_id → finance_category.id` SET NULL (idx); `connection_id → finance_connection.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_recurring_owner (owner_user_id)`, `ix_finance_recurring_account (account_id)`, `ix_finance_recurring_merchant (merchant_id)`, `ix_finance_recurring_category (category_id)`, `ix_finance_recurring_connection (connection_id)`, `ix_finance_recurring_next (owner_user_id, next_expected_date)`, `ix_finance_recurring_status (status)`, `ix_finance_recurring_deleted (deleted_at)`.
+- **Unique:** `uq_finance_recurring_provider UNIQUE(connection_id, provider_stream_id) WHERE provider_stream_id IS NOT NULL` (partial); `uq_finance_recurring_detected UNIQUE(owner_user_id, account_id, direction, normalized_payee) WHERE provider_stream_id IS NULL` (partial).
+- **Checks:** `ck_finance_recurring_direction: direction IN ('inflow','outflow')`; `ck_finance_recurring_frequency: frequency IN ('weekly','biweekly','semi_monthly','monthly','bimonthly','quarterly','semi_annually','annually','irregular','unknown')`; `ck_finance_recurring_status: status IN ('early_detection','mature','inactive','cancelled')`; `ck_finance_recurring_source: source IN ('plaid','derived','user')`.
+
+### `finance_budget` [reserved]
+Budget definition scoped to a period. Reserved until the budgeting UI ships.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| name | str(128) | |
+| period | str(16) String+Check | `monthly`\|`weekly`\|`quarterly`\|`yearly`\|`custom` |
+| start_date | date | period anchor |
+| end_date | date? | nullable (custom) |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| philosophy | text | nullable; `envelope`\|`flex`\|`top_down`. Growing → TEXT |
+| rollover | bool | default false |
+| is_active | bool | default true |
+| deleted_at | datetime? | nullable, indexed |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_budget_owner (owner_user_id)`, `ix_finance_budget_org (organization_id)`, `ix_finance_budget_deleted (deleted_at)`.
+- **Unique:** `uq_finance_budget_owner_name_start UNIQUE(owner_user_id, name, start_date)`.
+- **Checks:** `ck_finance_budget_period: period IN ('monthly','weekly','quarterly','yearly','custom')`.
+
+### `finance_budget_category` [reserved]
+Per-category budgeted amount per `period_month` (YYYYMM), with carryover/goal so envelope AND flex
+never need a new table. Actuals derived live from transactions/splits.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| budget_id | int FK finance_budget.id | indexed; CASCADE |
+| category_id | int? FK finance_category.id | nullable, indexed; CASCADE (NULL = overall budget line) |
+| period_month | int? | nullable, indexed; YYYYMM |
+| allocated_amount | int | budgeted for the category/period |
+| goal_amount | int? | nullable |
+| carryover_amount | int | default 0; envelope rollover |
+| rollover_enabled | bool | default false |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `budget_id → finance_budget.id` CASCADE (idx); `category_id → finance_category.id` CASCADE (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_budgetcat_owner (owner_user_id)`, `ix_finance_budgetcat_budget (budget_id)`, `ix_finance_budgetcat_category (category_id)`, `ix_finance_budgetcat_month (period_month)`.
+- **Unique:** `uq_finance_budgetcat UNIQUE(budget_id, category_id, period_month)`.
+- **Checks:** none.
+
+### `finance_spending_baseline` [reserved]
+Materialized trailing 3/6/12-mo averages per category (+optional merchant) — powers
+anomaly-vs-your-own-baseline "you're wasting money" insights. Computed by a job once history matures.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| category_id | int? FK finance_category.id | nullable, indexed; CASCADE |
+| merchant_id | int? FK finance_merchant.id | nullable, indexed; CASCADE |
+| window_months | int | 3\|6\|12 |
+| period_month | int | YYYYMM the baseline is anchored to |
+| trailing_avg_amount | int | rolled average |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| computed_at | datetime | |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `category_id → finance_category.id` CASCADE (idx); `merchant_id → finance_merchant.id` CASCADE (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_baseline_owner (owner_user_id)`, `ix_finance_baseline_category (category_id)`, `ix_finance_baseline_merchant (merchant_id)`.
+- **Unique:** `uq_finance_baseline UNIQUE(owner_user_id, category_id, merchant_id, window_months, period_month)`.
+- **Checks:** `ck_finance_baseline_window: window_months IN (3,6,12)`.
+
+### `finance_insight` [reserved]
+Finance-specific insight/alert rows (price_hike, duplicate_service, inactive_subscription,
+fee_charged, overspend, spending_anomaly, low_yield_cash). `dedup_key` prevents regenerating the same
+insight daily. **Reserved** — v1 rule-based signals emit through the existing `insight_event` system
+(§6.1); this table exists for finance `dedup_key` idempotency + typed `related_*` FKs + AI-readiness
+(Illiana) when that surface matures.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| insight_type | text | `price_hike`\|`duplicate_service`\|`inactive_subscription`\|`fee_charged`\|`overspend_category`\|`spending_anomaly`\|`low_yield_cash`\|... Growing → TEXT |
+| severity | str(16) String+Check | `info`\|`warning`\|`critical` |
+| title | text | |
+| body | text | nullable |
+| related_account_id | int? FK finance_account.id | nullable, indexed; CASCADE |
+| related_transaction_id | int? FK finance_transaction.id | nullable, indexed; CASCADE |
+| related_category_id | int? FK finance_category.id | nullable, indexed; SET NULL |
+| related_stream_id | int? FK finance_recurring_stream.id | nullable, indexed; SET NULL |
+| detected_amount | int? | nullable |
+| currency | str(16)? FK finance_currency.code | nullable; RESTRICT (unindexed) |
+| dedup_key | text | stable key (kind+period+subject); idempotent regeneration |
+| period_start | date? | nullable |
+| period_end | date? | nullable |
+| data | json | `Column("data", JSON)`; structured payload |
+| status | str(12) String+Check | `new`\|`seen`\|`dismissed`\|`actioned` |
+| is_read | bool | default false |
+| dismissed_at | datetime? | nullable |
+| metadata_ | json | `Column("metadata", JSON)` |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `related_account_id → finance_account.id` CASCADE (idx); `related_transaction_id → finance_transaction.id` CASCADE (idx); `related_category_id → finance_category.id` SET NULL (idx); `related_stream_id → finance_recurring_stream.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_insight_owner (owner_user_id)`, `ix_finance_insight_org (organization_id)`, `ix_finance_insight_type (insight_type)`, `ix_finance_insight_status (status)`, `ix_finance_insight_account (related_account_id)`, `ix_finance_insight_transaction (related_transaction_id)`, `ix_finance_insight_category (related_category_id)`, `ix_finance_insight_stream (related_stream_id)`, `ix_finance_insight_owner_read (owner_user_id, is_read)`.
+- **Unique:** `uq_finance_insight_dedup UNIQUE(owner_user_id, dedup_key)`.
+- **Checks:** `ck_finance_insight_severity: severity IN ('info','warning','critical')`; `ck_finance_insight_status: status IN ('new','seen','dismissed','actioned')`.
+
+---
+
+## GROUP F — Import & Reference
+
+### `finance_currency` [v1]
+Units-of-account reference (fiat + crypto). `id` int PK + `UNIQUE(code)`; `code` widened to str(16)
+for crypto tickers; stored lowercase. Every money column FKs `code` and reads `decimals` to render.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | autoincrement |
+| code | str(16) | UNIQUE, indexed; lowercase ISO-4217 or crypto ticker (`usd`,`eur`,`jpy`,`btc`,`usdc`) |
+| name | str(64) | display |
+| symbol | str(8) | nullable |
+| decimals | int | minor-unit exponent: usd=2, jpy=0, btc=8 |
+| kind | str(8) String+Check | `fiat`\|`crypto` |
+| is_active | bool | default true |
+
+- **FKs:** none.
+- **Indices:** `ix_finance_currency_code (code)` (unique), `ix_finance_currency_kind (kind)`.
+- **Unique:** `uq_finance_currency_code UNIQUE(code)`.
+- **Checks:** `ck_finance_currency_kind: kind IN ('fiat','crypto')`; `ck_finance_currency_decimals: decimals BETWEEN 0 AND 18`.
+
+### `finance_fx_rate` [v1]
+Historical FX time series for base-currency net-worth rollups. `rate_e8` scaled integer (no Decimal).
+Convert at DISPLAY time against dated rates. One rate per pair/day/source.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| base_currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| quote_currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| rate_date | date | observation date |
+| rate_e8 | int | 1 base = `rate_e8`/1e8 quote |
+| source | str(16) String+Check | rate source |
+
+- **FKs:** `base_currency → finance_currency.code` RESTRICT (unindexed); `quote_currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_fxrate_pair_date (base_currency, quote_currency, rate_date)`.
+- **Unique:** `uq_finance_fxrate UNIQUE(base_currency, quote_currency, rate_date, source)`.
+- **Checks:** `ck_finance_fxrate_source: source IN ('manual','ecb','exchange_api','coingecko','provider','derived')`; `ck_finance_fxrate_distinct: base_currency <> quote_currency`.
+
+### `finance_import_batch` [v1]
+One row per ingestion run (a Plaid/SnapTrade sync pass OR an uploaded QIF/QFX/OFX/CSV file OR manual
+bulk). Reversible unit + counts + `file_sha256` whole-file dedup (blocks identical re-upload before
+row parsing). Every imported transaction/trade FKs back here.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| connection_id | int? FK finance_connection.id | nullable, indexed; SET NULL |
+| account_id | int? FK finance_account.id | nullable, indexed; SET NULL (single-account file imports) |
+| import_profile_id | int? FK finance_import_profile.id | nullable, indexed; SET NULL |
+| source_type | str(16) String+Check | `plaid_sync`\|`snaptrade_sync`\|`ofx`\|`qfx`\|`qif`\|`csv`\|`manual` |
+| file_name | str(255) | nullable |
+| file_sha256 | text | nullable; whole-file dedup key |
+| sync_cursor_before | text | nullable; cursor at run start (audit) |
+| sync_cursor_after | text | nullable; `next_cursor` at run end |
+| rows_total | int | default 0 |
+| rows_inserted | int | default 0 |
+| rows_updated | int | default 0 |
+| rows_duplicate | int | default 0 |
+| rows_error | int | default 0 |
+| status | str(16) String+Check | `pending`\|`processing`\|`committed`\|`failed`\|`rolled_back` |
+| error | text | nullable |
+| started_at | datetime? | nullable |
+| finished_at | datetime? | nullable |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `connection_id → finance_connection.id` SET NULL (idx); `account_id → finance_account.id` SET NULL (idx); `import_profile_id → finance_import_profile.id` SET NULL (idx).
+- **Indices:** `ix_finance_importbatch_owner (owner_user_id)`, `ix_finance_importbatch_org (organization_id)`, `ix_finance_importbatch_connection (connection_id)`, `ix_finance_importbatch_account (account_id)`, `ix_finance_importbatch_profile (import_profile_id)`, `ix_finance_importbatch_status (status)`, `ix_finance_importbatch_owner_started (owner_user_id, started_at)`.
+- **Unique:** `uq_finance_importbatch_file UNIQUE(owner_user_id, file_sha256) WHERE file_sha256 IS NOT NULL` (partial).
+- **Checks:** `ck_finance_importbatch_source: source_type IN ('plaid_sync','snaptrade_sync','ofx','qfx','qif','csv','manual')`; `ck_finance_importbatch_status: status IN ('pending','processing','committed','failed','rolled_back')`.
+
+### `finance_import_batch_row` [v1]
+Staging: one raw parsed record per file row + parse status + match link + content hash. Powers
+review-before-commit, reversible batches, and precise dup/error reporting.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| import_batch_id | int FK finance_import_batch.id | indexed; CASCADE |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| account_id | int? FK finance_account.id | nullable, indexed; SET NULL |
+| row_number | int | position in file |
+| raw_line | text | nullable; original line |
+| parsed | json | `Column("parsed", JSON)`; parsed canonical fields |
+| content_hash | str(64) | nullable; the computed `import_hash` |
+| fitid | text | nullable; OFX FITID if present |
+| parsed_status | str(12) String+Check | outcome |
+| matched_transaction_id | int? FK finance_transaction.id | nullable, indexed; SET NULL |
+| matched_trade_id | int? FK finance_trade.id | nullable, indexed; SET NULL |
+| reason | text | nullable; why dup/error |
+
+- **FKs:** `import_batch_id → finance_import_batch.id` CASCADE (idx); `owner_user_id → user.id` CASCADE (idx); `account_id → finance_account.id` SET NULL (idx); `matched_transaction_id → finance_transaction.id` SET NULL (idx); `matched_trade_id → finance_trade.id` SET NULL (idx).
+- **Indices:** `ix_finance_importrow_batch (import_batch_id)`, `ix_finance_importrow_owner (owner_user_id)`, `ix_finance_importrow_account (account_id)`, `ix_finance_importrow_matched_txn (matched_transaction_id)`, `ix_finance_importrow_matched_trade (matched_trade_id)`, `ix_finance_importrow_hash (content_hash)`.
+- **Unique:** `uq_finance_importrow_batch_num UNIQUE(import_batch_id, row_number)`.
+- **Checks:** `ck_finance_importrow_status: parsed_status IN ('parsed','inserted','updated','duplicate','error','matched','skipped')`.
+
+### `finance_import_profile` [v1]
+Data-driven CSV/OFX column mapping + header signature (auto-detect Chase-CC vs Chase-checking vs AMEX
+variants) + sign convention. `owner_user_id` NULL = system seed. **Not hardcoded parsers** — the
+difference between "add a data row" and "add a parser + migrate" when AMEX ships yet another layout.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int? FK user.id | nullable, indexed; NULL = system seed. CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| institution_id | int? FK finance_institution.id | nullable, indexed; SET NULL |
+| name | str(128) | "Chase CC", "AMEX v2" |
+| source_format | str(8) String+Check | `csv`\|`ofx`\|`qfx`\|`qif` |
+| header_signature | json | `Column("header_signature", JSON)`; ordered column list to auto-match uploaded header |
+| column_mapping | json | `Column("column_mapping", JSON)`; provider column → canonical field |
+| date_format | text | nullable; strptime pattern |
+| amount_sign_convention | str(20) String+Check | `outflow_negative`\|`outflow_positive`\|`split_debit_credit` (AMEX inverts Chase) |
+| decimal_separator | str(1) | nullable |
+| thousands_separator | str(1) | nullable |
+| currency | str(16) FK finance_currency.code | RESTRICT (unindexed) |
+| is_system | bool | default false |
+| deleted_at | datetime? | nullable, indexed |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `institution_id → finance_institution.id` SET NULL (idx); `currency → finance_currency.code` RESTRICT (unindexed).
+- **Indices:** `ix_finance_importprofile_owner (owner_user_id)`, `ix_finance_importprofile_org (organization_id)`, `ix_finance_importprofile_institution (institution_id)`, `ix_finance_importprofile_deleted (deleted_at)`.
+- **Unique:** `uq_finance_importprofile_owner_name UNIQUE(owner_user_id, name)`.
+- **Checks:** `ck_finance_importprofile_format: source_format IN ('csv','ofx','qfx','qif')`; `ck_finance_importprofile_sign: amount_sign_convention IN ('outflow_negative','outflow_positive','split_debit_credit')`.
+
+### `finance_attachment` [reserved]
+Receipts/documents per transaction or account (object-store key). Reserved to avoid a later add.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| organization_id | int? FK organization.id | nullable, indexed; SET NULL |
+| transaction_id | int? FK finance_transaction.id | nullable, indexed; CASCADE |
+| account_id | int? FK finance_account.id | nullable, indexed; CASCADE |
+| file_name | text | |
+| content_type | text | nullable |
+| byte_size | int? | nullable |
+| storage_key | text | object-store key |
+| sha256 | text | nullable; content dedup |
+| deleted_at | datetime? | nullable, indexed |
+
+- **FKs:** `owner_user_id → user.id` CASCADE (idx); `organization_id → organization.id` SET NULL (idx); `transaction_id → finance_transaction.id` CASCADE (idx); `account_id → finance_account.id` CASCADE (idx).
+- **Indices:** `ix_finance_attachment_owner (owner_user_id)`, `ix_finance_attachment_org (organization_id)`, `ix_finance_attachment_transaction (transaction_id)`, `ix_finance_attachment_account (account_id)`, `ix_finance_attachment_deleted (deleted_at)`.
+- **Unique:** `uq_finance_attachment_owner_sha UNIQUE(owner_user_id, sha256) WHERE sha256 IS NOT NULL` (partial).
+- **Checks:** none.
+
+### `finance_transaction_changelog` [reserved]
+Append-only field-level audit of Plaid `modified[]` and user edits, kept separate from the mutable
+transaction row (the queryable row stays an upsert; audit is immutable). Reserved until an audit/undo
+surface is built.
+
+| column | type | notes |
+|---|---|---|
+| id | int PK | |
+| transaction_id | int FK finance_transaction.id | indexed; CASCADE |
+| owner_user_id | int FK user.id | indexed; CASCADE |
+| field | text | changed field name |
+| old_value | text | nullable |
+| new_value | text | nullable |
+| change_source | text | `plaid_modified`\|`user`\|`rule`\|`reconciliation`. Growing → TEXT |
+| sync_cursor | text | nullable; cursor at time of change |
+| changed_at | datetime | indexed, default |
+
+- **FKs:** `transaction_id → finance_transaction.id` CASCADE (idx); `owner_user_id → user.id` CASCADE (idx).
+- **Indices:** `ix_finance_changelog_transaction (transaction_id)`, `ix_finance_changelog_owner (owner_user_id)`, `ix_finance_changelog_changed (changed_at)`.
+- **Unique:** none (append-only).
+- **Checks:** none.
+
+---
+
+## 2. Dedup & idempotency
+
+Every ingestion path resolves to a real UNIQUE constraint so a re-run is an idempotent Postgres
+`insert(...).on_conflict_do_update(...)` / `on_conflict_do_nothing`, never a blind insert.
+
+### 2.1 Per-source unique key + on_conflict target
+
+| Source | Table | Natural key / on_conflict target |
+|---|---|---|
+| **Plaid `/transactions/sync`** | `finance_transaction` | `external_id = transaction_id`, `source='plaid'` → `uq_finance_txn_external (account_id, source, external_id)`. Cursor on `finance_connection.sync_cursor`. |
+| **Plaid `/investments/transactions`** | `finance_trade` | `external_id = investment_transaction_id`, `source='plaid'` → `uq_finance_trade_external (account_id, source, external_id)`. |
+| **Plaid holdings** | `finance_holding` | current-day upsert → `uq_finance_holding (account_id, security_id, as_of_date)` (today's date). |
+| **SnapTrade** | `finance_transaction` / `finance_trade` | activity `id` → same `(account_id, source='snaptrade', external_id)` target. |
+| **OFX / QFX** (Chase/AMEX/Fidelity/Quicken export) | `finance_transaction` | `external_id = <FITID>`, `source='ofx'`/`'qfx'` → `uq_finance_txn_external (account_id, source, external_id)`. **FITID is unique only WITHIN an account — the `(account_id, ...)` tuple, never FITID alone.** `account_id` resolved from OFX `<ACCTID>`/`<BANKID>` via `finance_account.provider_account_id`. |
+| **QIF / CSV / manual** (no stable id) | `finance_transaction` | `import_hash` → `uq_finance_txn_hash (account_id, import_hash) WHERE external_id IS NULL`. `import_hash = sha256(account_id | date.isoformat() | signed_amount | normalized_payee | memo | check_number | within_day_ordinal)` — normalize (uppercase, collapse whitespace, strip punctuation) before hashing. `within_day_ordinal` is assigned within a **deterministic sort (date, amount, normalized_payee, memo)**, never file order, so an overlapping-range re-export doesn't shift every subsequent hash. |
+| **Whole-file re-upload** | `finance_import_batch` | `uq_finance_importbatch_file (owner_user_id, file_sha256)` short-circuits an identical file before row parsing. |
+| institution / account / security / price / balance / valuation / fx / recurring | see each table | `uq_finance_institution_provider_extid`, `uq_finance_account_provider`, `uq_finance_security_{provider,figi,cusip,isin}`, `uq_finance_secprice`, `uq_finance_balsnap`, `uq_finance_valuation`, `uq_finance_fxrate`, `uq_finance_recurring_{provider,detected}`. |
+
+The `ck_finance_txn_dedup_lane` / `ck_finance_trade_dedup_lane` check (`NOT (external_id AND import_hash)`)
+forbids a row from occupying both lanes and evading both partial-uniques.
+
+### 2.2 Plaid sync churn (added / modified / removed)
+Wrap the whole `has_more` loop **plus** the `sync_cursor` advance in ONE DB transaction — never
+persist a cursor for a batch not fully applied.
+- `added[]` → `on_conflict_do_update` on the LANE-1 target (idempotent if the page is re-seen).
+- `modified[]` → same target, UPDATE-in-place (bank rewrote the row; re-derive from `raw_payload`).
+- `removed[]` → set `is_removed=true, removed_at, deleted_at, status='removed'` — **soft-delete, never
+  hard delete** (tombstone survives re-sync; honors bank deletions/fraud reversals).
+
+### 2.3 Pending → posted
+The posted row arrives with a NEW `external_id` and Plaid's `pending_transaction_id` (stored in
+`pending_provider_id`). On ingest, look up the internal pending row by `(account_id, pending_provider_id)`,
+set the posted row's self-FK `pending_transaction_id` → the pending row, and soft-delete the pending row.
+Aggregates and durable snapshots read POSTED, non-deleted rows only, so pending never double-counts and
+phantom pre-auths (that arrive in `removed[]` and never post) never manufacture spend.
+
+### 2.4 Cross-source collision (Plaid + a Chase QFX of the same account)
+The two rows have different natural keys (different lanes) so both insert. A service-layer
+reconciliation pass fuzzy-matches on `(account_id, date ±3d, exact signed amount, fuzzy normalized_payee)`.
+On a confident match: the higher `source_precedence` row (plaid/snaptrade 100 > ofx 70 > qif 50 >
+csv 40 > manual 30; tie → newest) is marked `dedup_status='primary'`; the loser gets
+`dedup_status='duplicate'` + `canonical_transaction_id → primary`. **Never destructively merged** —
+all money aggregates filter `dedup_status IN ('unique','primary') AND deleted_at IS NULL`. Below the
+high-confidence threshold, surface as a user-confirmable duplicate rather than silently collapsing
+(two genuine same-day/same-amount coffees must not merge).
+
+---
+
+## 3. v1 vs reserved summary
+
+| Group | Table | v1/reserved | Populated at launch by |
+|---|---|---|---|
+| A | finance_institution | **v1** | Plaid/SnapTrade institution metadata + seed |
+| A | finance_connection | **v1** | Link/connect flow (encrypted creds) |
+| A | finance_webhook_event | **v1** | Plaid/SnapTrade webhooks |
+| B | finance_account | **v1** | Plaid/SnapTrade accounts + manual |
+| B | finance_liability_detail | **v1** | Plaid Liabilities (Chase; AMEX null) |
+| B | finance_balance_snapshot | **v1** | Snapshot background job |
+| B | finance_net_worth_snapshot | **v1** | Snapshot background job |
+| B | finance_valuation | **v1** | Manual asset valuations |
+| C | finance_transaction | **v1** | Plaid/SnapTrade/OFX/QIF/CSV/manual |
+| C | finance_transaction_split | **v1** (feature-gated) | Split UI (schema live day 1) |
+| C | finance_transfer | **v1** | Transfer detection pass |
+| C | finance_category | **v1** | PFC seed + user |
+| C | finance_category_alias | **v1** | PFC/QIF/Chase/AMEX seed + user |
+| C | finance_merchant | **v1** | Plaid enrichment + normalization |
+| C | finance_tag | **v1** | QIF `/Class` import + user |
+| C | finance_transaction_tag | **v1** | Tagging |
+| C | finance_rule | **reserved** | Rules UI |
+| D | finance_security | **v1** | Plaid/SnapTrade securities catalog |
+| D | finance_security_price | **v1** | Price feed / provider |
+| D | finance_holding | **v1** | Plaid/SnapTrade holdings (dated) |
+| D | finance_trade | **v1** | Plaid/SnapTrade investment txns |
+| E | finance_recurring_stream | **v1** | Plaid Recurring + local detection |
+| E | finance_budget | **reserved** | Budgeting UI |
+| E | finance_budget_category | **reserved** | Budgeting UI |
+| E | finance_spending_baseline | **reserved** | Anomaly-baseline job |
+| E | finance_insight | **reserved** | Finance insight engine (v1 uses `insight_event`) |
+| F | finance_currency | **v1** | Seed (`usd` + crypto as needed) |
+| F | finance_fx_rate | **v1** | FX feed (reserved-populated; USD-only at launch) |
+| F | finance_import_batch | **v1** | Every sync/file import |
+| F | finance_import_batch_row | **v1** | File-import staging |
+| F | finance_import_profile | **v1** | Chase/AMEX layout seeds + user |
+| F | finance_attachment | **reserved** | Receipt upload feature |
+| C | finance_transaction_changelog | **reserved** | Audit/undo surface |
+
+**33 tables, one migration.** Reserved tables cost one `op.create_table` line each and zero runtime
+until populated — honoring "never add a finance table later."
+
+---
+
+## 4. ER diagram (core relationships)
+
+```mermaid
+erDiagram
+    user ||--o{ finance_connection : owns
+    user ||--o{ finance_account : owns
+    organization |o--o{ finance_connection : scopes
+
+    finance_institution ||--o{ finance_connection : "surfaced by"
+    finance_institution ||--o{ finance_account : "issued by"
+    finance_connection ||--o{ finance_account : "syncs"
+    finance_connection ||--o{ finance_webhook_event : "logs"
+    finance_connection ||--o{ finance_import_batch : "produces"
+
+    finance_account ||--o| finance_liability_detail : "1:1 detail"
+    finance_account ||--o{ finance_balance_snapshot : "daily balance"
+    finance_account ||--o{ finance_valuation : "dated value"
+    finance_account ||--o{ finance_transaction : "ledger"
+    finance_account ||--o{ finance_holding : "positions"
+    finance_account ||--o{ finance_trade : "investment txns"
+    user ||--o{ finance_net_worth_snapshot : "daily rollup"
+
+    finance_transaction ||--o{ finance_transaction_split : "splits"
+    finance_transaction ||--o{ finance_transaction_tag : "tags"
+    finance_tag ||--o{ finance_transaction_tag : "tagged"
+    finance_transfer |o--o| finance_transaction : "pairs 2 legs"
+    finance_transaction }o--o| finance_category : "categorized"
+    finance_transaction }o--o| finance_merchant : "normalized payee"
+    finance_transaction }o--o| finance_recurring_stream : "occurrence"
+    finance_category ||--o{ finance_category : "parent/child"
+    finance_category ||--o{ finance_category_alias : "aliases"
+    finance_merchant }o--o| finance_category : "default cat"
+
+    finance_security ||--o{ finance_security_price : "price series"
+    finance_security ||--o{ finance_holding : "held as"
+    finance_security ||--o{ finance_trade : "traded"
+    finance_trade }o--o| finance_transaction : "cash leg"
+
+    finance_recurring_stream }o--o| finance_merchant : "merchant"
+    finance_import_batch ||--o{ finance_import_batch_row : "staging"
+    finance_import_batch }o--o| finance_import_profile : "layout"
+    finance_import_batch ||--o{ finance_transaction : "batch of"
+
+    finance_currency ||--o{ finance_fx_rate : "base/quote"
+    finance_currency ||--o{ finance_account : "denominates"
+```
+
+---
+
+## 5. Seeds (populate in the migration / a seed routine)
+
+- **`finance_currency`**: `usd` (decimals 2, fiat) at minimum; add `btc`/`eth`/`usdc` when crypto lands.
+- **`finance_category`** + **`finance_category_alias`**: the Plaid PFC 16-primary / 104-detailed tree
+  as `is_system=true, owner_user_id=NULL`, plus an `uncategorized` catch-all; alias rows mapping each
+  PFC `primary/detailed` string and common QIF/Chase/AMEX category strings onto canonical ids.
+- **`finance_institution`**: Chase, American Express, Fidelity, Vanguard rows with `supported_products`
+  + `oauth_required` + `uses_tokenized_account_numbers` flags from the domain brief.
+- **`finance_import_profile`**: seed system profiles for Chase-CC, Chase-checking, and the known AMEX
+  CSV layouts (with `amount_sign_convention`), matched by `header_signature`.
+
+---
+
+## 6. Where finance touches existing schema
+
+### 6.1 Insights service reuse (`insight_event` vs `finance_insight`)
+The existing `app/services/insights/` service ships `insight_source`, `insight_record`, `insight_event`,
+`goal` and a rule-based anomaly-event system (country-spike pattern). **v1 "wasting money" signals emit
+`insight_event`-style rows** (rule-based, no AI) — recurring/subscription, price-hike, fee/interest,
+category overspend, low-yield cash, spending anomaly. `finance_insight` ships **reserved** and stays
+empty until the finance-specific surface (typed `related_*` FKs + `dedup_key` idempotency + Illiana
+AI-readiness) is built. Do NOT duplicate the country-spike machinery; register a finance event
+producer against the existing tables. A future `app/services/finance/finance_context.py` provider feeds
+the Illiana AI layer (`include_ai: false` today — design AI-ready, don't depend on it).
+
+### 6.2 Org / user tables
+Every user-scoped finance row carries `owner_user_id: int = Field(foreign_key="user.id", index=True)`
+(ON DELETE CASCADE) and `organization_id: int | None = Field(default=None, foreign_key="organization.id",
+index=True)` (ON DELETE SET NULL). FK targets are the existing `user` and `organization` tables.
+Org-tenancy is **not active** — reads are owner-based; the column ships now, nothing depends on it
+(matches the insights `Project` pattern). Import `User` at the top of `models.py`
+(`from app.models.user import User  # noqa: F401`) so FK-string resolution succeeds in non-webserver
+processes (scheduler/worker), exactly as `insights/models.py` does.
+
+### 6.3 Encryption + key-rotation CLI
+`finance_connection`'s five `*_encrypted` columns hold AES-256-GCM ciphertext produced/consumed in
+`FinanceService` (not the model) via `app.core.encryption.encrypt_secret/decrypt_secret`, with AAD
+`context=f"finance_connection:{id}:{column}"` (mirrors `insights.project_service._ctx`). `wallet_address`
+is public plaintext, NOT encrypted. Register the encrypted columns in the key-rotation CLI
+`app/cli/security.py::_run`: add a scan block streaming every `finance_connection` row with a non-null
+`*_encrypted` column and rotating each via the existing `rotate_column(owner, column, context, row_label)`
+helper — mirroring the `Project`/`UserOAuthIdentity` blocks. Define a
+`_ENCRYPTED_COLUMNS = ("access_token_encrypted","api_key_encrypted","api_secret_encrypted",
+"api_passphrase_encrypted","refresh_token_encrypted")` tuple in the finance service, and mask these in
+`finance_connection.__repr__`. **Missing this step silently strands finance credentials on the next key
+rotation** — the one operational footgun to document loudly.
+
+### 6.4 Alembic registration
+`031_finance.py` (`revision="031"`, `down_revision="030"`), hand-written `op.create_table` +
+`op.create_index(op.f("ix_..."))` + partial uniques via `postgresql_where=` (verified on live Postgres
+only — the pytest SQLite session runs FK/CHECK OFF, so FK-violation and partial-unique paths must be
+checked against the live endpoint, not asserted in unit tests), with a full reverse `downgrade()`
+dropping tables in FK-dependency order. **Add the finance import block to `alembic/env.py`** after the
+insights import (all 33 models, `# noqa: E402,F401`) or autogenerate/`create_all` won't see them.
+`finance_transaction.transfer_group_id → finance_transfer.id` uses `use_alter=True` to break the
+`finance_transaction ↔ finance_transfer` circular FK at DDL time.
+
+### 6.5 Service / deps / worker
+`class FinanceService: def __init__(self, db: AsyncSession)`; queries via `sqlmodel.select` +
+`await self.db.exec(...)`; writes `self.db.add(...)` + `await self.db.flush()` (no commit — the
+request-scoped `get_async_db` commits). `app/services/finance/deps.py`:
+`async def get_finance_service(db: AsyncSession = Depends(get_async_db)) -> FinanceService`. The
+snapshot recompute + recurring detection + reconciliation run in the taskiq worker / APScheduler with
+**bounded per-request payloads** (worker-OOM history: never load 365 days × N accounts at once).
+```

--- a/docs/plans/finance-service/finance-service-plan.md
+++ b/docs/plans/finance-service/finance-service-plan.md
@@ -1,0 +1,220 @@
+# Finance Service — aegis-stack Implementation Plan
+
+> A personal-finance aggregator (Quicken / Empower / Monarch class) authored as a **first-class
+> aegis-stack template service**, gated by `include_finance` and installable via `aegis add-service
+> finance` — so any project generated from the stack can opt in. Aggregates bank / credit-card /
+> brokerage accounts, imports Quicken/OFX/CSV, charts net worth over time, surfaces "wasting money"
+> insights, and (when `include_ai`) feeds those insights to the Illiana AI layer.
+>
+> **Status: planning only — nothing built.** This document is the blueprint. The load-bearing artifact
+> is the schema: [`finance-schema-canonical.md`](./finance-schema-canonical.md) (33 tables).
+>
+> **Target repo:** `aegis-stack` (the template), NOT a one-off in a generated project. Everything lives
+> under `aegis/templates/copier-aegis-project/{{ '{{ project_slug }}' }}/…` as `.jinja`/static sources,
+> plus registry entries in `aegis/core/`.
+
+---
+
+## 0. TL;DR
+
+- **Packaging:** a new gated service `include_finance`, wired the way `payment`/`insights` are — in **two parallel systems** that must stay in sync: (1) the **Copier template** (`{% if include_finance %}` blocks across ~17 `.jinja` files) and (2) the **Python registry** `aegis/core/services.py` `SERVICES["finance"]` (the single source of truth for pruning, `aegis add-service`, migrations, `aegis update` detection, and `aegis init` listing).
+- **Migrations are declarative, not hand-written.** The 33 tables become a `FINANCE_MIGRATION` `ServiceMigrationSpec` (list of `TableSpec`) in `aegis/core/migration_generator.py`. Revision IDs are **auto-assigned** so the chain is valid for any `include_*` combination — there is no "031".
+- **Dual-engine (sqlite + postgres).** Partial-unique indexes, CHECK constraints, and `on_conflict` UPSERT all work on both; finance tables get a Postgres `finance` schema. The dedup contract is unchanged from the design.
+- **Connectivity (unchanged from the design):** Plaid-first (Chase/AMEX/Vanguard), **SnapTrade for Fidelity** (Plaid-via-Fidelity is unreliable), manual/file import as a permanent fallback — behind one provider-polymorphic connection layer, so adding a provider later needs zero new tables.
+- **Prereqs:** finance declares `required_components=[BACKEND, DATABASE, SCHEDULER]`, `recommended_components=[WORKER]`; auth is **integrated-when-present** via the `finance_auth_link` migration (which adds the `owner_user_id -> user` FK only when auth is included), so `required_services=[]` and finance runs standalone too. The resolver/validator enforce the component prereqs at `init` and `add-service`.
+- **UI = Flet dashboard card + modal** (the template's convention — `payment_card.py`/`insights_card.py`). The Alpine "Overseer tabs" from the earlier Pulse draft are a *downstream* concern; the template ships Flet.
+- **Illiana hook is real here** (unlike Pulse): the template's AI service exists, so a conditional `finance_context.py` (gated `{% if include_ai and include_finance %}`) plugs finance data into the agent prompt, following `health_context.py`/`usage_context.py`. v1 "wasting money" signals ship rule-based (no AI required).
+- **Encryption exists in the template** (`app/core/encryption.py`, AES-256-GCM). The **key-rotation CLI does not** (it's Pulse-only — pending auth/encryption backport). So the "register encrypted columns in the rotation CLI" step is deferred/blocked on that backport (noted in §11).
+
+---
+
+## 1. What & scope
+
+Same product as the design brief. In scope (v1, populated when `include_finance` is selected):
+1. **Plaid** connect for Chase (checking/savings/credit + liabilities) and AMEX (cards).
+2. **SnapTrade** connect for Fidelity + brokerages (holdings/positions/trades) — Plaid attempt + manual fallback.
+3. **Import** existing Quicken (QIF, QFX/OFX) + bank CSV, deterministic dedup.
+4. **Accounts + Transactions** on the Flet dashboard.
+5. **Net worth over time** (materialized daily snapshots) + **investments/holdings**.
+6. **Manual accounts & valuations** (real estate, vehicles, crypto — anything with no API).
+7. **Rule-based "wasting money" insights** (recurring/subscription, price hikes, fees, overspend), emitted through the existing `insight_event` machinery when `include_insights`, else as finance-local rows.
+
+Non-goals / later (tables exist, unpopulated): tax-grade cost basis / lots, trade execution, budgeting UI, crypto exchange-key + on-chain connections, rules-engine UI, attachments, the Illiana narration wiring. See the design docs.
+
+The 33-table schema, connectivity decisions, import/dedup, net-worth engine, and insight signals are documented in **[`finance-schema-canonical.md`](./finance-schema-canonical.md)** and the [`finance-research/`](./finance-research/) briefs and are **unchanged** by the aegis-stack retargeting. This plan focuses on the parts that DO change: packaging.
+
+---
+
+## 2. Packaging as an aegis-stack service (the centerpiece)
+
+Wiring a gated service happens in **two parallel systems**. Mirror `payment` (the closest DB + API + frontend + migration analog) throughout.
+
+### 2.1 The Python registry — `aegis/core/services.py` `SERVICES["finance"]`
+This `ServiceSpec` is the single source of truth. Copy the `payment` spec and fill:
+- `name="finance"`, `description`, `long_description`, `docs_path`, `version`, `verified=True`, `aegis_version`.
+- `type` — reuse a `ServiceType` or add a member (+ `SERVICE_TYPE_I18N_KEYS` entry).
+- **Dependencies:** `required_components=[BACKEND, DATABASE, SCHEDULER]`, `recommended_components=[WORKER]`, `required_services=[]` (auth is integrated-when-present via `finance_auth_link`, so finance runs standalone), `conflicts=[]`.
+- **`pyproject_deps=[...]`** — the finance deps (see §2.4). A parity test (`test_pyproject_deps_parity`) checks this equals the `pyproject.toml.jinja` block, so keep them identical and in the same order.
+- **`files=FileManifest(primary=[...])`** — every path finance owns (service dir, api dir, cli file, Flet card+modal, tests, seed). This drives post-gen **pruning** when `include_finance=false`. Use `extras={"finance_<opt>": [...]}` for option-gated sub-files.
+- **`template_files=[...]`** — dirs rendered by `ManualUpdater` on `aegis add-service` (post-generation installs).
+- **`marker_path="app/services/finance"`** — drives `aegis update` disk detection.
+- **`migrations=[FINANCE_MIGRATION]`** (+ any cross-service link spec).
+- **`wiring=PluginWiring(routers=[...], deps_providers=[...], dashboard_cards=[...], dashboard_modals=[...])`**.
+- **`options=[OptionSpec(...)]`** if finance exposes `finance[...]` bracket options (e.g. `finance[snaptrade]`); register the handler in `aegis/cli/callbacks.py::SERVICE_OPTION_HANDLERS`.
+
+Once this spec exists, `aegis init` listing, `aegis add-service finance`, pruning, and update-detection all light up automatically.
+
+### 2.2 The migration — declarative `FINANCE_MIGRATION` in `aegis/core/migration_generator.py`
+- Author the 33 tables as `TableSpec`/`ColumnSpec`/`IndexSpec`/`ForeignKeySpec`/`CheckConstraintSpec` (the DSL supports everything the schema needs — partial-unique `where=`, `ondelete=`, cross-schema `ref_schema="auth"`, check constraints). The `finance_transaction ↔ finance_transfer` circular FK is an `AlterTableSpec` applied after both tables exist.
+- Set `schema="finance"` on the `ServiceMigrationSpec` (Postgres schema; ignored on SQLite).
+- Add a **finance block to `get_services_needing_migrations(context)`** (mirror payment's; append `"payment_auth_link"`-style cross-service link only if needed — finance's `owner_user_id → auth.user` is handled via `ref_schema`, not a separate link migration, unless auth is toggled independently, in which case follow the `payment_auth_link` conditional pattern).
+- In `aegis/core/copier_manager.py`: derive `is_finance_included`, add to `needs_migration_files`, and add `AnswerKeys.FINANCE: is_finance_included` to the migration `context`.
+- Revision numbering is automatic (`get_next_revision_id` / `get_previous_revision`) — **do not hardcode**.
+
+### 2.3 `copier.yml`
+```yaml
+include_finance:
+  type: bool
+  help: "Include finance aggregator service (Plaid/SnapTrade/import)?"
+  default: false
+
+finance_plaid:      { type: bool, default: true,  when: "{{ include_finance }}" }
+finance_snaptrade:  { type: bool, default: true,  when: "{{ include_finance }}" }
+finance_investments:{ type: bool, default: true,  when: "{{ include_finance }}" }
+finance_import:     { type: bool, default: true,  when: "{{ include_finance }}" }
+```
+- Append `or include_finance` to `_include_migrations` (copier.yml ~:327) **and** to the alembic gate in `pyproject.toml.jinja` (~:78).
+- Add `include_finance:` (+ sub-flags) to `.copier-answers.yml.jinja`.
+- Note: the `_X_deps` computed vars are **dead** (referenced only in copier.yml); real deps go in §2.4.
+
+### 2.4 Dependencies (two places, kept in parity)
+- `pyproject.toml.jinja` (~:118): a `{%- if include_finance %}` block listing deps.
+- `SERVICES["finance"].pyproject_deps=[...]` — identical list/order.
+- Candidate deps: `plaid-python>=…` (Plaid), a SnapTrade SDK or `httpx` (SnapTrade), `ofxtools>=…` (OFX/QFX), `quiffen>=…` (QIF). Keep provider deps gated by their sub-flags where possible.
+
+### 2.5 The `{% if include_finance %}` template touch-list (mirror `include_payment`, ~17 files)
+`app/components/backend/api/routing.py.jinja` (router import + mount) · `api/deps.py.jinja` (finance deps provider) · `app/core/config.py.jinja` (PLAID_*/SNAPTRADE_* settings block) · `app/components/frontend/dashboard/cards/__init__.py.jinja` (import + grid + the OR-guards that render the services row) · `.../modals/__init__.py.jinja` · `app/cli/main.py.jinja` (try/except `add_typer` for `finance.py`) · `alembic/env.py.jinja` (model import block) · `app/components/backend/startup/database_init.py.jinja` (`finance_needs_migrations` + seed hook) · `app/components/backend/startup/component_health.py.jinja` · `app/components/scheduler/main.py.jinja` (if finance schedules jobs — §7) · `pyproject.toml.jinja` · `.copier-answers.yml.jinja` · `Dockerfile.jinja` · `tests/conftest.py.jinja` · `docker-compose*.jinja` (only if finance needs a new service/env). Plus `post_gen_tasks.py` alembic-removal gets a `finance_needs_migrations` term.
+
+### 2.6 New service tree (rendered under `{{ '{{ project_slug }}' }}/`)
+```
+app/services/finance/                       # models.py(.jinja), schemas, finance_service.py, deps.py,
+  providers/{base,plaid,snaptrade,manual}.py(.jinja)   # constants, health, seed, sub-services,
+  importers/{base,ofx,qif,csv_profiles}.py            # categorize/, recurring.py, jobs.py.jinja
+  finance_context.py.jinja                  # {% if include_ai %} Illiana provider (§9)
+app/components/backend/api/finance/         # router.py.jinja, views/display endpoints
+app/components/frontend/dashboard/cards/finance_card.py      # Flet card (§10)
+app/components/frontend/dashboard/modals/finance_modal.py    # Flet modal (§10)
+app/cli/finance.py.jinja                    # import-quicken / import-csv / sync / connect (Typer)
+tests/services/test_finance_*.py
+docs/services/finance/                      # shipped service docs
+```
+
+### 2.7 Prerequisites & validation
+Declared on the spec (§2.1) and enforced by `validate_service_dependencies()` + `service_resolver.py`. Finance requires database + scheduler (components) and auth (service, for `owner_user_id`). If a sub-option needs more (e.g. a future `finance[per_user]`), use the conditional cross-service block in `service_resolver.py` (the `insights[per_user] → auth[org]` precedent). Missing components are surfaced + auto-added at `add-service` time.
+
+---
+
+## 3. Connectivity — the decision (unchanged)
+
+Provider-polymorphic connection layer. Same table as the design: **Plaid** (Chase/AMEX/Vanguard, free Trial = 10 live Items incl. Investments), **SnapTrade** for **Fidelity**/brokerages ($1/user/mo, self-serve, rides Akoya — because **Fidelity-via-Plaid is unreliable**, Fidelity states it "does not utilize Plaid"), **manual/file import** as the permanent fallback, and crypto later (exchange key / on-chain / manual — Plaid doesn't cover it). In the template these are gated by `finance_plaid` / `finance_snaptrade` sub-flags; the `manual` provider always ships. Details + the Fidelity caveat: [`finance-research/03-stocks-crypto-connectivity-brief.md`](./finance-research/03-stocks-crypto-connectivity-brief.md).
+
+---
+
+## 4. Data model
+
+The full 33-table schema, dedup contract, modeling decisions, ER diagram, and existing-schema touchpoints are in **[`finance-schema-canonical.md`](./finance-schema-canonical.md)**. For aegis-stack it is realized as (a) `app/services/finance/models.py` SQLModel classes and (b) the declarative `FINANCE_MIGRATION` spec (§2.2) — both dialect-aware, in a Postgres `finance` schema. 26 tables populate in v1; 7 ship reserved-but-empty (the "never add a table later" insurance). Money = int minor units; enums = String+CheckConstraint (owned) / TEXT (provider taxonomies); two-lane dedup via partial-unique indexes with a `ck_dedup_lane` guard.
+
+---
+
+## 5. Provider integration (Plaid & SnapTrade adapters)
+
+`app/services/finance/providers/` — a `BaseFinanceProvider` protocol with normalized result dataclasses, exactly like `payment/providers/` wraps Stripe behind `BasePaymentProvider`. `plaid.py` (official `plaid-python` SDK: Link token → public_token → `/item/public_token/exchange` → encrypted access_token; `/transactions/sync` cursor loop; `/investments/*`; `/liabilities/get`; webhook verify). `snaptrade.py` (brokerage authorization → aggregator_token; positions/balances/transactions normalized into the SAME `finance_account`/`finance_security`/`finance_holding`/`finance_trade` tables). `manual.py` (no-op). Token exchange mirrors the existing OAuth "connect-for-data" precedent; secrets encrypted via `app.core.encryption.encrypt_secret(..., context="finance_connection:{id}:{col}")`. Provider files are gated by their `finance_plaid`/`finance_snaptrade` sub-flags; the base protocol + manual always ship. Full flow (Link, sync invariant, pending→posted, webhooks, re-auth): [`finance-research/01-domain-brief.md`](./finance-research/01-domain-brief.md).
+
+---
+
+## 6. Import pipeline — Quicken / OFX / CSV / manual
+
+Mirrors the blog `/import` `UploadFile` pattern. `POST /api/v1/finance/import` dispatches by extension (`.qfx`/`.ofx` → `ofxtools`; `.qif` → `quiffen`; `.csv` → data-driven `finance_import_profile`). Typer CLI `finance import-quicken`/`import-csv` runs the same ingest synchronously. Two-lane dedup + cross-source reconciliation exactly per the schema doc's §2. `finance_import_batch`/`_row` give reversible, review-before-commit imports.
+
+---
+
+## 7. Sync & scheduled jobs (backend-agnostic — inline, NOT taskiq)
+
+**Key difference from the Pulse draft:** in the template, `worker_backend` ∈ {arq, taskiq, dramatiq}, and payment/insights do NOT ship a worker queue — they run scheduled work **inline as async functions in the scheduler** (`app/services/insights/jobs.py.jinja` → `async def collect_*_job()`, wired in `scheduler/main.py.jinja` behind `{% if include_insights %}`). Finance follows this: `app/services/finance/jobs.py.jinja` with `async def finance_sync_job()` / `finance_recompute_balances_job()`, registered via `scheduler.add_job(...)` inside a `{% if include_finance %}` block. This is backend-agnostic (APScheduler just awaits the coroutine). Only if finance genuinely needs distributed execution do we add a `queues/finance{,_taskiq,_dramatiq}.py` triplet (post-gen renames per backend) — deferred; bound payloads/date ranges regardless (worker-OOM history).
+
+---
+
+## 8. Net-worth engine
+
+Unchanged: materialized daily `finance_balance_snapshot` (per account) + `finance_net_worth_snapshot` (per user), recomputed by the inline scheduler job from transactions + valuations + holdings×prices. Net worth is a persistence problem, not derivable from partial history — snapshots start day one. Manual/illiquid assets ride the same series via `finance_valuation` (source-tagged + staleness).
+
+---
+
+## 9. Categorization & "wasting money" insights (+ the real Illiana hook)
+
+- **Categorization:** capture Plaid PFC raw + map to an owned category tree; data-driven `finance_rule` engine for overrides; `finance_category_alias` for free-text QIF/CSV categories.
+- **Insights (rule-based, ship without AI):** recurring/subscription detection (`finance_recurring_stream`), price-hike, fee/interest, category overspend vs baseline. When `include_insights`, emit through the existing `insight_event` machinery (the country-spike rule pattern) so it renders in the insights UI; otherwise store finance-local `finance_insight` rows.
+- **Illiana (works in the template):** unlike Pulse, the template's AI service is real when `include_ai`. Ship `app/services/finance/finance_context.py.jinja` gated `{% if include_ai and include_finance %}`, following `health_context.py`/`usage_context.py`/`rag_context.py` — it assembles accounts/spend/streams into the agent prompt so Illiana can narrate "you're wasting money on X." No cross-repo port needed; it's a conditional file.
+
+---
+
+## 10. UI — Flet dashboard card + modal (the template convention)
+
+The template's dashboard is **Flet** (no web_frontend/Alpine — that's Pulse-only). Finance ships `frontend/dashboard/cards/finance_card.py` (net-worth headline + connection-health chips) and `modals/finance_modal.py` (Accounts, Transactions, Net Worth, Investments views), registered via `PluginWiring.dashboard_cards/dashboard_modals` and the `cards/__init__.py.jinja` grid + OR-guards — mirroring `payment_card.py`/`insights_card.py`. (A downstream project with its own web_frontend, like Pulse, would additionally render finance in its own idiom; that is out of scope for the template.)
+
+---
+
+## 11. Security & encryption
+
+- **Encryption primitive exists in the template:** `app/core/encryption.py` (AES-256-GCM, `encrypt_secret/decrypt_secret` with row-bound AAD `context`). Finance stores provider tokens as ciphertext columns on `finance_connection`, encrypted in the service layer; `__repr__` masks them. Precedent: insights `Project.plausible_api_key`.
+- **Key-rotation CLI gap:** the template has **no `app/cli/security.py`** (Pulse-only; pending the auth/encryption backport). So the "register finance encrypted columns in the rotation CLI" step is **blocked/deferred** until that backport lands — flag it, and define the `_ENCRYPTED_COLUMNS` tuple in the finance service now so wiring it is a one-liner later. (Missing rotation coverage silently strands finance creds on a future key rotation — document loudly.)
+- Read-only scopes only; never store bank credentials; Plaid webhook signature verified; `/item/remove` + soft-delete on disconnect to stop per-Item billing.
+
+---
+
+## 12. Config & env
+
+- `app/core/config.py.jinja`: a `{% if include_finance %}` settings block — `PLAID_CLIENT_ID/SECRET/ENV/WEBHOOK_URL/REDIRECT_URI` (gated by `finance_plaid`), `SNAPTRADE_CLIENT_ID/CONSUMER_KEY` (gated by `finance_snaptrade`), `FINANCE_DEFAULT_CURRENCY`. Add a prod-safety `@model_validator` (require keys when `PLAID_ENV=production`), matching existing validators.
+- `.env.example.jinja`: matching `{% if include_finance %}` documented block.
+
+---
+
+## 13. Testing
+
+- **Template-generation tests** (the aegis-stack layer): `include_finance` on/off renders/prunes correctly; `test_pyproject_deps_parity` (spec vs jinja block); migration generation produces a valid revision chain across `include_*` combinations; `aegis add-service finance` on a generated project.
+- **Service tests** (rendered project): importers (OFX/QIF/CSV) with known-debit/known-credit sign fixtures + re-import idempotency; dedup two-lane + cross-source reconciliation; transfer pairing; recurring detection; Plaid/SnapTrade adapters against sandbox.
+- **Dual-engine:** run against **both** sqlite and postgres — the template supports both, and the pytest default may be sqlite (FK/partial-unique/`on_conflict` dialect paths verify on postgres). Follow existing services' conftest patterns.
+
+---
+
+## 14. Build phases
+
+- **Phase 0 — Registry + schema + gating.** `SERVICES["finance"]` spec, `FINANCE_MIGRATION` (33 `TableSpec`), copier.yml flags, `pyproject`/`env.py`/`config`/`post_gen` gating, seeds (currencies + PFC category tree + institutions + import profiles). *Exit: `aegis init --include-finance` on sqlite AND postgres generates a project whose migration applies clean; `include_finance=false` prunes cleanly; parity test green.*
+- **Phase 1 — Manual + import.** Manual accounts + valuations; OFX/QIF/CSV importers + `/import` + CLI; dedup; Flet card + modal (Accounts/Transactions). *Exit: import a Quicken/AMEX file, idempotent re-import.*
+- **Phase 2 — Plaid.** `providers/plaid.py`, Link, `/transactions/sync`, webhook + health, inline sync job. Chase + AMEX. *Exit: sandbox item syncs; reconnect UX.*
+- **Phase 3 — Investments + net worth.** Plaid Investments + **SnapTrade (Fidelity)**; securities/holdings/trades; snapshot engine; Investments + Net Worth views. *Exit: Fidelity holdings + net-worth chart.*
+- **Phase 4 — Insights.** Transfer detection, recurring/subscription, rule-based "wasting money" via `insight_event`. *Exit: subscriptions + a price-hike/overspend insight.*
+- **Phase 5 — Illiana + `aegis add-service`.** `finance_context.py` (when `include_ai`); finalize `template_files` + `ManualUpdater` path so `aegis add-service finance` works on existing projects. *Exit: add-service onto a generated app; Illiana narrates finance insights.*
+
+---
+
+## 15. Open decisions to confirm
+
+Design defaults (money int minor units, disconnect retention, USD-only FX, high-confidence-only cross-source merge, SnapTrade-primary for Fidelity, Transactions+Investments+Liabilities at launch, self-contained trades) are in the schema doc. aegis-stack-specific ones:
+1. **Sub-flag granularity** — one `include_finance`, or split `finance_plaid`/`finance_snaptrade`/`finance_investments`/`finance_import` as gating sub-questions? *(Default: sub-flags, providers gated individually.)*
+2. **Worker: inline vs queue** — inline scheduler jobs (backend-agnostic, matches insights) vs a per-backend `queues/finance*` triplet for distributed sync. *(Default: inline for v1.)*
+3. **Postgres-only vs dual-engine** — require postgres for finance, or fully support sqlite dev? *(Default: dual-engine, postgres recommended.)*
+4. **Encryption/rotation dependency** — proceed with `encrypt_secret` now and defer rotation-CLI registration until the auth/encryption backport, or pull that backport forward first? *(Default: proceed; leave a `_ENCRYPTED_COLUMNS` hook.)*
+5. **Insights coupling** — `insight_event` reuse requires `include_insights`; if absent, use finance-local `finance_insight`. Make finance *recommend* insights? *(Default: recommend, degrade gracefully.)*
+
+---
+
+## Appendix — research sources
+
+- [`finance-schema-canonical.md`](./finance-schema-canonical.md) — the 33-table schema (now framed for the aegis-stack migration DSL).
+- [`finance-research/00-codebase-conventions.md`](./finance-research/00-codebase-conventions.md) — conventions (captured from Pulse; the template shares them).
+- [`finance-research/01-domain-brief.md`](./finance-research/01-domain-brief.md) — Plaid API, Chase/AMEX, Quicken/OFX/CSV formats, OSS schemas.
+- [`finance-research/02-product-insights-brief.md`](./finance-research/02-product-insights-brief.md) — product teardowns + the hard problems.
+- [`finance-research/03-stocks-crypto-connectivity-brief.md`](./finance-research/03-stocks-crypto-connectivity-brief.md) — Plaid Investments, Fidelity/SnapTrade/Akoya, crypto + manual.
+
+> Note: the earlier Pulse-targeted plan (`aegis-pulse/docs/plans/finance-service-plan.md`) is superseded by this document. Its architecture/integration sections are largely reusable; the differences are exactly §2 (packaging), §7 (inline jobs), §10 (Flet UI), and §11 (rotation-CLI gap) here.

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -122,6 +122,9 @@ NAMED_PROJECT_SPECS: dict[str, ProjectTemplateSpec] = {
     "blog_with_database": ProjectTemplateSpec(
         components=("database",), services=("blog",)
     ),
+    "finance_with_database": ProjectTemplateSpec(
+        components=("database", "scheduler"), services=("finance",)
+    ),
     "comms_only": ProjectTemplateSpec(services=("comms",)),
     "everything": ProjectTemplateSpec(
         components=("database", "scheduler", "worker", "redis"),

--- a/tests/cli/test_ai_configuration.py
+++ b/tests/cli/test_ai_configuration.py
@@ -56,6 +56,7 @@ class TestAIProviderSelection:
             False,  # comms
             False,  # insights
             False,  # blog service
+            False,  # finance service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -97,6 +98,7 @@ class TestAIProviderSelection:
             False,  # comms
             False,  # insights
             False,  # blog service
+            False,  # finance service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -139,6 +141,7 @@ class TestAIProviderSelection:
             False,  # comms
             False,  # insights
             False,  # blog service
+            False,  # finance service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -169,6 +172,7 @@ class TestAIProviderSelection:
             False,  # comms
             False,  # insights
             False,  # blog service
+            False,  # finance service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -227,6 +231,7 @@ class TestAIBackendSelection:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -283,6 +288,7 @@ class TestAIBackendSelection:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -329,6 +335,7 @@ class TestAIBackendSelection:
             False,  # comms
             False,  # insights
             False,  # blog service
+            False,  # finance service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -494,6 +501,7 @@ class TestAIConfigurationEndToEnd:
             False,  # comms
             False,  # insights
             False,  # blog service
+            False,  # finance service
         ]
 
         # Run interactive selection
@@ -599,6 +607,7 @@ class TestOllamaModeSelection:
             False,  # comms
             False,  # insights
             False,  # blog service
+            False,  # finance service
         ]
 
         interactive_project_selection()

--- a/tests/cli/test_guided.py
+++ b/tests/cli/test_guided.py
@@ -31,9 +31,9 @@ def _drive(keys: list[str]):
 
 
 # worker scheduler database redis ingress observability |
-# auth payment ai comms insights blog
+# auth payment ai comms insights blog finance
 # (redis is skipped entirely when an accepted worker already bundled it)
-_DECLINE_ALL = ["n"] * 12
+_DECLINE_ALL = ["n"] * 13
 
 
 class TestGuidedDrivesEngine:
@@ -44,7 +44,7 @@ class TestGuidedDrivesEngine:
 
     def test_add_database_only(self) -> None:
         # yes only on the 3rd confirm (database); engine screen -> enter = SQLite
-        keys = ["n", "n", "y", "\r"] + ["n"] * 9
+        keys = ["n", "n", "y", "\r"] + ["n"] * 10
         state = _drive(keys)
         assert state.components == ["database"]
         assert state.services == []
@@ -52,7 +52,7 @@ class TestGuidedDrivesEngine:
     def test_add_database_postgres_neon(self) -> None:
         # database yes -> engine: right+enter = PostgreSQL -> host: right+enter
         # = Neon. Encodes as database[neon] (engine normalizes to postgres).
-        keys = ["n", "n", "y", "right", "\r", "right", "\r"] + ["n"] * 9
+        keys = ["n", "n", "y", "right", "\r", "right", "\r"] + ["n"] * 10
         state = _drive(keys)
         assert state.components == ["database[neon]"]
         assert state.postgres_provider == "neon"
@@ -60,7 +60,7 @@ class TestGuidedDrivesEngine:
     def test_add_database_postgres_container(self) -> None:
         # database yes -> engine: right+enter = PostgreSQL -> host: enter =
         # local container (the default). Encodes as database[postgres].
-        keys = ["n", "n", "y", "right", "\r", "\r"] + ["n"] * 9
+        keys = ["n", "n", "y", "right", "\r", "\r"] + ["n"] * 10
         state = _drive(keys)
         assert state.components == ["database[postgres]"]
         assert state.postgres_provider == "container"
@@ -70,7 +70,7 @@ class TestGuidedDrivesEngine:
         # skips the redis screen entirely (no point asking for something
         # already added). worker(y) backend(enter), then decline the
         # remaining 4 asked components and all 6 services.
-        keys = ["y", "\r"] + ["n"] * 10
+        keys = ["y", "\r"] + ["n"] * 11
         state = _drive(keys)
         assert "redis" in state.components
         assert "worker" in state.components
@@ -79,7 +79,7 @@ class TestGuidedDrivesEngine:
         # decline worker, accept scheduler, then the single backend
         # screen: chips are [In-memory, SQLite, PostgreSQL] — right twice
         # lands on PostgreSQL. Database is auto-skipped; redis still asks.
-        keys = ["n", "y", "right", "right", "\r"] + ["n"] * 9
+        keys = ["n", "y", "right", "right", "\r"] + ["n"] * 10
         state = _drive(keys)
         assert "scheduler[postgres]" in state.components
         assert "database[postgres]" in state.components
@@ -88,7 +88,7 @@ class TestGuidedDrivesEngine:
     def test_auth_configures_level(self) -> None:
         # decline all 6 components, accept auth, pick RBAC (right+enter), then
         # confirm the "auth needs a database" prompt (y), decline the rest.
-        keys = _DECLINE_ALL[:6] + ["y", "right", "\r", "y"] + ["n"] * 5
+        keys = _DECLINE_ALL[:6] + ["y", "right", "\r", "y"] + ["n"] * 6
         state = _drive(keys)
         assert "auth[rbac]" in state.services
 
@@ -96,7 +96,7 @@ class TestGuidedDrivesEngine:
         # comms, insights, and payment were silently skipped by the old
         # hand-written AUTH/AI/CONTENT trio; accepting their confirms must
         # now land them in the selection.
-        keys = _DECLINE_ALL[:6] + ["n", "y", "n", "y", "y", "n"]
+        keys = _DECLINE_ALL[:6] + ["n", "y", "n", "y", "y", "n", "n"]
         state = _drive(keys)
         assert state.services == ["payment", "comms", "insights"]
 
@@ -119,7 +119,7 @@ class TestGuidedDrivesEngine:
             + ["n", "n", "y", "\r", "up", "\r", "n", "n"]  # auth n, payment n,
             # ai y -> framework, providers (Continue), rag n, voice n
             # (NO storage screen)
-            + ["n", "n", "n"]  # comms, insights, blog
+            + ["n", "n", "n", "n"]  # comms, insights, blog, finance
         )
         state = _drive(keys)
         assert "ai[postgres,pydantic-ai,public]" in state.services
@@ -133,7 +133,7 @@ class TestGuidedDrivesEngine:
             ["n", "n", "y", "\r", "n", "n", "n"]  # database accepted, engine=sqlite
             + ["n", "n", "y", "\r", "up", "\r", "n", "n"]  # ai: framework,
             # providers (Continue), rag, voice — no storage screen
-            + ["n", "n", "n"]
+            + ["n", "n", "n", "n"]
         )
         state = _drive(keys)
         assert "ai[sqlite,pydantic-ai,public]" in state.services
@@ -148,7 +148,7 @@ class TestGuidedDrivesEngine:
             + ["down", "\r", "up", "up", "\r"]  # toggle openai via enter,
             # wrap up to Continue, accept
             + ["n", "n"]  # rag, voice
-            + ["n", "n", "n"]
+            + ["n", "n", "n", "n"]
         )
         state = _drive(keys)
         assert state.services == ["ai[memory,pydantic-ai,public,openai]"]
@@ -160,7 +160,7 @@ class TestGuidedDrivesEngine:
             + ["n", "n", "y", "\r", "\r"]
             + [" ", "up", "\r"]  # uncheck LLM7.io, Continue with none
             + ["n", "n"]
-            + ["n", "n", "n"]
+            + ["n", "n", "n", "n"]
         )
         state = _drive(keys)
         assert state.services == ["ai[memory,pydantic-ai,public]"]
@@ -185,13 +185,13 @@ class TestGuidedDrivesEngine:
         # skipped screen as declined, so esc from review still rewinds.
         ui = GuidedSelectionUI(keys=["f"])
         run_guided_selection(ui)
-        assert len(ui.breadcrumbs) == 12
+        assert len(ui.breadcrumbs) == 13
         assert all("✗" in crumb for crumb in ui.breadcrumbs)
 
     def test_skip_to_services_goes_live_at_service_phase(self) -> None:
         # "s" declines the remaining components but services are still
         # asked for real — accepting auth here proves the screen was live.
-        keys = ["s", "y", "right", "\r", "y"] + ["n"] * 5
+        keys = ["s", "y", "right", "\r", "y"] + ["n"] * 6
         state = _drive(keys)
         assert state.components == []
         assert "auth[rbac]" in state.services
@@ -226,14 +226,14 @@ class TestBackNavigation:
         # Accept worker, then esc on the backend chips -> worker is
         # re-asked (journal popped) and this time declined. With worker
         # gone, redis IS asked, so the full 12 declines follow.
-        keys = ["y", "esc"] + ["n"] * 12
+        keys = ["y", "esc"] + ["n"] * 13
         state = _drive(keys)
         assert state.components == []
 
     def test_back_at_first_question_is_safe(self) -> None:
         # esc with an empty journal re-shows the welcome (a no-op when
         # scripted) and re-asks the first question.
-        keys = ["esc"] + ["n"] * 12
+        keys = ["esc"] + ["n"] * 13
         state = _drive(keys)
         assert state.components == []
 
@@ -242,7 +242,7 @@ class TestBackNavigation:
         # then decline worker -> the auto-added redis must vanish too,
         # because the engine genuinely re-runs (and the redis screen comes
         # back, hence 11 trailing declines).
-        keys = ["y", "esc", "n"] + ["n"] * 11
+        keys = ["y", "esc", "n"] + ["n"] * 12
         state = _drive(keys)
         assert "worker" not in state.components
         assert "redis" not in state.components
@@ -255,7 +255,7 @@ class TestReviewScreen:
     def test_review_enter_confirms_plan(self) -> None:
         # database accepted (engine screen -> enter = SQLite), everything else
         # declined, enter on REVIEW.
-        keys = ["n", "n", "y", "\r"] + ["n"] * 9 + ["\r"]
+        keys = ["n", "n", "y", "\r"] + ["n"] * 10 + ["\r"]
         ui = GuidedSelectionUI(keys=keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         assert "database" in plan.components
@@ -263,23 +263,23 @@ class TestReviewScreen:
         assert plan.template_files  # previews resolved for the screen
 
     def test_review_back_revises_last_answer(self) -> None:
-        # Accept blog (last question), esc on REVIEW -> blog re-asked and
-        # declined -> second REVIEW confirmed. The plan must reflect the
+        # Accept the last service (finance), esc on REVIEW -> it is re-asked
+        # and declined -> second REVIEW confirmed. The plan must reflect the
         # revision, not the original answer.
-        keys = _DECLINE_ALL[:11] + ["y", "esc", "n", "\r"]
+        keys = _DECLINE_ALL[:12] + ["y", "esc", "n", "\r"]
         ui = GuidedSelectionUI(keys=keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         assert plan.services == []
 
     def test_review_detail_panes_toggle_harmlessly(self) -> None:
-        keys = ["n", "n", "y"] + ["n"] * 9 + ["f", "d", "f", "\r"]
+        keys = ["n", "n", "y"] + ["n"] * 10 + ["f", "d", "f", "\r"]
         ui = GuidedSelectionUI(keys=keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         assert "database" in plan.components
 
     def test_yes_skips_review(self) -> None:
         # With --yes the review is skipped entirely: no extra key consumed.
-        keys = ["n", "n", "y", "\r"] + ["n"] * 9
+        keys = ["n", "n", "y", "\r"] + ["n"] * 10
         ui = GuidedSelectionUI(keys=keys)
         plan, _ = run_guided_init_flow("demo", "3.13", yes=True, ui=ui)
         assert "database" in plan.components
@@ -287,7 +287,7 @@ class TestReviewScreen:
     def test_plan_includes_dependency_auto_adds(self) -> None:
         # Worker accepted -> the resolved plan carries the auto-added redis
         # (same resolution quick mode runs; REVIEW shows it tagged "auto").
-        keys = ["y", "\r"] + ["n"] * 10 + ["\r"]
+        keys = ["y", "\r"] + ["n"] * 11 + ["\r"]
         ui = GuidedSelectionUI(keys=keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         bases = [c.split("[", 1)[0] for c in plan.components]
@@ -308,7 +308,7 @@ class TestInExperienceBuild:
             calls.append(plan.project_name)
             return "/tmp/demo"
 
-        keys = ["n", "n", "y", "\r"] + ["n"] * 9 + ["\r", "\r"]
+        keys = ["n", "n", "y", "\r"] + ["n"] * 10 + ["\r", "\r"]
         ui = GuidedSelectionUI(keys=keys)
         plan, _ = run_guided_init_flow(
             "demo",
@@ -410,19 +410,19 @@ class TestBreadcrumbs:
     def test_crumbs_record_each_component_decision(self) -> None:
         # Worker leads now; accepting it amends its crumb with the backend
         # and pushes the auto-added redis crumb (capability-first name).
-        ui = GuidedSelectionUI(keys=["y", "\r"] + ["n"] * 10)
+        ui = GuidedSelectionUI(keys=["y", "\r"] + ["n"] * 11)
         run_guided_selection(ui)
         assert ui.breadcrumbs[0] == "Worker ✓ arq"
         assert "Cache/Broker/Pubsub ✓" in ui.breadcrumbs
         assert "Scheduler ✗" in ui.breadcrumbs
-        # 12 entries: the skipped redis screen contributes no crumb of its
+        # 13 entries: the skipped redis screen contributes no crumb of its
         # own, but the auto-add pushed one in its place.
-        assert len(ui.breadcrumbs) == 12
+        assert len(ui.breadcrumbs) == 13
 
     def test_chip_selections_amend_the_owning_crumb(self) -> None:
         # scheduler accepted, postgres backend: the engine choice attaches
         # to the Scheduler crumb instead of adding noise.
-        keys = ["n", "y", "right", "right", "\r"] + ["n"] * 9
+        keys = ["n", "y", "right", "right", "\r"] + ["n"] * 10
         ui = GuidedSelectionUI(keys=keys)
         run_guided_selection(ui)
         assert "Scheduler ✓ postgres" in ui.breadcrumbs
@@ -430,7 +430,7 @@ class TestBreadcrumbs:
     def test_worker_auto_added_redis_pushes_its_crumb(self) -> None:
         # Worker accepted: the engine bundles redis and pushes its crumb
         # (the redis screen itself is skipped, so this is its only trace).
-        keys = ["y", "\r"] + ["n"] * 10
+        keys = ["y", "\r"] + ["n"] * 11
         ui = GuidedSelectionUI(keys=keys)
         run_guided_selection(ui)
         assert "Cache/Broker/Pubsub ✓" in ui.breadcrumbs
@@ -441,7 +441,7 @@ class TestBreadcrumbs:
         # answer; the auto-pushed redis crumb rides with it. esc again to
         # back out of worker entirely, then decline it — redis is asked
         # for real this time and declined.
-        keys = ["y", "\r", "esc", "esc", "n"] + ["n"] * 11
+        keys = ["y", "\r", "esc", "esc", "n"] + ["n"] * 12
         ui = GuidedSelectionUI(keys=keys)
         run_guided_selection(ui)
         assert "Cache/Broker/Pubsub ✗" in ui.breadcrumbs
@@ -451,7 +451,7 @@ class TestBreadcrumbs:
     def test_auto_added_database_gets_its_own_crumb(self) -> None:
         # Picking a persistent scheduler backend pulls in Database; the
         # sidebar must show that, not hide it inside the Scheduler crumb.
-        keys = ["n", "y", "right", "right", "\r"] + ["n"] * 9
+        keys = ["n", "y", "right", "right", "\r"] + ["n"] * 10
         ui = GuidedSelectionUI(keys=keys)
         run_guided_selection(ui)
         assert "Database ✓ postgres" in ui.breadcrumbs
@@ -463,7 +463,7 @@ class TestBreadcrumbs:
         # In-memory means no auto database, so the Database screen comes
         # back on the replayed pass: 10 declines, not 9.
         keys = ["n", "y", "right", "right", "\r", "esc"]
-        keys += ["left", "left", "\r"] + ["n"] * 10
+        keys += ["left", "left", "\r"] + ["n"] * 11
         ui = GuidedSelectionUI(keys=keys)
         run_guided_selection(ui)
         # The auto-pushed crumb is gone; what remains is the re-asked (and
@@ -479,7 +479,7 @@ class TestBreadcrumbs:
             + ["n", "n", "y", "\r", "right", "\r", "up", "\r", "n", "n"]
             # ai -> framework, storage right (sqlite), providers Continue,
             # rag n, voice n
-            + ["n", "n", "n"]
+            + ["n", "n", "n", "n"]
         )
         ui = GuidedSelectionUI(keys=keys)
         run_guided_selection(ui)
@@ -491,7 +491,7 @@ class TestBreadcrumbs:
         keys = (
             _DECLINE_ALL[:6]
             + ["n", "n", "y", "\r", "right", "\r", "up", "\r", "n", "n"]
-            + ["n", "n", "n"]
+            + ["n", "n", "n", "n"]
         )
         ui = GuidedSelectionUI(keys=keys)
         run_guided_selection(ui)
@@ -537,7 +537,7 @@ class TestBreadcrumbs:
     def test_back_rewinds_the_trail(self) -> None:
         # Worker accepted then revised to declined via esc on the backend
         # chips: the trail must show the revised answer, not the original.
-        ui = GuidedSelectionUI(keys=["y", "esc"] + ["n"] * 12)
+        ui = GuidedSelectionUI(keys=["y", "esc"] + ["n"] * 13)
         run_guided_selection(ui)
         assert ui.breadcrumbs[0] == "Worker ✗"
         assert all("✓" not in crumb for crumb in ui.breadcrumbs)

--- a/tests/cli/test_interactive_project_selection.py
+++ b/tests/cli/test_interactive_project_selection.py
@@ -25,7 +25,7 @@ from aegis.constants import WorkerBackends
 class TestProjectSelectionBaseline:
     @patch("typer.confirm")
     def test_decline_everything(self, mock_confirm: Any) -> None:
-        mock_confirm.side_effect = [False] * 12
+        mock_confirm.side_effect = [False] * 13
         components, scheduler_backend, services, skip_llm = (
             interactive_project_selection()
         )
@@ -33,7 +33,7 @@ class TestProjectSelectionBaseline:
         assert scheduler_backend == "memory"
         assert services == []
         assert skip_llm is False
-        assert mock_confirm.call_count == 12
+        assert mock_confirm.call_count == 13
 
 
 class TestWorkerRedisBundling:
@@ -45,11 +45,11 @@ class TestWorkerRedisBundling:
         mock_backend.return_value = WorkerBackends.ARQ
         # worker=yes bundles redis and SKIPS the redis prompt; decline the
         # remaining 4 components and 6 services.
-        mock_confirm.side_effect = [True] + [False] * 10
+        mock_confirm.side_effect = [True] + [False] * 11
         components, _, _, _ = interactive_project_selection()
         assert "redis" in components
         assert "worker" in components
-        assert mock_confirm.call_count == 11  # redis prompt never shown
+        assert mock_confirm.call_count == 12  # redis prompt never shown
 
     @patch("aegis.cli.interactive.select_worker_backend")
     @patch("typer.confirm")
@@ -58,10 +58,10 @@ class TestWorkerRedisBundling:
     ) -> None:
         mock_backend.return_value = WorkerBackends.ARQ
         # worker=no -> redis gets its own prompt (4th) and can be accepted.
-        mock_confirm.side_effect = [False, False, False, True] + [False] * 8
+        mock_confirm.side_effect = [False, False, False, True] + [False] * 9
         components, _, _, _ = interactive_project_selection()
         assert components == ["redis"]
-        assert mock_confirm.call_count == 12
+        assert mock_confirm.call_count == 13
 
     @patch("aegis.cli.interactive.select_worker_backend")
     @patch("typer.confirm")
@@ -69,7 +69,7 @@ class TestWorkerRedisBundling:
         self, mock_confirm: Any, mock_backend: Any
     ) -> None:
         mock_backend.return_value = WorkerBackends.TASKIQ
-        mock_confirm.side_effect = [True] + [False] * 10
+        mock_confirm.side_effect = [True] + [False] * 11
         components, _, _, _ = interactive_project_selection()
         assert "worker[taskiq]" in components
         assert "worker" not in components  # bracket form replaces plain name
@@ -84,10 +84,10 @@ class TestAuthDatabaseDance:
         mock_auth_config.return_value = "basic"
         # 6 components declined, auth=yes, db-confirm=yes, then decline
         # payment, ai, comms, insights, blog
-        mock_confirm.side_effect = [False] * 6 + [True, True] + [False] * 5
+        mock_confirm.side_effect = [False] * 6 + [True, True] + [False] * 6
         components, _, services, _ = interactive_project_selection()
         assert "auth[basic]" in services
-        assert mock_confirm.call_count == 13  # db-confirm prompt was inserted
+        assert mock_confirm.call_count == 14  # db-confirm prompt was inserted
 
     @patch("aegis.cli.interactive.interactive_auth_service_config")
     @patch("typer.confirm")
@@ -96,7 +96,7 @@ class TestAuthDatabaseDance:
     ) -> None:
         mock_auth_config.return_value = "basic"
         # auth=yes but decline the database confirmation -> auth dropped
-        mock_confirm.side_effect = [False] * 6 + [True, False] + [False] * 5
+        mock_confirm.side_effect = [False] * 6 + [True, False] + [False] * 6
         _, _, services, _ = interactive_project_selection()
         assert services == []
 
@@ -112,19 +112,19 @@ class TestAuthDatabaseDance:
         # database=yes among components (3rd prompt), auth=yes -> no extra
         # db prompt
         mock_confirm.side_effect = (
-            [False, False, True, False, False, False] + [True] + [False] * 5
+            [False, False, True, False, False, False] + [True] + [False] * 6
         )
         components, _, services, _ = interactive_project_selection()
         assert "database" in components
         assert "auth[rbac]" in services
-        assert mock_confirm.call_count == 12  # no inserted db-confirm prompt
+        assert mock_confirm.call_count == 13  # no inserted db-confirm prompt
 
 
 class TestContentServices:
     @patch("typer.confirm")
     def test_blog_selected_as_plain_name(self, mock_confirm: Any) -> None:
-        # decline everything except blog (the final service prompt)
-        mock_confirm.side_effect = [False] * 11 + [True]
+        # decline everything except blog (2nd-to-last service; finance last)
+        mock_confirm.side_effect = [False] * 11 + [True, False]
         _, _, services, _ = interactive_project_selection()
         assert services == ["blog"]
 
@@ -213,7 +213,7 @@ class TestEngineWithScriptedUI:
         # insights=n, blog=y
         ui = ScriptedUI(
             confirms=[True, True, False, False]
-            + [True, False, True, False, False, True],
+            + [True, False, True, False, False, True, False],
             worker_backend="taskiq",
             scheduler_backend="postgres",
             database_engine="postgres",
@@ -242,12 +242,12 @@ class TestEngineWithScriptedUI:
     def test_transcript_captures_flow(self) -> None:
         from aegis.cli.interactive import run_project_selection
 
-        ui = ScriptedUI(confirms=[False] * 12)
+        ui = ScriptedUI(confirms=[False] * 13)
         state = run_project_selection(ui)
         assert state.components == []
         assert state.services == []
         confirms = [line for line in ui.transcript if line.startswith("[confirm]")]
-        assert len(confirms) == 12
+        assert len(confirms) == 13
 
 
 class TestDatabaseHostSelection:
@@ -259,7 +259,8 @@ class TestDatabaseHostSelection:
     """
 
     def _accept_only_database(self) -> list[bool]:
-        return [False, False, True, False, False, False] + [False] * 6
+        # 6 components (database on) + 7 services (all declined incl. finance).
+        return [False, False, True, False, False, False] + [False] * 7
 
     def test_standalone_sqlite_stays_plain(self) -> None:
         from aegis.cli.interactive import run_project_selection

--- a/tests/cli/test_interactive_scheduler.py
+++ b/tests/cli/test_interactive_scheduler.py
@@ -42,6 +42,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -53,7 +54,7 @@ class TestInteractiveSchedulerFlow:
             assert services == []  # No services selected
 
             # Verify correct calls were made (including blog service prompt)
-            assert mock_confirm.call_count == 12
+            assert mock_confirm.call_count == 13
         finally:
             clear_database_engine_selection()
 
@@ -80,6 +81,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -113,6 +115,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -142,6 +145,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -177,6 +181,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -187,7 +192,7 @@ class TestInteractiveSchedulerFlow:
             assert scheduler_backend == "sqlite"
 
             # Should not have been prompted for generic database (12 confirms total, including blog)
-            assert mock_confirm.call_count == 12
+            assert mock_confirm.call_count == 13
         finally:
             clear_database_engine_selection()
 
@@ -218,6 +223,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -253,6 +259,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()

--- a/tests/cli/test_scheduler_persistence.py
+++ b/tests/cli/test_scheduler_persistence.py
@@ -43,6 +43,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -73,6 +74,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -103,6 +105,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -135,6 +138,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -168,6 +172,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -206,6 +211,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -240,6 +246,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -406,6 +413,7 @@ class TestSchedulerPersistenceLogic:
                 False,  # comms
                 False,  # insights
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -438,6 +446,7 @@ class TestSchedulerPersistenceLogic:
                     False,  # comms
                     False,  # insights
                     False,  # blog service
+                    False,  # finance service
                 ]
 
                 components, scheduler_backend, services, _ = (

--- a/tests/cli/test_services_cli.py
+++ b/tests/cli/test_services_cli.py
@@ -269,6 +269,7 @@ class TestInteractiveServiceSelection:
                 False,  # comms service
                 False,  # insights service
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -298,6 +299,7 @@ class TestInteractiveServiceSelection:
                 False,  # comms service
                 False,  # insights service
                 False,  # blog service
+                False,  # finance service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()

--- a/tests/cli/test_stack_generation.py
+++ b/tests/cli/test_stack_generation.py
@@ -265,6 +265,21 @@ STACK_COMBINATIONS = [
         expected_pyproject_deps=["fastapi", "flet", "sqlmodel"],
     ),
     StackCombination(
+        name="finance",
+        # Finance requires database + scheduler; auth is optional (owner FK
+        # via finance_auth_link when present). This row proves standalone.
+        components=["database", "scheduler"],
+        services=["finance"],
+        description="Finance service + database + scheduler (standalone)",
+        expected_files=[
+            "app/services/finance/",
+            "app/core/db.py",
+            "app/components/scheduler/",
+        ],
+        expected_docker_services=["webserver", "scheduler"],
+        expected_pyproject_deps=["fastapi", "flet", "sqlmodel"],
+    ),
+    StackCombination(
         name="comms",
         components=[],
         services=["comms"],
@@ -422,6 +437,7 @@ def test_stack_combinations_comprehensive() -> None:
         "insights",
         "payment",
         "blog",
+        "finance",
         "comms",
         "everything",
     }

--- a/tests/core/test_migration_generator.py
+++ b/tests/core/test_migration_generator.py
@@ -89,6 +89,70 @@ class TestGetServicesNeedingMigrations:
         result = get_services_needing_migrations(context)
         assert result == ["blog"]
 
+    def test_finance_needs_migration(self) -> None:
+        """Finance service needs migrations when selected."""
+        context = {
+            "include_finance": True,
+            "include_ai": False,
+            "ai_backend": "memory",
+        }
+        assert get_services_needing_migrations(context) == ["finance"]
+
+    def test_finance_needs_migration_with_yes_string(self) -> None:
+        """Finance service supports Copier-style yes strings."""
+        context = {
+            "include_finance": "yes",
+            "include_ai": False,
+            "ai_backend": "memory",
+        }
+        assert get_services_needing_migrations(context) == ["finance"]
+
+    def test_finance_auth_link_when_both(self) -> None:
+        """finance + auth emits the owner-FK link migration, after auth+finance."""
+        context = {
+            "include_auth": True,
+            "include_finance": True,
+            "include_ai": False,
+            "ai_backend": "memory",
+        }
+        result = get_services_needing_migrations(context)
+        assert "finance_auth_link" in result
+        # auth (user table) and finance base must precede the link.
+        assert result.index("auth") < result.index("finance_auth_link")
+        assert result.index("finance") < result.index("finance_auth_link")
+
+    def test_no_finance_auth_link_without_auth(self) -> None:
+        """Standalone finance emits no link migration."""
+        context = {
+            "include_finance": True,
+            "include_ai": False,
+            "ai_backend": "memory",
+        }
+        assert "finance_auth_link" not in get_services_needing_migrations(context)
+
+    def test_finance_postgres_uses_finance_schema(self, tmp_path: Path) -> None:
+        """On Postgres, finance tables land in a dedicated ``finance`` schema
+        and the owner FK crosses to ``public.user``; SQLite stays unqualified."""
+        (tmp_path / "alembic" / "versions").mkdir(parents=True)
+        pg = {"database_engine": "postgres"}
+        fin = generate_migration(tmp_path, "finance", pg).read_text()
+        assert 'CREATE SCHEMA IF NOT EXISTS "finance"' in fin
+        assert "schema='finance'" in fin
+
+        (tmp_path / "alembic" / "versions2").mkdir(parents=True)
+        link = generate_migration(tmp_path, "finance_auth_link", pg).read_text()
+        assert "schema='finance'" in link
+        assert "referent_schema='public'" in link
+
+    def test_finance_sqlite_has_no_schema(self, tmp_path: Path) -> None:
+        """SQLite has no schemas, so the finance migration is unqualified."""
+        (tmp_path / "alembic" / "versions").mkdir(parents=True)
+        fin = generate_migration(
+            tmp_path, "finance", {"database_engine": "sqlite"}
+        ).read_text()
+        assert "CREATE SCHEMA" not in fin
+        assert "schema='finance'" not in fin
+
     def test_auth_rbac_needs_migration(self) -> None:
         """Test auth_rbac migration needed when rbac level enabled."""
         context = {
@@ -659,6 +723,51 @@ class TestMigrationSpecs:
             "blog_post",
             "blog_tag",
         }
+
+    def test_finance_spec_exists(self) -> None:
+        """Test finance migration spec is defined (reference-data tables)."""
+        from aegis.core.migration_generator import FINANCE_MIGRATION
+
+        assert "finance" in MIGRATION_SPECS
+        assert FINANCE_MIGRATION.service_name == "finance"
+        # Public schema (SQLite + Postgres); no Postgres-only namespacing.
+        assert FINANCE_MIGRATION.schema is None
+
+        table_names = [t.name for t in FINANCE_MIGRATION.tables]
+        assert "finance_currency" in table_names
+        assert "finance_fx_rate" in table_names
+
+        currency = next(
+            t for t in FINANCE_MIGRATION.tables if t.name == "finance_currency"
+        )
+        assert {c.name for c in currency.columns} >= {"code", "decimals", "kind"}
+        assert any(idx.unique for idx in currency.indexes)
+        assert {ck.name for ck in currency.check_constraints} == {
+            "ck_finance_currency_kind",
+            "ck_finance_currency_decimals",
+        }
+
+        fx = next(t for t in FINANCE_MIGRATION.tables if t.name == "finance_fx_rate")
+        # rate_e8 is a BigInteger scaled integer, not a float.
+        rate_col = next(c for c in fx.columns if c.name == "rate_e8")
+        assert rate_col.type == "sa.BigInteger()"
+        assert {fk.ref_table for fk in fx.foreign_keys} == {"finance_currency"}
+
+    def test_generates_finance_migration(self, tmp_path: Path) -> None:
+        """Finance migration file renders with tables, FKs, and constraints."""
+        result = generate_migration(tmp_path, "finance")
+
+        assert result is not None
+        assert result.exists()
+        assert result.name == "001_finance.py"
+
+        content = result.read_text()
+        assert "'finance_currency'" in content
+        assert "'finance_fx_rate'" in content
+        assert "ck_finance_currency_kind" in content
+        assert "ck_finance_fxrate_distinct" in content
+        assert "sa.BigInteger()" in content
+        assert "finance_currency.code" in content
 
 
 class TestOrgMigrationSpec:

--- a/tests/core/test_migration_spec.py
+++ b/tests/core/test_migration_spec.py
@@ -158,6 +158,8 @@ class TestInTreeRegistry:
             "payment_auth_link",
             "insights",
             "blog",
+            "finance",
+            "finance_auth_link",
         }
 
     def test_each_migration_is_a_servicemigrationspec(self) -> None:

--- a/tests/core/test_services.py
+++ b/tests/core/test_services.py
@@ -31,6 +31,7 @@ class TestServiceType:
         assert ServiceType.ANALYTICS.value == "analytics"
         assert ServiceType.STORAGE.value == "storage"
         assert ServiceType.CONTENT.value == "content"
+        assert ServiceType.FINANCE.value == "finance"
 
     def test_service_type_enum_completeness(self):
         """Test that we have all expected service types."""
@@ -42,6 +43,7 @@ class TestServiceType:
             "analytics",
             "storage",
             "content",
+            "finance",
         }
         actual_types = {st.value for st in ServiceType}
         assert actual_types == expected_types
@@ -118,6 +120,7 @@ class TestServicesRegistry:
         assert "auth" in SERVICES
         assert "blog" in SERVICES
         assert "insights" in SERVICES
+        assert "finance" in SERVICES
 
     def test_insights_service_specification(self):
         """Test the insights service specification is properly defined."""
@@ -203,6 +206,38 @@ class TestServicesRegistry:
         spec = SERVICES["payment"]
         assert ComponentNames.BACKEND in spec.required_components
         assert ComponentNames.DATABASE in spec.required_components
+        assert ComponentNames.WORKER in spec.recommended_components
+
+    def test_finance_service_specification(self):
+        """Test the finance service specification is properly defined.
+
+        The spec ships template file paths and its migration specs
+        (FINANCE_MIGRATION + conditional FINANCE_AUTH_LINK_MIGRATION); runtime
+        wiring and pyproject deps are added by later tickets. Assert only what
+        the spec currently establishes.
+        """
+        spec = SERVICES["finance"]
+
+        assert spec.name == "finance"
+        assert spec.type == ServiceType.FINANCE
+        assert spec.description
+        assert "backend" in spec.required_components
+        assert "database" in spec.required_components
+        assert "scheduler" in spec.required_components
+        assert "worker" in spec.recommended_components
+        # Auth is integrated-when-present, not required — finance runs
+        # standalone (single-user) and links owner FKs only when auth ships.
+        assert spec.required_services == []
+        assert len(spec.template_files) > 0
+
+    def test_finance_uses_component_constants(self):
+        """Test that finance spec uses ComponentNames, not magic strings."""
+        from aegis.constants import ComponentNames
+
+        spec = SERVICES["finance"]
+        assert ComponentNames.BACKEND in spec.required_components
+        assert ComponentNames.DATABASE in spec.required_components
+        assert ComponentNames.SCHEDULER in spec.required_components
         assert ComponentNames.WORKER in spec.recommended_components
 
     def test_blog_service_specification(self):


### PR DESCRIPTION
A first-class aegis-stack template service (include_finance / `aegis add-service finance`) for a personal-finance aggregator, mirroring the payment/insights service pattern (registry spec + declarative migration + engine-gated schema).

M1 - packaging:
- include_finance copier flag + finance_plaid / finance_snaptrade / finance_import sub-flags across the template tree.
- SERVICES["finance"] registry spec: required components database+scheduler, recommended worker, runs standalone OR with auth; i18n keys; wizard-test updates.

M2 - the 33-table schema (one generated 001_finance.py from FINANCE_MIGRATION):
- reference: finance_currency, finance_fx_rate
- connections: finance_institution, finance_connection (inline AES-GCM-encrypted credential columns, masked __repr__), finance_webhook_event
- accounts: finance_account, finance_liability_detail, finance_balance_snapshot, finance_net_worth_snapshot, finance_valuation
- ledger: finance_transaction (two-lane provider/import dedup), finance_transaction_split, finance_transfer (circular FK closed via alter_tables)
- categorization: finance_category (self-FK tree), finance_category_alias, finance_merchant, finance_tag, finance_transaction_tag (composite PK), finance_rule
- investments: finance_security, finance_security_price, finance_holding, finance_trade
- analytics/import: finance_recurring_stream, finance_budget, finance_budget_category, finance_spending_baseline, finance_insight, finance_import_profile, finance_import_batch, finance_import_batch_row, finance_attachment, finance_transaction_changelog

Design:
- On Postgres every finance table lives in a dedicated "finance" schema; SQLite has no schemas so it is dropped via an engine-gated _SCHEMA.
- owner_user_id has no model-level FK; the FK to public.user is added by the finance_auth_link migration only when auth is present (cross-schema on Postgres), so finance runs standalone too.
- Circular/forward FKs (transaction<->transfer, transaction/trade -> category/ merchant/recurring/import_batch) are plain columns wired through alter_tables so create_all stays acyclic while the migration enforces them.
- Money is integer minor units (BigInteger); enums are String+CheckConstraint; dedup uses partial-unique indexes declaring both sqlite_where and postgresql_where.
- Adds an optional ForeignKeySpec.name so long alter-FK constraint names stay under Postgres' 63-char identifier limit.

Validated on SQLite and Postgres via alembic upgrade/downgrade/upgrade; 89 finance model tests pass on both engines; full make check green (1588 passed).