### PR TITLE
v0.9.1-rc3: fix spurious update conflicts on pristine projects

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Each generated project includes:
 
 ## Installation
 
-**Current Version**: 0.9.1rc2
+**Current Version**: 0.9.1rc3
 
 ```bash
 pip install aegis-stack

--- a/aegis/__init__.py
+++ b/aegis/__init__.py
@@ -2,4 +2,4 @@
 Aegis Stack CLI - Component generation and project management tools.
 """
 
-__version__ = "0.9.1rc2"
+__version__ = "0.9.1rc3"

--- a/aegis/core/manual_updater.py
+++ b/aegis/core/manual_updater.py
@@ -8,8 +8,6 @@ and copies files to the target project.
 
 import shutil
 import subprocess
-import sys
-import tempfile
 from pathlib import Path
 from typing import Any
 
@@ -25,7 +23,11 @@ from ..cli import brand
 from .component_files import get_component_files, get_copier_defaults, get_template_path
 from .copier_manager import is_copier_project, load_copier_answers
 from .plugins.template_resolver import get_plugin_template_root
-from .template_cleanup import merge_three_way_text, run_resilient
+from .template_cleanup import (
+    merge_three_way_text,
+    normalize_for_compare,
+    run_ruff_on_text,
+)
 from .verbosity import verbose_print
 
 # Constants
@@ -76,28 +78,9 @@ def _is_empty_stub(path: Path) -> bool:
         return False
 
 
-def _normalize_for_compare(text: str) -> str:
-    """Canonicalize text for divergence comparison.
-
-    Strips per-line trailing whitespace and trailing blank lines, and
-    normalizes line endings. This absorbs the only difference between a
-    file as Copier wrote it at init and the same file as
-    ``_render_template_file`` re-renders it: blank-line whitespace, which
-    differs because Copier and this module configure Jinja differently.
-    """
-    lines = text.replace("\r\n", "\n").split("\n")
-    return "\n".join(line.rstrip() for line in lines).rstrip("\n")
-
-
-def _ruff_executable() -> str | None:
-    """Locate a ruff binary, preferring the one in the running interpreter's
-    environment. ``ruff`` is a runtime dependency of aegis, so this is
-    normally present; returns None if it cannot be found (callers then bias
-    toward preserving the file rather than overwriting it)."""
-    candidate = Path(sys.executable).parent / "ruff"
-    if candidate.is_file():
-        return str(candidate)
-    return shutil.which("ruff")
+# Canonicalization/ruff helpers live in template_cleanup so the update-sync
+# path can share them; imported above as normalize_for_compare / run_ruff_on_text.
+_normalize_for_compare = normalize_for_compare
 
 
 # Directories that should never be swept. Some contain authored content
@@ -690,68 +673,7 @@ class ManualUpdater:
         The temp file lives in the project so ruff discovers the project's
         ``[tool.ruff]`` config by walking up from the file's location.
         """
-        ruff = _ruff_executable()
-        if ruff is None:
-            return None
-        tmp_path = ""
-        try:
-            with tempfile.NamedTemporaryFile(
-                "w",
-                suffix=".py",
-                dir=str(self.project_path),
-                delete=False,
-                encoding="utf-8",
-            ) as handle:
-                handle.write(src)
-                tmp_path = handle.name
-            steps: list[list[str]] = []
-            if check_select == "":
-                steps.append([ruff, "check", "--fix", "--quiet", tmp_path])
-            elif check_select is not None:
-                steps.append(
-                    [
-                        ruff,
-                        "check",
-                        "--fix",
-                        "--select",
-                        check_select,
-                        "--quiet",
-                        tmp_path,
-                    ]
-                )
-            steps.append([ruff, "format", "--quiet", tmp_path])
-            for args in steps:
-                proc = run_resilient(
-                    args,
-                    cwd=str(self.project_path),
-                    capture_output=True,
-                    timeout=30,
-                    retry_on_signal_kill=True,
-                    # A merged .py file spawns ~6 ruff subprocesses; under a
-                    # parallel test/CI run that contends with uv/git/copier,
-                    # fork failures (EAGAIN) and timeouts spike briefly. A
-                    # wider retry budget rides out the spike instead of
-                    # silently degrading the merge to preserve+warn.
-                    retries=5,
-                    backoff=1.0,
-                )
-                # ``ruff check --fix`` exits 1 when fixable issues remain after
-                # fixing (normal — e.g. unfixable lint rules); only >=2 is a
-                # real error (bad config, unreadable file). ``ruff format``
-                # exits non-zero only on error (e.g. unparseable input). Either
-                # way, bail to None so the caller preserves the file rather than
-                # acting on partially/unformatted output.
-                is_format = args[1] == "format"
-                if (is_format and proc.returncode != 0) or (
-                    not is_format and proc.returncode >= 2
-                ):
-                    return None
-            return Path(tmp_path).read_text()
-        except (OSError, subprocess.SubprocessError):
-            return None
-        finally:
-            if tmp_path:
-                Path(tmp_path).unlink(missing_ok=True)
+        return run_ruff_on_text(src, self.project_path, check_select)
 
     def _ruff_normalize(self, src: str) -> str | None:
         """Return ``src`` run through the project's full ruff (check --fix + format).

--- a/aegis/core/template_cleanup.py
+++ b/aegis/core/template_cleanup.py
@@ -7,6 +7,7 @@ dealing with nested directory structures created during template updates.
 
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import dataclass, field
@@ -68,6 +69,111 @@ def run_resilient(
         return proc
     assert last_exc is not None
     raise last_exc
+
+
+def normalize_for_compare(text: str) -> str:
+    """Canonicalize text for divergence comparison.
+
+    Strips per-line trailing whitespace and trailing blank lines, and
+    normalizes line endings. This absorbs whitespace-only differences
+    between a file as Copier wrote it and a re-render of the same template
+    (Jinja configuration differences surface as blank-line whitespace).
+    """
+    lines = text.replace("\r\n", "\n").split("\n")
+    return "\n".join(line.rstrip() for line in lines).rstrip("\n")
+
+
+def ruff_executable() -> str | None:
+    """Locate a ruff binary, preferring the one in the running interpreter's
+    environment. ``ruff`` is a runtime dependency of aegis, so this is
+    normally present; returns None if it cannot be found (callers then bias
+    toward preserving the file rather than overwriting it)."""
+    candidate = Path(sys.executable).parent / "ruff"
+    if candidate.is_file():
+        return str(candidate)
+    return shutil.which("ruff")
+
+
+def run_ruff_on_text(
+    src: str, project_path: Path, check_select: str | None
+) -> str | None:
+    """Run ruff over ``src`` and return the result, or None on any failure.
+
+    ``check_select`` controls the ``ruff check --fix`` step that runs
+    before ``ruff format``:
+      - ``""``  → check with the project's configured rule set (used for
+        equality comparison, where matching ``make fix`` exactly matters;
+        the result must never be written to disk because destructive rules
+        like unused-import removal are in play).
+      - a value like ``"I"`` → check with only those rules (used before a
+        merge, where we must NOT delete code — isort never removes).
+      - ``None`` → skip check entirely, format only.
+
+    The temp file lives in the project so ruff discovers the project's
+    ``[tool.ruff]`` config by walking up from the file's location.
+    """
+    ruff = ruff_executable()
+    if ruff is None:
+        return None
+    tmp_path = ""
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            suffix=".py",
+            dir=str(project_path),
+            delete=False,
+            encoding="utf-8",
+        ) as handle:
+            handle.write(src)
+            tmp_path = handle.name
+        steps: list[list[str]] = []
+        if check_select == "":
+            steps.append([ruff, "check", "--fix", "--quiet", tmp_path])
+        elif check_select is not None:
+            steps.append(
+                [
+                    ruff,
+                    "check",
+                    "--fix",
+                    "--select",
+                    check_select,
+                    "--quiet",
+                    tmp_path,
+                ]
+            )
+        steps.append([ruff, "format", "--quiet", tmp_path])
+        for args in steps:
+            proc = run_resilient(
+                args,
+                cwd=str(project_path),
+                capture_output=True,
+                timeout=30,
+                retry_on_signal_kill=True,
+                # A merged .py file spawns ~6 ruff subprocesses; under a
+                # parallel test/CI run that contends with uv/git/copier,
+                # fork failures (EAGAIN) and timeouts spike briefly. A
+                # wider retry budget rides out the spike instead of
+                # silently degrading the merge to preserve+warn.
+                retries=5,
+                backoff=1.0,
+            )
+            # ``ruff check --fix`` exits 1 when fixable issues remain after
+            # fixing (normal — e.g. unfixable lint rules); only >=2 is a
+            # real error (bad config, unreadable file). ``ruff format``
+            # exits non-zero only on error (e.g. unparseable input). Either
+            # way, bail to None so the caller preserves the file rather than
+            # acting on partially/unformatted output.
+            is_format = args[1] == "format"
+            if (is_format and proc.returncode != 0) or (
+                not is_format and proc.returncode >= 2
+            ):
+                return None
+        return Path(tmp_path).read_text(encoding="utf-8")
+    except (OSError, subprocess.SubprocessError):
+        return None
+    finally:
+        if tmp_path:
+            Path(tmp_path).unlink(missing_ok=True)
 
 
 @dataclass
@@ -375,6 +481,19 @@ def sync_template_changes(
                         # Template didn't change this file — keep user's version
                         verbose_print(f"   Preserved: {relative} (user customized)")
                         continue
+                    elif project_file.name.endswith(".py") and _sync_python_file(
+                        project_file,
+                        old_file,
+                        template_file,
+                        relative,
+                        result,
+                        project_path,
+                    ):
+                        # Handled with formatting awareness: init-time
+                        # ``make fix`` reformats project files, so a byte
+                        # comparison against the raw renders misreads
+                        # formatting as user edits (spurious conflicts).
+                        continue
                     else:
                         # All three differ — 3-way merge
                         _three_way_merge(
@@ -399,6 +518,81 @@ def sync_template_changes(
             verbose_print(f"   Backfilled new answer: {key}")
 
     return result
+
+
+def _sync_python_file(
+    project_file: Path,
+    old_file: Path,
+    new_file: Path,
+    relative: Path,
+    result: SyncResult,
+    project_path: Path,
+) -> bool:
+    """Sync a Python file whose three versions all differ, looking through
+    formatting.
+
+    ``aegis init`` post-gen runs ``make fix``, so project files are
+    ruff-formatted while the old/new template renders are raw Jinja output
+    (blank-line runs from unselected ``{% if %}`` blocks, unsorted imports).
+    Compared byte-wise that formatting reads as user edits, turning a
+    pristine file into a merge with conflicts wherever real template
+    changes land near the formatting differences. Mirrors the add/remove
+    path's fix for issue #715 (``ManualUpdater._merge_shared_file``).
+
+    Returns True when the file was handled (synced, preserved, merged, or
+    genuinely conflicted after a normalized merge); False when ruff or git
+    is unavailable, so the caller falls back to the raw 3-way merge.
+    """
+    project_text = project_file.read_text(encoding="utf-8")
+    old_text = old_file.read_text(encoding="utf-8")
+
+    # Full-rule normalization matches what ``make fix`` did to the project
+    # file at init; comparison only, never written to disk.
+    project_norm = run_ruff_on_text(project_text, project_path, "")
+    old_norm = run_ruff_on_text(old_text, project_path, "")
+    if project_norm is None or old_norm is None:
+        return False
+
+    if normalize_for_compare(project_norm) == normalize_for_compare(old_norm):
+        # Pristine: the project file differs from the old render only by
+        # formatting. Take the new render wholesale; post-gen formatting
+        # reformats it after a conflict-free update.
+        project_file.write_bytes(new_file.read_bytes())
+        result.synced.append(str(relative))
+        verbose_print(f"   Synced: {relative} (pristine, formatting-only drift)")
+        return True
+
+    new_text = new_file.read_text(encoding="utf-8")
+    new_norm = run_ruff_on_text(new_text, project_path, "")
+    if new_norm is not None and normalize_for_compare(old_norm) == (
+        normalize_for_compare(new_norm)
+    ):
+        # The template change is formatting-only noise — keep the user's file.
+        verbose_print(f"   Preserved: {relative} (template change is format-only)")
+        return True
+
+    # Real user edit AND real template change: merge import-sorted and
+    # formatted versions of all three sides so formatting noise cannot
+    # conflict. ``--select I`` never deletes code, so the normalized ours
+    # side is safe to write back to disk.
+    project_safe = run_ruff_on_text(project_text, project_path, "I")
+    old_safe = run_ruff_on_text(old_text, project_path, "I")
+    new_safe = run_ruff_on_text(new_text, project_path, "I")
+    if project_safe is None or old_safe is None or new_safe is None:
+        return False
+
+    returncode, merged = merge_three_way_text(project_safe, old_safe, new_safe)
+    if returncode == 0:
+        project_file.write_text(merged, encoding="utf-8")
+        result.synced.append(str(relative))
+        verbose_print(f"   Merged: {relative}")
+        return True
+    if 1 <= returncode <= 127:
+        project_file.write_text(merged, encoding="utf-8")
+        result.conflicts.append(str(relative))
+        verbose_print(f"   Conflict (needs manual review): {relative}")
+        return True
+    return False  # git merge-file unavailable/errored — raw fallback
 
 
 def merge_three_way_text(current: str, base: str, other: str) -> tuple[int, str]:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/find-free-port.sh
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/find-free-port.sh
@@ -18,23 +18,44 @@ max="${2:-20}"
 
 is_free() {
     python3 - "$1" <<'PY'
+import errno
 import socket
 import sys
 
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-sock.settimeout(1.0)
-try:
-    sock.connect(("127.0.0.1", int(sys.argv[1])))
-except ConnectionRefusedError:
-    sys.exit(0)  # nothing listening -> port is free
-except OSError:
-    # Timed out / unreachable: we couldn't confirm the port is free, so
-    # treat it as unavailable rather than risk handing out a busy port.
-    sys.exit(1)
-else:
-    sys.exit(1)  # connection accepted -> port is in use
-finally:
-    sock.close()
+port = int(sys.argv[1])
+
+
+def attempt() -> int:
+    """Probe once: 0 = free, 1 = busy, -1 = self-connect collision."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1.0)
+    try:
+        sock.connect(("127.0.0.1", port))
+    except ConnectionRefusedError:
+        return 0  # nothing listening -> port is free
+    except OSError as exc:
+        # macOS allocates ephemeral SOURCE ports sequentially, so probing
+        # a port just above a recent bind makes connect() pick source ==
+        # destination and fail with EINVAL (Darwin rejects self-connects).
+        # The port is not actually in use; a retry draws a different
+        # source port and gives the real answer.
+        if exc.errno == errno.EINVAL:
+            return -1
+        # Timed out / unreachable: we couldn't confirm the port is free,
+        # so treat it as unavailable rather than risk handing out a busy
+        # port.
+        return 1
+    else:
+        return 1  # connection accepted -> port is in use
+    finally:
+        sock.close()
+
+
+for _ in range(3):
+    verdict = attempt()
+    if verdict >= 0:
+        sys.exit(verdict)
+sys.exit(1)  # persistent EINVAL: treat as unavailable
 PY
 }
 

--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@
 # - Update support
 
 _min_copier_version: "9.0.0"
-_version: "0.9.1rc2"
+_version: "0.9.1rc3"
 
 # IMPORTANT: Template content is in subdirectory
 # This allows the template to be recognized as git-tracked (aegis-stack repo root has .git)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-stack"
-version = "0.9.1rc2"
+version = "0.9.1rc3"
 description = "A production-ready FastAPI platform with modular components and a built-in control plane. Try: uvx aegis-stack init my-project"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/tests/cli/test_issue_715_shared_file_divergence.py
+++ b/tests/cli/test_issue_715_shared_file_divergence.py
@@ -23,7 +23,8 @@ import subprocess
 
 import pytest
 
-from aegis.core.manual_updater import ManualUpdater, _ruff_executable
+from aegis.core.manual_updater import ManualUpdater
+from aegis.core.template_cleanup import ruff_executable
 from tests.cli.conftest import ProjectFactory
 
 # Shares the merge path (``_regenerate_shared_files`` → ruff + git
@@ -101,7 +102,7 @@ class TestPristineSharedFilesStillRegenerate:
         project has been through ``make fix`` (import merging, quote
         normalization, line wrapping). The detector must look through that.
         """
-        ruff = _ruff_executable()
+        ruff = ruff_executable()
         if ruff is None:
             pytest.skip("ruff not available")
         assert ruff is not None  # narrow for the type checker (skip isn't NoReturn)

--- a/tests/core/test_template_cleanup.py
+++ b/tests/core/test_template_cleanup.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 import yaml
 
 from aegis.core.template_cleanup import (
@@ -694,6 +695,7 @@ class TestThreeWayMerge:
         project_slug: str,
         old_content: str,
         new_content: str,
+        filename: str = "config.py",
     ) -> Callable[..., None]:
         """Create a mock_run_copy that renders old/new based on dst_path."""
 
@@ -702,9 +704,9 @@ class TestThreeWayMerge:
             rendered_dir = Path(dst_path) / project_slug / "app"
             rendered_dir.mkdir(parents=True)
             if "/old" in dst_path:
-                (rendered_dir / "config.py").write_text(old_content)
+                (rendered_dir / filename).write_text(old_content)
             else:
-                (rendered_dir / "config.py").write_text(new_content)
+                (rendered_dir / filename).write_text(new_content)
 
         return mock_run_copy
 
@@ -766,7 +768,12 @@ class TestThreeWayMerge:
         assert project_file.read_text() == "# user customized content"
 
     def test_clean_three_way_merge(self, tmp_path: Path) -> None:
-        """When all three differ but changes don't overlap, clean merge."""
+        """When all three differ but changes don't overlap, clean merge.
+
+        Uses a non-Python file so this exercises the raw byte-level merge;
+        .py files route through the formatting-aware path covered by
+        TestSyncFormattingNoise.
+        """
         project_slug = "my-project"
         answers = {"project_slug": project_slug}
 
@@ -775,11 +782,13 @@ class TestThreeWayMerge:
         user = "user-changed-line1\nline2\nline3\n"
         new = "line1\nline2\ntemplate-changed-line3\n"
 
-        project_file = tmp_path / "app" / "config.py"
+        project_file = tmp_path / "app" / "config.txt"
         project_file.parent.mkdir(parents=True)
         project_file.write_text(user)
 
-        mock = self._make_mock(project_slug, old_content=base, new_content=new)
+        mock = self._make_mock(
+            project_slug, old_content=base, new_content=new, filename="config.txt"
+        )
 
         with patch("copier.run_copy", side_effect=mock):
             result = sync_template_changes(
@@ -790,14 +799,17 @@ class TestThreeWayMerge:
                 old_commit="abc123",
             )
 
-        assert "app/config.py" in result.synced
+        assert "app/config.txt" in result.synced
         assert result.conflicts == []
         merged = project_file.read_text()
         assert "user-changed-line1" in merged
         assert "template-changed-line3" in merged
 
     def test_conflicting_merge_writes_markers(self, tmp_path: Path) -> None:
-        """When user and template changed the same line, write conflict markers."""
+        """When user and template changed the same line, write conflict markers.
+
+        Non-Python file: exercises the raw merge path directly.
+        """
         project_slug = "my-project"
         answers = {"project_slug": project_slug}
 
@@ -805,11 +817,13 @@ class TestThreeWayMerge:
         user = "user-line1\nline2\nline3\n"
         new = "template-line1\nline2\nline3\n"
 
-        project_file = tmp_path / "app" / "config.py"
+        project_file = tmp_path / "app" / "config.txt"
         project_file.parent.mkdir(parents=True)
         project_file.write_text(user)
 
-        mock = self._make_mock(project_slug, old_content=base, new_content=new)
+        mock = self._make_mock(
+            project_slug, old_content=base, new_content=new, filename="config.txt"
+        )
 
         with patch("copier.run_copy", side_effect=mock):
             result = sync_template_changes(
@@ -821,8 +835,8 @@ class TestThreeWayMerge:
             )
 
         # Conflicting file should be reported as conflict, not synced
-        assert "app/config.py" not in result.synced
-        assert "app/config.py" in result.conflicts
+        assert "app/config.txt" not in result.synced
+        assert "app/config.txt" in result.conflicts
         # File should contain conflict markers with both versions
         content = project_file.read_text()
         assert "<<<<<<<" in content
@@ -848,11 +862,13 @@ class TestThreeWayMerge:
         user = f"user-top\n{ctx}user-bottom\n"
         new = f"template-top\n{ctx}template-bottom\n"
 
-        project_file = tmp_path / "app" / "config.py"
+        project_file = tmp_path / "app" / "config.txt"
         project_file.parent.mkdir(parents=True)
         project_file.write_text(user)
 
-        mock = self._make_mock(project_slug, old_content=base, new_content=new)
+        mock = self._make_mock(
+            project_slug, old_content=base, new_content=new, filename="config.txt"
+        )
 
         with patch("copier.run_copy", side_effect=mock):
             result = sync_template_changes(
@@ -863,8 +879,8 @@ class TestThreeWayMerge:
                 old_commit="abc123",
             )
 
-        assert "app/config.py" not in result.synced
-        assert "app/config.py" in result.conflicts
+        assert "app/config.txt" not in result.synced
+        assert "app/config.txt" in result.conflicts
         content = project_file.read_text()
         # Both conflict regions surfaced, user's side preserved in each
         assert content.count("<<<<<<<") == 2
@@ -987,3 +1003,138 @@ class TestThreeWayMerge:
 
         assert "app/config.py" in result.synced
         assert project_file.read_text() == "# new template content"
+
+
+@pytest.mark.xdist_group("generated_stacks")
+class TestSyncFormattingNoise:
+    """Formatting must not create conflicts during template sync.
+
+    ``aegis init`` post-gen runs ``make fix``, so files in a real project are
+    ruff-formatted (blank-line runs from unselected ``{% if %}`` blocks are
+    collapsed, imports sorted). The old/new template renders used by
+    ``sync_template_changes`` are raw and unformatted. A byte-level 3-way
+    merge therefore sees the pristine project file as "user edits" and
+    raises spurious conflicts wherever real template changes land near the
+    formatting differences. The sync path must look through formatting the
+    same way the add/remove path does (issue #715).
+
+    Pinned to the ``generated_stacks`` xdist group like the issue-715
+    suites: the normalized-merge path spawns ruff subprocesses, and under
+    a fully parallel CI run those transiently fail (fork pressure), which
+    degrades the sync to a raw merge and flakes these strict assertions.
+    Serializing away from the fork-heavy tests keeps ruff reliable.
+    """
+
+    @staticmethod
+    def _make_mock(
+        project_slug: str,
+        old_content: str,
+        new_content: str,
+    ) -> Callable[..., None]:
+        """Create a mock_run_copy that renders old/new based on dst_path."""
+
+        def mock_run_copy(**kwargs: object) -> None:
+            dst_path = str(kwargs["dst_path"])
+            rendered_dir = Path(dst_path) / project_slug / "app"
+            rendered_dir.mkdir(parents=True)
+            if "/old" in dst_path:
+                (rendered_dir / "config.py").write_text(old_content)
+            else:
+                (rendered_dir / "config.py").write_text(new_content)
+
+        return mock_run_copy
+
+    # Raw render: an unselected {% if %} block leaves a run of blank lines.
+    OLD_RAW = "A = 1\n\n\n\n\n\nB = 2\n"
+    # What make fix left in the project at init time (blank run collapsed).
+    PROJECT_FORMATTED = "A = 1\n\n\nB = 2\n"
+    # New template: the unselected block grew (more blank lines in the raw
+    # render, overlapping the collapsed region) AND a real setting was added.
+    NEW_RAW = "A = 1\n\n\n\n\n\n\n\n\nB = 2\nNEW_SETTING = 3\n"
+
+    def test_pristine_formatted_project_gets_no_conflicts(self, tmp_path: Path) -> None:
+        """A project file that only differs from the old render by formatting
+        is pristine: the template change must apply cleanly, never conflict."""
+        project_slug = "my-project"
+        answers = {"project_slug": project_slug}
+
+        project_file = tmp_path / "app" / "config.py"
+        project_file.parent.mkdir(parents=True)
+        project_file.write_text(self.PROJECT_FORMATTED)
+
+        mock = self._make_mock(project_slug, self.OLD_RAW, self.NEW_RAW)
+        with patch("copier.run_copy", side_effect=mock):
+            result = sync_template_changes(
+                tmp_path,
+                answers,
+                "gh:test/repo",
+                "v2.0.0",
+                old_commit="abc123",
+            )
+
+        assert result.conflicts == []
+        assert "app/config.py" in result.synced
+        content = project_file.read_text()
+        assert "<<<<<<<" not in content
+        assert "NEW_SETTING = 3" in content
+
+    def test_customized_file_merges_without_formatting_conflicts(
+        self, tmp_path: Path
+    ) -> None:
+        """A real user edit still 3-way merges with the template change, and
+        formatting differences alone must not turn that merge conflicted."""
+        project_slug = "my-project"
+        answers = {"project_slug": project_slug}
+
+        project_file = tmp_path / "app" / "config.py"
+        project_file.parent.mkdir(parents=True)
+        # User genuinely changed A's value in the formatted file.
+        project_file.write_text("A = 111\n\n\nB = 2\n")
+
+        mock = self._make_mock(project_slug, self.OLD_RAW, self.NEW_RAW)
+        with patch("copier.run_copy", side_effect=mock):
+            result = sync_template_changes(
+                tmp_path,
+                answers,
+                "gh:test/repo",
+                "v2.0.0",
+                old_commit="abc123",
+            )
+
+        assert result.conflicts == []
+        assert "app/config.py" in result.synced
+        content = project_file.read_text()
+        assert "<<<<<<<" not in content
+        assert "A = 111" in content
+        assert "NEW_SETTING = 3" in content
+
+    def test_formatting_only_template_change_preserves_custom_file(
+        self, tmp_path: Path
+    ) -> None:
+        """When the template change is formatting-only noise, a customized
+        file is left untouched instead of being churned or conflicted."""
+        project_slug = "my-project"
+        answers = {"project_slug": project_slug}
+
+        project_file = tmp_path / "app" / "config.py"
+        project_file.parent.mkdir(parents=True)
+        user_content = "A = 111\n\n\nB = 2\n"
+        project_file.write_text(user_content)
+
+        # Old and new renders differ only in blank-line runs.
+        mock = self._make_mock(
+            project_slug,
+            "A = 1\n\n\n\n\nB = 2\n",
+            "A = 1\n\n\n\n\n\n\n\nB = 2\n",
+        )
+        with patch("copier.run_copy", side_effect=mock):
+            result = sync_template_changes(
+                tmp_path,
+                answers,
+                "gh:test/repo",
+                "v2.0.0",
+                old_commit="abc123",
+            )
+
+        assert result.conflicts == []
+        assert project_file.read_text() == user_content

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { editable = "tests/fixtures/aegis_plugin_test" }
 
 [[package]]
 name = "aegis-stack"
-version = "0.9.1rc2"
+version = "0.9.1rc3"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
Fixes the bug found by the 0.9.0 -> 0.9.1rc2 TestPyPI upgrade test: a completely pristine project got merge conflicts in app/core/config.py and status_overview.py on aegis update.

**Root cause**: init post-gen runs make fix, so project files are ruff-formatted, while sync_template_changes 3-way merged raw template renders byte-wise. Formatting read as user edits; wherever real template changes (all finance-gated in 0.9.1, rendering as blank-line noise on non-finance stacks) landed near collapsed blank-line runs, git merge-file conflicted.

**Fix**: port the issue #715 normalization from ManualUpdater into the sync path (shared helpers now live in template_cleanup):
- pristine detection via full ruff normalization (comparison only, never written)
- formatting-only template changes preserve the user's file instead of churning it
- genuine edit + genuine change merges import-sorted/formatted sides (--select I, never code-deleting)
- ruff/git unavailable falls back to the previous raw merge

**Verification**:
- TDD: 3 new tests in tests/core/test_template_cleanup.py (pristine, customized-merge, noise-preserve); 45/45 pass
- e2e: fresh TestPyPI 0.9.0 projects (base and database[postgres]) updated to HEAD: zero conflicts, post-gen runs, imports clean
- make check + make test-stacks-full results to be posted below before merge

Includes the 0.9.1rc3 version bump (rc2 is burned on TestPyPI by the rc1-era filename policy incident; each rc that touches TestPyPI is single-use).

🤖 Generated with [Claude Code](https://claude.com/claude-code)