### PR TITLE
v0.9.1-rc2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Each generated project includes:
 
 ## Installation
 
-**Current Version**: 0.9.1rc1
+**Current Version**: 0.9.1rc2
 
 ```bash
 pip install aegis-stack

--- a/aegis/__init__.py
+++ b/aegis/__init__.py
@@ -2,4 +2,4 @@
 Aegis Stack CLI - Component generation and project management tools.
 """
 
-__version__ = "0.9.1rc1"
+__version__ = "0.9.1rc2"

--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@
 # - Update support
 
 _min_copier_version: "9.0.0"
-_version: "0.9.1rc1"
+_version: "0.9.1rc2"
 
 # IMPORTANT: Template content is in subdirectory
 # This allows the template to be recognized as git-tracked (aegis-stack repo root has .git)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-stack"
-version = "0.9.1rc1"
+version = "0.9.1rc2"
 description = "A production-ready FastAPI platform with modular components and a built-in control plane. Try: uvx aegis-stack init my-project"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { editable = "tests/fixtures/aegis_plugin_test" }
 
 [[package]]
 name = "aegis-stack"
-version = "0.9.1rc1"
+version = "0.9.1rc2"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
Version bump 0.9.1rc1 -> 0.9.1rc2.

The 0.9.1rc1 version string was accidentally published to TestPyPI on July 5 (stale tag on the old #807 merge). TestPyPI permanently forbids filename reuse, so rc1 is unusable; this increments to rc2 so the release workflow can publish the current code.

Gates:
- make check: passed (1608 tests, lint + typecheck clean)
- make test-stacks-full: running, result will be posted before tagging

🤖 Generated with [Claude Code](https://claude.com/claude-code)