### PR TITLE
v0.9.1-rc4: ship ruff as a runtime dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ Each generated project includes:
 
 ## Installation
 
-**Current Version**: 0.9.1rc3
+**Current Version**: 0.9.1rc4
 
 ```bash
 pip install aegis-stack

--- a/aegis/__init__.py
+++ b/aegis/__init__.py
@@ -2,4 +2,4 @@
 Aegis Stack CLI - Component generation and project management tools.
 """
 
-__version__ = "0.9.1rc3"
+__version__ = "0.9.1rc4"

--- a/aegis/core/template_cleanup.py
+++ b/aegis/core/template_cleanup.py
@@ -551,6 +551,10 @@ def _sync_python_file(
     project_norm = run_ruff_on_text(project_text, project_path, "")
     old_norm = run_ruff_on_text(old_text, project_path, "")
     if project_norm is None or old_norm is None:
+        verbose_print(
+            f"   Warning: ruff unavailable/failed for {relative}; "
+            "falling back to raw merge (formatting may read as edits)"
+        )
         return False
 
     if normalize_for_compare(project_norm) == normalize_for_compare(old_norm):
@@ -579,6 +583,10 @@ def _sync_python_file(
     old_safe = run_ruff_on_text(old_text, project_path, "I")
     new_safe = run_ruff_on_text(new_text, project_path, "I")
     if project_safe is None or old_safe is None or new_safe is None:
+        verbose_print(
+            f"   Warning: ruff unavailable/failed for {relative}; "
+            "falling back to raw merge (formatting may read as edits)"
+        )
         return False
 
     returncode, merged = merge_three_way_text(project_safe, old_safe, new_safe)

--- a/aegis/core/template_cleanup.py
+++ b/aegis/core/template_cleanup.py
@@ -520,6 +520,19 @@ def sync_template_changes(
     return result
 
 
+def _warn_raw_merge_fallback(relative: Path) -> None:
+    """Warn visibly (not just in verbose mode) that a Python merge degraded.
+
+    Routed to stderr unconditionally: a silent degrade here is exactly what
+    made the 0.9.1rc3 conflicts undiagnosable from the user's terminal.
+    """
+    print(
+        f"   Warning: ruff unavailable/failed for {relative}; "
+        "falling back to raw merge (formatting may read as edits)",
+        file=sys.stderr,
+    )
+
+
 def _sync_python_file(
     project_file: Path,
     old_file: Path,
@@ -551,10 +564,7 @@ def _sync_python_file(
     project_norm = run_ruff_on_text(project_text, project_path, "")
     old_norm = run_ruff_on_text(old_text, project_path, "")
     if project_norm is None or old_norm is None:
-        verbose_print(
-            f"   Warning: ruff unavailable/failed for {relative}; "
-            "falling back to raw merge (formatting may read as edits)"
-        )
+        _warn_raw_merge_fallback(relative)
         return False
 
     if normalize_for_compare(project_norm) == normalize_for_compare(old_norm):
@@ -583,10 +593,7 @@ def _sync_python_file(
     old_safe = run_ruff_on_text(old_text, project_path, "I")
     new_safe = run_ruff_on_text(new_text, project_path, "I")
     if project_safe is None or old_safe is None or new_safe is None:
-        verbose_print(
-            f"   Warning: ruff unavailable/failed for {relative}; "
-            "falling back to raw merge (formatting may read as edits)"
-        )
+        _warn_raw_merge_fallback(relative)
         return False
 
     returncode, merged = merge_three_way_text(project_safe, old_safe, new_safe)

--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@
 # - Update support
 
 _min_copier_version: "9.0.0"
-_version: "0.9.1rc3"
+_version: "0.9.1rc4"
 
 # IMPORTANT: Template content is in subdirectory
 # This allows the template to be recognized as git-tracked (aegis-stack repo root has .git)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-stack"
-version = "0.9.1rc3"
+version = "0.9.1rc4"
 description = "A production-ready FastAPI platform with modular components and a built-in control plane. Try: uvx aegis-stack init my-project"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,11 @@ dependencies = [
     "pyyaml>=6.0",
     "filelock>=3.20.1",
     "urllib3>=2.7.0",
+    # Runtime, not just dev: `aegis update` / add-service 3-way merges shell
+    # out to ruff to look through formatting (template_cleanup.run_ruff_on_text,
+    # issue #715). Without it in the installed env (uvx/pip), merges silently
+    # degrade to raw byte diffs and pristine projects get spurious conflicts.
+    "ruff>=0.9.0",
 ]
 
 [project.urls]
@@ -72,7 +77,6 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=0.23.0",
     "pytest-xdist>=3.5.0",
-    "ruff>=0.1.0",
     "ty>=0.0.8",  # Type checker
     "pre-commit>=3.7.0",
     "pip-audit>=2.6.0",

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -1,0 +1,35 @@
+"""Guards on [project].dependencies — what an installed aegis-stack can rely on.
+
+Dev extras exist only in this repo's venv. Anything the CLI shells out to at
+RUNTIME (uvx / pip installs, no extras) must be a runtime dependency, or the
+feature silently degrades in production while every local test passes.
+"""
+
+import tomllib
+from pathlib import Path
+
+PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
+
+
+def _runtime_dependencies() -> list[str]:
+    with PYPROJECT.open("rb") as handle:
+        return tomllib.load(handle)["project"]["dependencies"]
+
+
+def test_ruff_is_a_runtime_dependency() -> None:
+    """The updater's 3-way merges shell out to ruff at runtime.
+
+    ``template_cleanup.run_ruff_on_text`` (used by both the version-update
+    sync and the ManualUpdater add/remove path, issue #715) needs a ruff
+    binary in the installed environment. When it is only a dev extra, a
+    uvx-installed CLI finds no ruff, every Python merge degrades to the raw
+    byte-level path, and pristine projects get spurious update conflicts —
+    exactly what the 0.9.0 -> 0.9.1rc3 TestPyPI upgrade test caught.
+    """
+    assert any(
+        dep.split(">=")[0].split("==")[0].strip() == "ruff"
+        for dep in _runtime_dependencies()
+    ), (
+        "ruff must be declared in [project].dependencies, not only the dev "
+        "extra: aegis update / add-service merge correctness depends on it"
+    )

--- a/tests/test_runtime_dependencies.py
+++ b/tests/test_runtime_dependencies.py
@@ -8,6 +8,8 @@ feature silently degrades in production while every local test passes.
 import tomllib
 from pathlib import Path
 
+from packaging.requirements import Requirement
+
 PYPROJECT = Path(__file__).parent.parent / "pyproject.toml"
 
 
@@ -26,10 +28,7 @@ def test_ruff_is_a_runtime_dependency() -> None:
     byte-level path, and pristine projects get spurious update conflicts —
     exactly what the 0.9.0 -> 0.9.1rc3 TestPyPI upgrade test caught.
     """
-    assert any(
-        dep.split(">=")[0].split("==")[0].strip() == "ruff"
-        for dep in _runtime_dependencies()
-    ), (
+    assert any(Requirement(dep).name == "ruff" for dep in _runtime_dependencies()), (
         "ruff must be declared in [project].dependencies, not only the dev "
         "extra: aegis update / add-service merge correctness depends on it"
     )

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pyyaml" },
     { name = "rich" },
+    { name = "ruff" },
     { name = "typer" },
     { name = "urllib3" },
 ]
@@ -32,7 +33,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-xdist" },
-    { name = "ruff" },
     { name = "sqlalchemy" },
     { name = "ty" },
 ]
@@ -71,7 +71,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.5.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "rich", specifier = ">=13.0.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
+    { name = "ruff", specifier = ">=0.9.0" },
     { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.8" },
     { name = "typer", specifier = "==0.26.8" },

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { editable = "tests/fixtures/aegis_plugin_test" }
 
 [[package]]
 name = "aegis-stack"
-version = "0.9.1rc3"
+version = "0.9.1rc4"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
The 0.9.0 -> 0.9.1rc3 TestPyPI upgrade test STILL produced conflicts after rc3's sync fix. Root cause: ruff lived only in the dev extra, so a uvx/pip-installed CLI has no ruff binary; ruff_executable() returns None and every Python 3-way merge (the new update-sync path AND the issue-715 add/remove path) silently degraded to raw byte merges in production, while every repo-venv test passed with dev extras installed.

Changes:
- ruff moved from the dev extra to [project].dependencies (>=0.9.0)
- new test parses pyproject and fails if ruff ever leaves runtime deps
- the merge fallback now warns instead of degrading silently
- version bump to 0.9.1rc4 (rc3 is burned on TestPyPI)

Verification:
- TDD: test failed before the pyproject change, passes after; full template_cleanup suite green
- Production-mode wheel test (the scenario rc3 missed): built the rc4 wheel, ran the update through 'uvx --from ./dist/...whl' (isolated env, no dev extras) against a fresh TestPyPI 0.9.0 database[postgres] project: ruff present in the env, zero conflict markers, post-gen completed
- make check + make test-stacks-full results to be posted before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)