### PR TITLE
Agent Skills M1: framework workflow skills (SK-01..SK-09)

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -1,0 +1,90 @@
+# Skill conventions
+
+Skills are on-demand procedural knowledge for coding agents. Claude Code loads
+`.claude/skills/<name>/SKILL.md` when a task matches the skill's frontmatter
+`description`. Skills keep recurring workflows (add a service, add a component,
+i18n, CLI commands, releases, template development) out of always-loaded context
+and out of one developer's session memory, so any agent with this repo can
+execute the work.
+
+This document is the house format. It is a conventions reference, not a skill
+itself, so it has no frontmatter and never loads as a skill.
+
+## Layout
+
+- One skill per directory: `.claude/skills/<kebab-name>/SKILL.md`.
+- The directory name is the skill name and must be kebab-case.
+- `SKILL.md` opens with YAML frontmatter carrying exactly two keys:
+
+  ```yaml
+  ---
+  name: add-service
+  description: Use when adding a new service to the framework. Covers the registry, CLI, template, test, and docs files that must change together.
+  ---
+  ```
+
+- `name` matches the directory name.
+- `description` states the trigger in plain language ("Use when ..."), because
+  it is the only text an agent reads when deciding whether to load the skill. A
+  vague description means the skill never fires. Lead with the trigger, then say
+  what the skill covers.
+- Supporting files (checklists, scripts, snippets) may live beside `SKILL.md` in
+  the same directory. Reference them by relative path from the skill directory.
+
+## Required sections
+
+Every `SKILL.md` body has these sections, in this order, with these exact H2
+headings:
+
+1. `## When to use`
+   State the trigger conditions, then state when NOT to use the skill so it is
+   not loaded for adjacent-but-different work.
+
+2. `## Files that change`
+   Exact repo-relative paths, grouped by role. Use whichever of these groups
+   apply: registry, CLI, template, tests, docs, i18n. List the real paths, not
+   descriptions of them, so an agent can open them without searching.
+
+3. `## Procedure`
+   Numbered steps. TDD-first: the failing test comes before the implementation.
+   Each step is an action, not a discussion.
+
+4. `## Gates`
+   The `make` targets that must pass before the work counts as done (for
+   example `make check`, `make test-template`). Name the exact targets.
+
+5. `## Pitfalls`
+   Known traps, one sentence each, including the why. A pitfall without its
+   reason is not actionable.
+
+Omit a section only when it genuinely does not apply; do not reorder them.
+
+## Style rules
+
+- Imperative voice: "Add the route", not "You should add the route".
+- Compact. Prefer a path or a command over a paragraph describing one.
+- No emojis.
+- No em-dashes; use commas, parentheses, or rewrite.
+- Repo-relative paths only. Never absolute paths, never user- or
+  machine-specific references (home directories, personal project locations,
+  local ports chosen by one machine).
+
+## Portability rule
+
+A skill describes the repo contract: the files, commands, and gates that define
+the work. It never describes one person's environment.
+
+Skills destined for generated projects (see Milestone 2) additionally carry:
+
+- No internal codenames.
+- No aegis-stack issue references.
+
+Write every skill as if a stranger's agent, in a fresh checkout on an unknown
+machine, will run it. If a line only makes sense on one machine or to one
+person, it does not belong in a skill.
+
+## Example
+
+`.claude/skills/example-skill/SKILL.md` is a filled-in skeleton that exercises
+every required section. Copy it as the starting point for a new skill, then
+replace the placeholder content.

--- a/.claude/skills/add-cli-command/SKILL.md
+++ b/.claude/skills/add-cli-command/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: add-cli-command
+description: Use when adding a command to the aegis tool CLI (the framework's own `aegis ...` entry point, not a generated project's CLI). Covers Typer registration, the sync-plus-asyncio.run rule, brand help theming, i18n strings, optional guided/interactive wiring, tests, and the CLI reference doc that must change together.
+---
+
+# Add CLI command
+
+Adds a new top-level command to the aegis tool's own CLI (`aegis <command>`),
+as opposed to a command inside a generated project. Traced from
+`aegis/commands/update.py` and its registration in `aegis/__main__.py`.
+
+## When to use
+
+Use when the task is "add a new `aegis <command>`" to the framework's own
+CLI surface (the tool that generates and updates projects).
+
+Do NOT use for adding a subcommand to a generated project's CLI
+(`app/cli/*.py.jinja` in the template tree) - that is template work with its
+own conventions, not this skill. Do NOT use for adding a component or
+service (`aegis add <component>` / `aegis add-service <name>`); those already
+have dedicated commands and belong to the `add-component` / `add-service`
+skills. Do NOT use for a plugin-provided CLI sub-app mounted via
+`aegis/core/plugins/discovery.py`; that is a separate, plugin-owned
+registration path.
+
+## Files that change
+
+Command implementation and registration:
+
+- `aegis/commands/<name>.py`: the command function, e.g. `<name>_command`
+  (see `update_command` in `aegis/commands/update.py` for the shape: Typer
+  options via `typer.Option(...)`, `lazy_t(...)` for help strings, `t(...)`
+  for runtime messages, `brand.success/warn/error` for status lines).
+- `aegis/__main__.py`: import the command function and register it with the
+  module-level Typer `app`. The exact registration point is the block of
+  `app.command(name="...")(...)` calls after `app.add_typer(plugins_app,
+  name="plugins")` - add `app.command(name="<name>")(<name>_command)` there,
+  next to the existing entries (`update`, `deploy-init`, `ingress-enable`,
+  and so on). This is the single place a new command becomes reachable as
+  `aegis <name>`.
+
+Help/UX theming (no new files, just correct usage):
+
+- `aegis/cli/brand.py` is the single source of the CLI palette: `AEGIS_TEAL`
+  (`#17CCBF`, typeable tokens and success state), `AEGIS_WARNING` (`#F5A623`,
+  amber), `AEGIS_ERROR` (`#E23E3E`, red). Call sites never hardcode colors;
+  they call `brand.success(...)`, `brand.warn(...)`, `brand.error(...)`,
+  `brand.accent(...)`, `brand.muted(...)` (or the `_text` variants for
+  inline composition) to express intent. `brand.apply_help_theme()` themes
+  Typer's rich `--help` rendering globally (teal for command names and
+  flags, dim for metavars/env-var hints, neutral for prose); it runs once
+  at CLI startup and needs no per-command change.
+
+Strings (i18n):
+
+- All user-facing text goes through i18n keys in `aegis/i18n/locales/en.py`
+  (the real English string), with the same key stubbed into every other
+  locale file for parity. Use `lazy_t("<name>.help_opt_...")` for Typer
+  `help=` strings (lazy because locale isn't resolved until the `--lang`
+  callback runs) and `t("<name>....")` for runtime echo strings. Follow the
+  `<command>.<thing>` naming already used by `update.*` and `common.*` (for
+  example `common.help_yes`, `common.help_project_path_full` for options
+  shared across commands). See the i18n skill for the full add-a-key
+  procedure and locale list; do not attempt real (non-English) translation
+  in the same change.
+
+Init-style options (only if the new command takes project-shaping options,
+the way `init`/`add`/`add-service` do):
+
+- `aegis/cli/guided.py`: add a `choose_<thing>(...)` method on the
+  guided-setup UI class if the command should offer a guided prompt step,
+  following the existing `choose_worker_backend()` /
+  `choose_database_engine()` pattern (a list of `_Choice(value, label,
+  description)` fed to `self._select(...)`, i18n-backed via `_g(...)`).
+- `aegis/cli/interactive.py`: add an `interactive_<name>_selection(...)` /
+  `interactive_<name>_config(...)` function if the command needs a
+  non-guided interactive prompt fallback, following
+  `interactive_component_add_selection` / `interactive_ai_service_config`.
+- `aegis/cli/validators.py`: input validation for CLI-supplied values
+  (project names, component/service name lists) - add a
+  `validate_<thing>(...)` here if the new option needs syntactic validation,
+  following `validate_project_name`.
+- `aegis/cli/validation.py`: shared cross-command checks that are not raw
+  input validation, such as `validate_copier_project(target_path,
+  command_name)` (confirms the target is a Copier-generated project before
+  proceeding). Call this if the new command operates on an existing project
+  directory, mirroring how `update_command` and others gate on it.
+- Most new commands (a status check, a report, a one-shot action) need
+  none of this; skip the whole section if the command takes no
+  project-shaping options.
+
+Tests:
+
+- `tests/cli/test_<name>_command.py` (or add to an existing file if the
+  command is small): `typer.testing.CliRunner` against `aegis.__main__.app`
+  (see `tests/cli/test_utils.py` for `CLI_RUNNER`, timeouts, and
+  `run_aegis_command` / `run_cli_help_command` helpers). Cover `--help`
+  text, success path, and error path.
+- `tests/cli/test_cli_basic.py`: add a `test_<name>_help` case asserting the
+  command's help text and options appear, following `test_init_help`.
+
+Docs:
+
+- `docs/cli-reference.md`: add a `### aegis <name>` section in command
+  order (matches the registration order in `aegis/__main__.py`), with a
+  `**Usage:**` code block and an `**Example Output:**` block, following the
+  existing `### aegis update` / `### aegis services` sections. No `mkdocs.yml`
+  nav change is needed; this page is already wired under `Reference: CLI
+  Reference`.
+
+## Procedure
+
+1. Write the failing test first: `tests/cli/test_<name>_command.py` (or a
+   case in `test_cli_basic.py`) asserting `aegis <name> --help` exits 0 and
+   shows the expected help text. Confirm it fails because the command
+   doesn't exist yet.
+2. Add `aegis/commands/<name>.py` with `<name>_command(...) -> None`. Keep
+   it a plain sync `def`; if it needs to await anything, call
+   `asyncio.run(...)` inside the function body (see Pitfalls - Typer has no
+   native async command support).
+3. Register it in `aegis/__main__.py`: import the function, add
+   `app.command(name="<name>")(<name>_command)` next to the existing
+   `app.command(...)` calls.
+4. Add the command's i18n keys to `aegis/i18n/locales/en.py` (help strings
+   via `lazy_t`, runtime strings via `t`), then stub the same keys into
+   every other locale file for parity (see the i18n skill).
+5. Use `brand.success/warn/error/accent/muted` for all status output; never
+   call `typer.secho` with a raw color inline.
+6. If the command takes project-shaping options, wire the guided/interactive
+   flows (`aegis/cli/guided.py`, `aegis/cli/interactive.py`) and validation
+   (`aegis/cli/validators.py` for input shape, `aegis/cli/validation.py` for
+   shared project-state checks like `validate_copier_project`). Skip this
+   step for options-free or simple-flag commands.
+7. Add or extend the test coverage in `tests/cli/` from step 1, including an
+   error-path case.
+8. Add the `### aegis <name>` section to `docs/cli-reference.md`.
+9. Run the gates below and fix anything red.
+
+## Gates
+
+- `make check` (lint, typecheck, test) must pass.
+- `make cli-test` for a manual smoke: runs `python -m aegis --help` and
+  confirms the CLI still loads with the new command registered.
+
+## Pitfalls
+
+- Typer has no native async command support in any version: a command
+  function must be a sync `def`. If it needs async work, call
+  `asyncio.run(...)` from inside the sync function body rather than trying
+  to declare the command itself `async def` - Typer will not await it.
+- Forgetting the `app.command(name="...")(...)` line in `aegis/__main__.py`
+  leaves the command fully implemented but unreachable; `aegis <name>
+  --help` fails with "no such command" even though `aegis/commands/<name>.py`
+  imports and type-checks cleanly.
+- Don't hardcode a color (`typer.secho(msg, fg="red")`) at a call site; use
+  `brand.error`/`brand.warn`/`brand.success` so the palette stays defined in
+  exactly one place (`aegis/cli/brand.py`) and stays in sync with the
+  generated frontend's theme.
+- Adding a key to `en.py` only fails `tests/core/test_i18n.py`, which
+  requires the same key in every other locale file; stub the key everywhere
+  in the same change and leave real translation to the separate
+  translator-reviewed pass (see the i18n skill).
+- `lazy_t(...)` is for `help=` strings evaluated before the `--lang` option
+  is resolved (Typer short-circuits its main callback on `--help`); using
+  plain `t(...)` for a help string can render against the wrong locale on a
+  fresh process. Use `t(...)` for anything echoed at runtime, after the
+  callback has already set the locale.
+- A command that takes a `--project-path` and operates on an existing
+  project should call `validate_copier_project` (or the equivalent check)
+  before doing any work, the way `update_command` does immediately after
+  resolving the target path - skipping it lets the command run against a
+  directory that was never generated by Copier and fail with a confusing
+  downstream error instead of a clear one.

--- a/.claude/skills/add-component/SKILL.md
+++ b/.claude/skills/add-component/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: add-component
+description: Use when adding a new infrastructure component (worker, scheduler, database, redis, ingress, observability) to the Aegis Stack framework itself, or adding a new variant axis (like worker_backend or database_engine) to an existing component. Covers the plugin-spec registry, dependency resolution, copier questions, generation/update plumbing, template, test, docs, and i18n files that must change together.
+---
+
+# Add component
+
+Adds a new infrastructure component (background worker, scheduler, database,
+redis, ingress, observability) to the framework so generated projects can
+select it via `aegis init` or add it later via `aegis add`, OR adds a new
+variant axis to an existing component (a second/third backend choice like
+`worker_backend` on `worker` or `database_engine` on `database`). Traced from
+`worker` (with its `worker_backend` axis: arq/dramatiq/taskiq) and `database`
+(with its `database_engine` axis: sqlite/postgres).
+
+## When to use
+
+Use for either:
+
+- A brand-new optional component (infrastructure, not business logic) behind
+  its own `include_<name>` copier question, addable/removable via
+  `aegis add` / `aegis remove`.
+- A new variant axis on an existing component: a second copier question
+  (`<component>_<axis>`) that changes which files render for that component,
+  following the `worker_backend` / `database_engine` pattern.
+
+Do NOT use for adding a **service** (business logic: auth, AI, blog,
+finance, payment, comms, insights) - services live in
+`aegis/core/services.py` and share the same `PluginSpec` shape but a
+different file footprint and CLI surface (`aegis add-service`, not
+`aegis add`); use the `add-service` skill instead. Do NOT use for changing
+behavior inside an existing component with no new question or file gating;
+that is ordinary feature work.
+
+## Files that change
+
+Registry (`ComponentSpec` is a thin alias of `PluginSpec` pinned to
+`kind=COMPONENT`; see `aegis/core/plugins/spec.py`):
+
+- `aegis/core/components.py`: add a `ComponentSpec` entry to the `COMPONENTS`
+  dict. Set `type` (`ComponentType.INFRASTRUCTURE`; `ComponentType.CORE` is
+  reserved for `backend`/`frontend` in `CORE_COMPONENTS` - core components are
+  never prompted, never removable, and skipped by cleanup entirely),
+  `description`/`long_description`, `required_components` (hard deps, e.g.
+  worker requires `["redis"]`), `recommended_components`, `pyproject_deps`,
+  `docker_services` (compose service names this component owns, used by
+  stack-generation tests), `template_files` (display list), `marker_path`
+  (the path used to detect the component on disk - for `reconcile_answers_from_disk`
+  and dev-mode cleanup context), `docs_path` (see docs section below), and
+  `migrations=[...]` only if the component owns tables (see `SCHEDULER_MIGRATION`
+  in `aegis/core/migration_generator.py` for the pattern: a schema-qualified
+  table, generated only for non-memory/non-sqlite backends).
+- `aegis/core/components.py`: `files=FileManifest(primary=[...], extras={...})`
+  - every path the component owns. `primary` is the always-on add/init base;
+  `aegis/core/post_gen_tasks.py`'s `get_component_file_mapping()` derives
+  from every spec's manifest via `compute_file_mapping()` (`aegis/core/file_manifest.py`),
+  so there is no separate hand-maintained mapping to edit. Use `extras` for
+  file groups that only render real content for a specific variant value
+  (e.g. scheduler's `"scheduler_persistence"` group, gated on
+  `scheduler_backend != "memory"`) - keeping them out of `primary` stops
+  `aegis add` from writing 0-byte stubs when the parent variant doesn't need
+  them; `aegis remove` still deletes them via `get_component_files(..., full=True)`.
+- `aegis/constants.py`: `ComponentNames` - add `<NAME> = "<name>"` and append
+  it to `INFRASTRUCTURE_ORDER` (controls interactive prompt ordering).
+  `AnswerKeys` - add `<NAME> = "include_<name>"`. For a new variant axis, add
+  the axis key (e.g. `<COMPONENT>_<AXIS> = "<component>_<axis>"`) and, if the
+  axis has a fixed enum of values, a dedicated `<Axis>Backends`/`<Axis>Type`
+  class near `WorkerBackends` / `StorageBackends` with an `ALL` list.
+- `aegis/core/dependency_resolver.py`: no edits needed for a plain component -
+  it reads `ComponentSpec.requires`/`.recommends`/`.conflicts` generically via
+  `COMPONENTS`. Only add logic here if the new component needs a resolution
+  rule beyond simple hard-dependency (worker -> redis is handled by
+  `required_components` alone, no custom code).
+- `copier.yml` (repo root, not under `templates/`): add the `include_<name>`
+  bool question. For a variant axis, add `<component>_<axis>` with
+  `choices:` and `when: "{{ include_<component> }}"` - UNLESS the value must
+  survive even when the component is off (compare `database_engine`, which
+  has **no** `when` clause because templates gate on it regardless of
+  `include_database`, e.g. a persistent scheduler needs to know the engine
+  before database is even selected).
+- `aegis/templates/copier-aegis-project/{{ project_slug }}/.copier-answers.yml.jinja`:
+  add `include_<name>: {{ include_<name> }}`. For an axis gated by `when`,
+  adding the line here is NOT required for correctness - Copier omits
+  `when`-gated fields from the rendered answers file (observed for
+  `worker_backend`, `scheduler_backend`, `include_oauth`; none of them
+  appear in this file today), and `copier_manager.py`'s post-generation
+  patch (below) backfills every `copier_data` key Copier dropped. Add the
+  line anyway for axes that are NOT `when`-gated (like `database_engine`,
+  which IS listed here) since those are the ones templates read
+  unconditionally.
+
+Generation and update plumbing (thread the new `AnswerKeys.<NAME>` /
+`AnswerKeys.<COMPONENT>_<AXIS>` answer key through every one of these; a
+component that skips them generates fine at `aegis init` but breaks
+`aegis add`/`aegis remove`/`aegis update` on an existing project):
+
+- `aegis/core/template_generator.py` (`TemplateGenerator.__init__` and
+  `get_template_context()`): extract the axis value from bracket syntax
+  (`worker[dramatiq]`) the same way `self.worker_backend` is derived from
+  `extract_engine_info(component)`, default it (`WorkerBackends.ARQ`), and
+  add it to the returned context dict. Also branch in the pyproject-deps
+  loop (`base_name == ComponentNames.WORKER` block) if different variant
+  values pull different pip packages.
+- `aegis/core/copier_manager.py` (`generate_with_copier`): add
+  `AnswerKeys.<NAME>: template_context[AnswerKeys.<NAME>] == "yes"` (or
+  `.get(..., default)` for optional flags) to the `copier_data` dict passed
+  to `run_copy`. This is also where the backfill described above lives -
+  every non-underscore `copier_data` key gets written into
+  `.copier-answers.yml` after generation if Copier dropped it, so this dict
+  is the actual source of truth for what ends up in the answers file, not
+  the `.copier-answers.yml.jinja` list.
+- `aegis/core/manual_updater.py` (`ManualUpdater`): `get_copier_defaults()`
+  (from `aegis/core/component_files.py`) merges copier.yml defaults under
+  the persisted answers at construction time, so a variant axis with a
+  `default:` in copier.yml needs no extra wiring here for the *default*
+  case. But `add_component`/`remove_component` must reference
+  `AnswerKeys.<COMPONENT>_<AXIS>` explicitly anywhere the render context
+  needs it - as of this trace, `manual_updater.py` has **zero** references
+  to `worker_backend`, which is why `aegis add worker[dramatiq]` on an
+  existing project silently ignores the bracket and always adds arq (the
+  default). Don't repeat this gap for a new axis: thread it through
+  `add_component`'s context building, mirroring how `aegis/commands/add.py`
+  threads `AnswerKeys.DATABASE_ENGINE`/`AnswerKeys.SCHEDULER_BACKEND` into
+  `component_data` before calling `updater.add_component(component, component_data)`.
+- `aegis/commands/add.py` (`add_command`): parse the variant out of bracket
+  syntax via `extract_engine_info(comp)` for the new component (mirrors the
+  scheduler-backend block), validate it against the axis's `ALL` list, and
+  populate `update_data[AnswerKeys.<COMPONENT>_<AXIS>]` / the per-component
+  `component_data` dict passed to `updater.add_component(...)`.
+- `aegis/commands/update.py`: no per-component AnswerKeys threading exists
+  here today (verify this still holds before skipping it) - `aegis update`
+  runs the full Copier update flow and re-derives context from the project's
+  own (reconciled) answers file, not from a hand-maintained key list.
+- `aegis/cli/guided.py` / `aegis/cli/interactive.py`: add a
+  `choose_<component>_backend(self) -> str` method (on the guided-setup UI
+  class) following `choose_worker_backend()` / `choose_database_engine()` -
+  a list of `_Choice(value, label, description)` tuples fed to `self._select(...)`
+  with an i18n-backed prompt string (`_g("prompt.<component>_backend", "...")`)
+  and per-choice description keys (`choice.<component>.<value>`).
+
+Template side (`aegis/templates/copier-aegis-project/{{ project_slug }}/`):
+
+- `app/components/<name>/`: the component's own package.
+- `docker-compose.yml.jinja` / `.dev` / `.prod`: gate services behind
+  `{%- if include_<name> %}` (full-body wrap, never a Jinja expression
+  inside a YAML value Copier can't parse standalone). These compose
+  templates carry **no inline comments** - which components a given
+  project selects varies per stack, so a comment written for one
+  combination misleads for another; state conditions through the Jinja
+  gate itself, not prose beside it.
+- `Makefile.jinja`: gate any new `make` targets the component needs
+  (compare how `worker`/`scheduler` targets are conditioned).
+- `app/components/backend/startup/component_health.py.jinja`: register the
+  health check behind `{%- if include_<name> %}`, following the existing
+  `include_worker` / `include_database` blocks. For a variant axis, nest a
+  second `{%- if <component>_<axis> == "value" %}` inside.
+- `pyproject.toml.jinja`: gate the component's `pyproject_deps` behind
+  `{%- if include_<name> %}`. For a variant axis with per-value deps (arq
+  vs dramatiq vs taskiq each pull different packages), branch on the axis
+  value inside that same gate.
+- `docs/components/<name>/index.md` (+ `configuration.md`, `examples.md`,
+  `extras/<topic>.md` as applicable - this is the multi-page convention
+  `worker` and `scheduler` use; a single `docs/components/<name>.md` file
+  also satisfies the docs_path test, matching `database`/`scheduler`'s
+  top-level file). Wire the new pages into the root `mkdocs.yml` nav under
+  the `Components:` block.
+- Tests (generated-project template tests): `tests/components/test_<name>.py`,
+  and API/frontend tests if the component ships routes or dashboard
+  cards/modals (`app/components/frontend/dashboard/cards/<name>_card.py`,
+  `modals/<name>_modal.py`, exported from the matching `__init__.py.jinja`
+  files, same wiring shape as the service card/modal pattern in `add-service`).
+
+Cross-cutting:
+
+- `aegis/config/shared_files.py`: only if the component introduces a **new**
+  shared file with `{% if include_<name> %}` conditionals that isn't already
+  in `SHARED_TEMPLATE_FILES` (most component-conditional content lives in
+  already-registered shared files: `docker-compose.yml`, `pyproject.toml`,
+  `Makefile`, `component_health.py`, `app/core/config.py`, `.env.example`).
+  `tests/cli/test_shared_files_completeness.py` diffs a minimal and a
+  maximal generated stack and fails, naming the missing file, if a new
+  stack-dependent shared file is forgotten here.
+- `docs/components/<name>/index.md` (or `<name>.md`) is pinned by
+  `tests/core/test_spec_docs_paths.py` once `docs_path` is set on the spec
+  - it accepts either `docs/<docs_path>.md` or `docs/<docs_path>/index.md`.
+  Leave `docs_path=""` until the page exists.
+
+i18n:
+
+- `aegis/i18n/locales/en.py`: add `"component.<name>"` (short description,
+  shown by `aegis add --help` component listings and the guided setup) and
+  `"component.<name>.long"` (long-form description) with real English
+  strings. For a variant axis, also add `"prompt.<component>_<axis>"` and
+  one `"choice.<component>.<value>"` key per choice (see
+  `choice.worker.arq` / `choice.worker.dramatiq` / `choice.worker.taskiq`).
+- `aegis/i18n/locales/{de,es,fr,ja,ko,ru,zh,zh_hant}.py`: add the SAME keys
+  to every other locale, using the English string as a placeholder. This is
+  required for parity: `tests/core/test_i18n.py` asserts every locale
+  carries the same keys as English (one `test_<locale>_has_all_keys` per
+  locale) and fails naming the missing key otherwise. Real translation is a
+  separate translator-reviewed pass; do not attempt it here, but the keys
+  must exist now.
+
+Tests (this repo's own CLI/core test suite):
+
+- `tests/cli/test_stack_generation.py`: add a `StackCombination` entry to
+  `STACK_COMBINATIONS` (mirrors the `worker`/`scheduler`/`full` entries) with
+  `expected_files`, `expected_docker_services`, and `expected_pyproject_deps`.
+- `tests/cli/conftest.py`: add a `<name>_with_<variant>` entry to
+  `NAMED_PROJECT_SPECS` for each new variant value (see
+  `base_with_worker_taskiq` / `base_with_worker_dramatiq`) so downstream
+  tests copy a cached project instead of regenerating one.
+- `tests/cli/test_add_command.py`: add coverage for `aegis add <name>` (and,
+  if applicable, `aegis add <name>[<variant>]`) following the existing
+  `test_add_scheduler_with_backend_flag_sqlite` / `test_add_worker_auto_adds_redis`
+  style. There is no dedicated "importable regen guard" test for components
+  analogous to `add-service`'s `SERVICE_INVOCATIONS` - add explicit add-path
+  assertions here instead so a missing `FileManifest` entry surfaces as a
+  test failure rather than a stub file in the wild.
+- `tests/core/test_spec_docs_paths.py` and `tests/core/test_i18n.py` need no
+  edits - they parametrize over `COMPONENTS`/`SERVICES` and the locale
+  catalogs automatically; they just need to pass.
+
+## Procedure
+
+1. Write the failing test first: add a `StackCombination` to
+   `tests/cli/test_stack_generation.py::STACK_COMBINATIONS` asserting the
+   new component's expected files/docker services/deps. Confirm it fails
+   for the right reason (component doesn't exist yet).
+2. Add `ComponentNames.<NAME>` (+ `INFRASTRUCTURE_ORDER` entry) and
+   `AnswerKeys.<NAME>` in `aegis/constants.py`. For a variant axis, add the
+   axis key and its `<Axis>Backends`-style enum class.
+3. Add the `ComponentSpec` entry in `aegis/core/components.py`: identity
+   fields, `required_components`, `pyproject_deps`, `docker_services`,
+   `marker_path`, `files=FileManifest(primary=[...], extras={...})`, and
+   `migrations=[...]` if it owns tables.
+4. Add the `include_<name>` question to `copier.yml` (and the axis question
+   with `choices`/`when` if applicable). Add the corresponding line to
+   `.copier-answers.yml.jinja` for any NOT-`when`-gated field; `when`-gated
+   fields are backfilled automatically (see Files that change).
+5. Thread the new answer key(s) through the generation/update plumbing:
+   `template_generator.py`, `copier_manager.py`, `manual_updater.py`,
+   `aegis/commands/add.py` (bracket parsing + `component_data`), and the
+   guided/interactive prompt classes (`guided.py`/`interactive.py`).
+6. Build the template package: `app/components/<name>/`, docker-compose
+   gating (no inline comments), `Makefile.jinja` targets, `pyproject.toml.jinja`
+   deps, and the health check registration in `component_health.py.jinja`.
+7. If the component ships dashboard UI, wire the card/modal and their
+   `__init__.py.jinja` exports (mirror the service pattern in `add-service`).
+8. Add the i18n keys (`component.<name>`, `component.<name>.long`, plus
+   `prompt.<component>_<axis>` / `choice.<component>.<value>` for a variant
+   axis) to `en.py`, then stub the same keys into every other locale for
+   parity; `tests/core/test_i18n.py` fails otherwise.
+9. Add the `tests/cli/test_stack_generation.py` combination (from step 1,
+   now passing), the `tests/cli/conftest.py` cache entries per variant, and
+   `tests/cli/test_add_command.py` add-path coverage.
+10. If any generated-project fix happened in a scratch/prototype project
+    rather than directly in the template, backport it into
+    `aegis/templates/` before finishing - templates are the source of truth.
+11. Once the docs page exists, add `docs/components/<name>/` (or
+    `<name>.md`), wire it into the root `mkdocs.yml` nav, and set
+    `docs_path` on the spec.
+12. Run the gates below and fix anything red.
+
+## Gates
+
+- `make check` (lint, typecheck, test) must pass.
+- `make test-stacks-quick` while iterating (fast feedback: runs the stack
+  validation phase against a representative subset - base, everything,
+  insights).
+- `make test-stacks-full` before calling the work done (runs the
+  generation-only `test-stacks` pass, the slow `test-stacks-build`
+  validation pass, and the kitchen-sink `everything` stack).
+
+## Pitfalls
+
+- Template changes render from the committed git state unless you pass
+  `aegis init --dev` (working tree) or commit first; testing a template
+  edit with plain `aegis init` on an uncommitted change silently uses stale
+  content.
+- Copier conditional filenames are banned (broke on Windows); gate content
+  with a full-body `{% if %}...{% endif %}` wrap inside the file instead of
+  naming the file conditionally.
+- `copier` is pinned below 9.15 in `pyproject.toml` (9.15+ relocates
+  `.copier-answers.yml`, breaking `aegis update`); a dependabot ignore rule
+  guards the pin - do not "fix"/bump it even if a bot PR proposes it.
+- `.copier-answers.yml.jinja` looks incomplete on purpose: fields gated by a
+  copier.yml `when:` clause (like `worker_backend`, `scheduler_backend`,
+  `include_oauth`) are omitted from it, because Copier itself drops
+  conditional answers on render. Don't "fix" this by adding them - the
+  actual persistence path is `copier_manager.py`'s post-generation backfill,
+  which patches any `copier_data` key Copier dropped directly into the
+  written `.copier-answers.yml`.
+- `FileManifest.primary` on the spec is the single source
+  `get_component_file_mapping()` derives from. A file present in the
+  template but missing from `primary` renders correctly on fresh `init`
+  (Copier just includes it) but is silently skipped by `aegis add`/`aegis
+  remove` on an existing project - there is no equivalent to `add-service`'s
+  `SERVICE_INVOCATIONS` regen-gap guard for components today, so cover this
+  with explicit `tests/cli/test_add_command.py` assertions instead.
+- The worker backend suffix-rename in `post_gen_tasks.cleanup_components`
+  (`_rename_backend_files` / `_remove_backend_files`) is the concrete model
+  for a variant axis that ships parallel source files
+  (`registry_dramatiq.py`, `registry_taskiq.py`, canonical `registry.py`):
+  at generation time it renames the chosen backend's `*_<backend>.py` files
+  to their canonical names and deletes the other backends' files. Skipping
+  this for a new axis leaves all variants' files on disk simultaneously,
+  each importing modules that shadow each other.
+- The same function distinguishes **init** (backend-specific source files
+  still present, e.g. `*_dramatiq.py`) from **update** (only canonical
+  files remain from a prior run) by checking whether any `*_<backend>.py`
+  files exist before renaming. Running the arq-cleanup unconditionally on
+  update would delete the canonical files a previous run already renamed
+  into place, which is the exact bug the init-vs-update branch exists to
+  prevent; a new variant axis must preserve it.
+- `aegis/commands/manual_updater.py`'s `add_component` has **no** knowledge
+  of `worker_backend` today: `aegis add worker[dramatiq]` on an existing
+  project always installs the arq default, silently discarding the bracket
+  value. Don't assume bracket syntax "just works" for a new axis on the add
+  path - verify (and if needed, add) the threading in `add.py` and
+  `manual_updater.py` explicitly; it is not inherited for free from the
+  `aegis init` path.
+- `docs_path` on the spec is pinned by `tests/core/test_spec_docs_paths.py`
+  to a real file under this repo's root `/docs` (either `docs/<path>.md` or
+  `docs/<path>/index.md`) - setting it before the docs page exists fails
+  that test.
+- New i18n keys get real strings in `aegis/i18n/locales/en.py` and the same
+  keys with English-placeholder values in every other locale in the same
+  change (required for `tests/core/test_i18n.py` parity); real translation is
+  left to a separate translator-reviewed pass.
+- A component that owns tables (like scheduler's Postgres-only execution
+  history) generates its migration only when the chosen backend needs
+  persistence - model the `scheduler_backend != "memory"` gating in
+  `get_services_needing_migrations` and the `needs_migrations` set in
+  `post_gen_tasks.cleanup_components`; forgetting either leaves `alembic/`
+  either missing when needed or present with no matching migration.

--- a/.claude/skills/add-service/SKILL.md
+++ b/.claude/skills/add-service/SKILL.md
@@ -1,0 +1,335 @@
+---
+name: add-service
+description: Use when adding a new service (a business capability like auth, AI, blog, or finance) to the Aegis Stack framework itself. Covers the plugin-spec registry, migrations, CLI, template, dashboard, test, docs, and i18n files that must change together.
+---
+
+# Add service
+
+Adds a new service (business logic, e.g. blog, finance, auth) to the framework
+so generated projects can select it via `aegis init --services` or add it
+later via `aegis add-service`. Traced from the two most recent services,
+`blog` and `finance`.
+
+## When to use
+
+Use when the task is "add a new service to Aegis Stack" (a business
+capability under `app/services/<name>/`, selected via `include_<name>` in
+`copier.yml`).
+
+Do NOT use for adding a **component** (infrastructure: worker, scheduler,
+database, redis, ingress, observability) - components live in
+`aegis/core/components.py` and share the same `PluginSpec` shape but a
+different file footprint. Do NOT use for changing behavior inside an
+existing service; that is ordinary feature work, not this skill.
+
+## Files that change
+
+Registry (`ServiceSpec` is a thin alias of `PluginSpec` pinned to
+`kind=SERVICE`; see `aegis/core/plugins/spec.py`):
+
+- `aegis/core/services.py`: add a `ServiceSpec` entry to the `SERVICES` dict.
+  Set `type` (add a new `ServiceType` member only if none fit),
+  `description`/`long_description`, `required_components`,
+  `recommended_components`, `pyproject_deps`, `template_files` (display list),
+  `marker_path` (the path `aegis update` uses to detect the service on disk),
+  and `docs_path` (leave `""` until the docs page ships - a non-empty value
+  is pinned by `tests/core/test_spec_docs_paths.py`).
+- `aegis/core/services.py`: `wiring=PluginWiring(...)` on the spec - declares
+  `routers` (`RouterWiring`), `dashboard_cards`/`dashboard_modals`
+  (`FrontendWidgetWiring`), and `deps_providers` (`SymbolWiring`). This
+  metadata mirrors, and must stay in sync with, the hand-written Jinja
+  conditionals in the template files below - it does not currently drive
+  their rendering for in-tree services.
+- `aegis/core/services.py`: `files=FileManifest(primary=[...], extras={...})`
+  - every path the service owns. `primary` is the add/init base;
+    `compute_file_mapping()` derives `post_gen_tasks.get_component_file_mapping()`
+    from this, so there is no separate hand-maintained mapping to edit.
+- `aegis/core/migration_generator.py`: only if the service owns tables, add a
+  `ServiceMigrationSpec` (built from `TableSpec`/`ColumnSpec`/`IndexSpec`/
+  `ForeignKeySpec`/`CheckConstraintSpec`) as a module-level constant (see
+  `BLOG_MIGRATION`, `FINANCE_MIGRATION`) and reference it from the spec's
+  `migrations=[...]` list in `services.py`. Import the plugin-facing aliases
+  from `aegis/core/migration_spec.py` if writing from outside this module.
+  `MIGRATION_SPECS` is derived lazily from every spec's `.migrations` via
+  `collect_migrations()` - no dict entry to hand-maintain.
+- `aegis/constants.py`: `AnswerKeys` - add `<NAME> = "include_<name>"` and
+  `SERVICE_<NAME> = "<name>"`. Add any sub-flag keys the service needs (see
+  `FINANCE_PLAID`, `FINANCE_SNAPTRADE`, `FINANCE_IMPORT`).
+- `copier.yml` (repo root, not under `templates/`): add the `include_<name>`
+  bool question, plus any per-service config questions gated with
+  `when: "{{ include_<name> }}"` (model on `finance_plaid`). Extend
+  `_include_migrations` if the service owns tables.
+- `aegis/core/<name>_service_parser.py`: only if the service takes bracket
+  syntax like `<name>[option]` (model on `ai_service_parser.py`,
+  `auth_service_parser.py`, `insights_service_parser.py`; blog and finance
+  need none of this - they have no `options=` on their spec). Wire it into
+  `aegis/core/service_resolver.py` if it introduces a cross-service
+  dependency check (see the `insights[per_user]` requires `auth[org]` block).
+- `aegis/cli/interactive.py`: `interactive_<name>_service_config()` only if
+  the service needs an interactive config prompt during `aegis add-service
+  --interactive` (model on `interactive_ai_service_config`; not needed for
+  blog/finance).
+
+Generation and update plumbing (thread the new `AnswerKeys.<NAME>` answer key
+through the generate and update flows; a table-owning service that skips these
+generates fine but breaks migrations on `aegis update`):
+
+- `aegis/core/template_generator.py`: add an `AnswerKeys.<NAME>: "yes"/"no"`
+  entry to the answer dict built from `selected_services` (model on the
+  existing per-service entries using `extract_base_service_name`).
+- `aegis/core/copier_manager.py`: add `AnswerKeys.<NAME>` to the template
+  context booleans, and if the service owns tables include it in the
+  `needs_migration_files` detection.
+- `aegis/core/copier_updater.py` and `aegis/commands/update.py`: add
+  `include_<name> = answers.get(AnswerKeys.<NAME>, False)` and OR it into the
+  aggregate migration/needs check used during update.
+- `aegis/core/manual_updater.py`: add `AnswerKeys.<NAME>` to the answer-keys
+  list it threads through add/remove.
+
+CLI (framework commands, not the generated project's CLI):
+
+- `aegis/commands/add_service.py`: resolves service deps to components,
+  prompts for config, calls `ManualUpdater.add_component`, generates
+  migrations via `generate_migration`/`bootstrap_alembic`. Only add a
+  service-specific branch here if the service needs bracket-syntax parsing
+  or extra answer keys threaded through (auth, ai, insights do; blog and
+  finance need none).
+- `aegis/commands/remove_service.py`: calls `ManualUpdater.remove_component`;
+  no per-service branch needed unless the service needs a custom warning
+  (see the auth-specific data-loss warning block).
+- `aegis/commands/services.py`: the `aegis services` list command reads
+  `SERVICES`/`ServiceType` automatically; no edit needed unless a new
+  `ServiceType` header is required.
+
+Template (`aegis/templates/copier-aegis-project/{{ project_slug }}/`):
+
+- `app/services/<name>/`: the service package (business logic, `deps.py` for
+  the FastAPI dependency provider referenced by `wiring.deps_providers`).
+- `app/components/backend/api/<name>/`: routes, registered in
+  `app/components/backend/api/routing.py.jinja` behind a full-body
+  `{%- if include_<name> %}` import + `app.include_router(...)` block.
+- `app/cli/<name>.py.jinja`: the project's `<name>` subcommand. Register it
+  in `app/cli/main.py.jinja` with the existing
+  `try: importlib.import_module(...) / except ImportError: pass` pattern.
+- Dashboard card: `app/components/frontend/dashboard/cards/<name>_card.py`,
+  exported from `cards/__init__.py.jinja` behind `{%- if include_<name> %}`,
+  and added to the aggregate `{%- if include_auth or ... or include_<name>
+  or _plugins %}` gate in that same file (guards `ServicesCard`'s import).
+- Dashboard modal: `app/components/frontend/dashboard/modals/<name>_modal.py`,
+  exported from `modals/__init__.py.jinja`, and added to the `modal_map` and
+  import block in `dashboard/cards/card_utils.py.jinja` (key convention:
+  `"service_<name>"`, matching `wiring.dashboard_cards[0].modal_id`).
+- The card/modal also need registering in the surrounding frontend wiring, each
+  behind `{%- if include_<name> %}`: `dashboard/status_overview.py.jinja` (the
+  status grid), `app/components/frontend/main.py.jinja` (the frontend app that
+  mounts the card), `app/services/system/ui.py.jinja` (dashboard registry), and
+  `app/components/backend/api/deps.py.jinja` if the service's routes need a
+  shared dependency. Trace how `blog` appears in each before adding `<name>`.
+- `app/components/backend/startup/component_health.py.jinja`: register the
+  service's health check behind `{%- if include_<name> %}` with
+  `register_service_health_check("<name>", check_<name>_service_health)`.
+- `app/components/backend/startup/database_init.py.jinja` (table-owning
+  services only): import the service's SQLModel models behind
+  `{%- if include_<name> %}` (with `# noqa: F401`), add `include_<name>` to the
+  `needs_migrations` set expression, and add a `"<name>": ("table",
+  "<table>")` entry to the existing-table stamp map. Skipping this means the
+  service's tables are never created or stamped.
+- `alembic/env.py.jinja` (table-owning services only): import the models behind
+  `{%- if include_<name> %}` so Alembic autogenerate sees them.
+- `pyproject.toml.jinja`: gate service-specific dependencies behind
+  `{%- if include_<name> %}`. If the service owns tables, add it to the
+  shared `alembic==1.16.5` gate condition (the big `{%- if include_auth or
+  ... or include_<name> %}` line).
+- `docs/services/<name>/` under the template tree is a separate, optional
+  convention (ships docs inside the generated project itself); only `comms`
+  has it today. Do not treat it as required.
+
+Framework docs (this repo's own `/docs`, published via the root `mkdocs.yml`
+- distinct from the template docs above, and what `ServiceSpec.docs_path`
+points at):
+
+- `docs/services/<name>/index.md` (+ `cli.md`, `api.md`, `dashboard.md`,
+  `examples.md`, `setup.md` as applicable - see `docs/services/blog/` and
+  `docs/services/payment/` for the current shape).
+- `mkdocs.yml` (repo root): add a `Services: - <Name>:` nav block pointing at
+  the new pages (see the `blog`/`payment`/`insights` entries).
+- `aegis/core/services.py`: set `docs_path="services/<name>"` on the spec
+  once the pages exist (leave `""` until then, per above).
+
+Tests (generated-project template tests, under
+`aegis/templates/copier-aegis-project/{{ project_slug }}/`):
+
+- `tests/services/<name>/test_<name>_service.py` (or
+  `tests/services/test_<name>_service.py` for a small service): unit tests
+  for the service's business logic (write first, TDD).
+- `tests/api/test_<name>_endpoints.py`: only if the service exposes routes.
+- Template-render test (framework side, optional): if the service's template
+  has non-trivial cross-service Jinja branching (e.g. blog's router renders
+  differently with auth on/off/rbac), add a
+  `tests/core/test_<name>_template_render.py` that renders the `.jinja` file
+  directly via `Environment(loader=FileSystemLoader(get_template_path()))`
+  and asserts on the rendered source (see `tests/core/test_blog_template_render.py`).
+
+Tests (this repo's own CLI/core test suite):
+
+- `tests/core/test_services.py`: add a spec-shape test class (name, type,
+  required/recommended components, `pyproject_deps`) and a
+  `test_<name>_service_wiring` test asserting `spec.wiring.routers[0].module`,
+  `.alias`, and the dashboard `modal_id`s (mirrors `test_blog_service_wiring`).
+- `tests/cli/test_services_cli.py`: extend the `aegis services` list-command
+  coverage tables with the new service's expected inclusion/exclusion flags.
+- `tests/cli/conftest.py`: add a `<name>_with_database` (or similarly named)
+  entry to `NAMED_PROJECT_SPECS` so downstream tests copy a cached project
+  instead of regenerating one (`tests/CLAUDE.md` explains the cache; skipping
+  this entry costs 10+ minutes of CI time). Also add the new stack to
+  `tests/cli/test_stack_generation.py`'s `STACK_COMBINATIONS` and to the
+  `everything` entry in `NAMED_PROJECT_SPECS`.
+- `tests/cli/test_add_service_importable.py`: add the service name (with
+  bracket options if it would otherwise prompt interactively) to
+  `SERVICE_INVOCATIONS`. This is the regen-gap guard: it runs
+  `aegis add-service <name>` against a cached base project and imports the
+  webserver/CLI/routing entry chains in the generated project's own venv,
+  catching files that render fine at `init` time but are missing from the
+  add/remove file mapping.
+- A migration test in the style of `tests/cli/test_add_service_migrations.py`
+  if the service owns tables (asserts `aegis add-service <name>` bootstraps
+  alembic and writes the migration file).
+- Collateral: adding a service to `SERVICES` shifts the service list that
+  several existing tests assert against. Expect to update
+  `tests/cli/test_guided.py`, `tests/cli/test_interactive_project_selection.py`,
+  `tests/cli/test_interactive_scheduler.py`, `tests/cli/test_ai_configuration.py`,
+  and `tests/cli/test_scheduler_persistence.py` when they fail on counts or
+  expected-option lists. These are not new files; run the gates and fix what
+  goes red.
+
+i18n:
+
+- `aegis/i18n/locales/en.py`: add `"service.<name>"` (short description, used
+  by `aegis services`) and `"projectmap.<name>"` (label used by the project map
+  renderer) with the real English strings.
+- `aegis/i18n/locales/{de,es,fr,ja,ko,ru,zh,zh_hant}.py`: add the SAME two keys
+  to every other locale, using the English string as a placeholder. This is
+  required for parity: `tests/core/test_i18n.py` asserts every locale carries
+  the same keys as English and fails naming the missing key otherwise. Real
+  translation of the placeholders is a separate translator-reviewed pass; do
+  not attempt it here, but the keys must exist now.
+
+Cross-cutting:
+
+- `aegis/config/shared_files.py`: only if the service introduces a **new**
+  shared file with `{% if include_<name> %}` conditionals (one not already in
+  `SHARED_TEMPLATE_FILES`). Editing an already-registered shared file (e.g.
+  `routing.py.jinja`, `component_health.py.jinja`, `cards/__init__.py.jinja`)
+  needs no new entry. `tests/cli/test_shared_files_completeness.py` fails
+  and names the missing file if a new one is forgotten.
+
+## Procedure
+
+1. Write the failing tests first: `tests/services/<name>/test_<name>_service.py`
+   (template side) for business logic, and `tests/api/test_<name>_endpoints.py`
+   if the service exposes routes. Confirm they fail for the right reason.
+2. Add `AnswerKeys.<NAME>` / `AnswerKeys.SERVICE_<NAME>` in
+   `aegis/constants.py`.
+3. If the service owns tables, add its `ServiceMigrationSpec` to
+   `aegis/core/migration_generator.py`.
+4. Add the `ServiceSpec` entry in `aegis/core/services.py`: identity fields,
+   `required_components`, `pyproject_deps`, `wiring=PluginWiring(...)`,
+   `migrations=[...]`, and `files=FileManifest(primary=[...])`.
+5. Add the `include_<name>` question (and any config questions) to
+   `copier.yml`, gating `_include_migrations` if relevant. Thread the new
+   `AnswerKeys.<NAME>` through the generation/update plumbing:
+   `template_generator.py`, `copier_manager.py`, `copier_updater.py`,
+   `manual_updater.py`, and `commands/update.py` (see Files that change).
+6. Build the template package: `app/services/<name>/`, the API router plus
+   `routing.py.jinja` registration, the CLI module plus `main.py.jinja`
+   registration, and the health check registration in
+   `component_health.py.jinja`.
+7. Wire the dashboard and frontend: card, modal, both `__init__.py.jinja`
+   files, the `modal_map`/import block in `card_utils.py.jinja`, plus
+   `status_overview.py.jinja`, `frontend/main.py.jinja`, and
+   `system/ui.py.jinja`. If the service owns tables, also register its models
+   in `database_init.py.jinja` (import + `needs_migrations` + stamp map) and
+   `alembic/env.py.jinja`.
+8. Gate `pyproject.toml.jinja` deps (and the shared alembic condition if the
+   service owns tables).
+9. Add the i18n keys `service.<name>` and `projectmap.<name>` to `en.py` with
+   real strings, and stub the same two keys into every other locale for parity
+   (see i18n above); `tests/core/test_i18n.py` fails otherwise.
+10. Add the `tests/core/test_services.py` spec-shape + wiring tests, the
+    `tests/cli/conftest.py` cache entry, and the `STACK_COMBINATIONS` /
+    `everything` entries.
+11. Add the service to `SERVICE_INVOCATIONS` in
+    `tests/cli/test_add_service_importable.py` and, if it owns tables, add a
+    migration test in the style of `test_add_service_migrations.py`. This
+    verifies the add path on an EXISTING project (`aegis add-service <name>`
+    against a cached base), not just fresh `aegis init` - the only way to
+    catch files that render at init time but are missing from the FileManifest.
+12. If any generated-project fix happened in a scratch/prototype project
+    rather than directly in the template, backport it into
+    `aegis/templates/` before finishing - templates are the source of truth.
+13. Once the docs page exists, add `docs/services/<name>/` pages, wire them
+    into the root `mkdocs.yml` nav, and set `docs_path` on the spec.
+14. Run the gates below and fix anything red.
+
+## Gates
+
+- `make check` (lint, typecheck, test) must pass.
+- `make test-stacks-quick` while iterating (fast feedback: runs the full
+  validation phase against a representative subset - base, everything,
+  insights).
+- `make test-stacks-full` before calling the work done (runs `test-stacks`
+  generation-only pass, the slow `test-stacks-build` validation pass, and
+  the kitchen-sink `everything` stack across every combination).
+
+## Pitfalls
+
+- Template changes render from the committed git state unless you pass
+  `aegis init --dev` (working tree) or commit first; testing a template edit
+  with plain `aegis init` on an uncommitted change silently uses stale
+  content.
+- `FileManifest.primary` on the spec is the single source
+  `get_component_file_mapping()` derives from (via `compute_file_mapping()`).
+  A file present in the template but missing from `primary` renders
+  correctly on fresh `init` (Copier just includes it) but is silently
+  skipped by `add-service`/`remove-service` on an existing project - the gap
+  only shows up when `tests/cli/test_add_service_importable.py` exercises
+  the add path, which is why that test's `SERVICE_INVOCATIONS` list must
+  include the new service.
+- Any file with `{% if include_<name> %}` conditionals that lives outside
+  the spec's `FileManifest` (e.g. a shared file edited in place, like
+  `routing.py.jinja`) must be registered in
+  `aegis/config/shared_files.py`'s `SHARED_TEMPLATE_FILES` or `ManualUpdater`
+  never regenerates it when the service is added/removed from an existing
+  project; `tests/cli/test_shared_files_completeness.py` names the missing
+  file if this is forgotten.
+- SQLModel model definitions (in the service's `models.py`) and the
+  `ServiceMigrationSpec`'s `TableSpec` entries in `migration_generator.py`
+  are two independent sources of truth for the same table; changing one
+  without the other drifts the schema from the ORM model silently, since
+  nothing type-checks them against each other.
+- `ServiceSpec.wiring` (routers, dashboard cards/modals, deps providers) is
+  metadata that currently only *mirrors* what's hand-wired into the shared
+  Jinja template files - it does not yet drive their rendering for in-tree
+  services. Editing one without the other leaves the spec's self-description
+  (used by `aegis services`, tests, and future plugin tooling) inconsistent
+  with what the generated project actually does.
+- `docs_path` on the spec is pinned by `tests/core/test_spec_docs_paths.py`
+  to a real file under this repo's root `/docs` - setting it before the docs
+  page exists (or pointing it at the template's `docs/services/<name>/`
+  instead of the root one) fails that test.
+- A table-owning service needs its models registered in
+  `database_init.py.jinja` (and `alembic/env.py.jinja`) on top of the
+  `ServiceMigrationSpec`; if you add the migration spec but skip these, the
+  service generates cleanly yet its tables are never created, and the failure
+  only surfaces at runtime, not at generation.
+- Threading `AnswerKeys.<NAME>` into `services.py` and `copier.yml` is not
+  enough: the generate/update plumbing (`template_generator.py`,
+  `copier_manager.py`, `copier_updater.py`, `manual_updater.py`,
+  `commands/update.py`) also reads it, and `copier_manager.py` gates
+  `needs_migration_files` on it, so a table-owning service that skips them
+  breaks migrations on `aegis update` while passing a fresh `aegis init`.
+- Adding an i18n key to `en.py` only fails `tests/core/test_i18n.py`, which
+  requires every locale to carry the same keys; stub the key into all locales
+  now and leave real translation to the separate translator pass.
+- Full-body `{% if %}` gating only inside a shared file; never use Copier
+  conditional filenames (breaks on Windows).

--- a/.claude/skills/example-skill/SKILL.md
+++ b/.claude/skills/example-skill/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: example-skill
+description: Use when you need the canonical shape of an Aegis Stack skill, or as the copy-from starting point for a new skill. Demonstrates every required section; not a real workflow.
+---
+
+# Example skill
+
+This skill exists to validate and demonstrate the house format defined in
+`.claude/skills/README.md`. It is a template, not a real workflow. Copy this
+directory, rename it, and replace the placeholder content.
+
+## When to use
+
+Use when starting a new skill and you want a known-good skeleton to fill in, or
+when you need to see how the required sections fit together.
+
+Do NOT use for real work. This skill performs no framework change; it only
+shows the format.
+
+## Files that change
+
+Grouped by role. A real skill lists exact repo-relative paths here so an agent
+opens them without searching. Placeholder example:
+
+- Registry: `aegis/services/registry.py`
+- CLI: `aegis/cli/<command>.py`
+- Template: `aegis/templates/copier-aegis-project/{{ project_slug }}/...`
+- Tests: `tests/<area>/test_<thing>.py`
+- Docs: `docs/<page>.md`
+- i18n: `aegis/i18n/en.py`
+
+## Procedure
+
+1. Write the failing test first (TDD): add the case to the relevant
+   `tests/...` file and confirm it fails for the right reason.
+2. Make the change in the registry, CLI, and template files listed above.
+3. Backport any change made in a generated project into its template under
+   `aegis/templates/`, so it survives the next `aegis init`.
+4. Update docs and i18n keys touched by the change.
+5. Run the gates below and fix anything red.
+
+## Gates
+
+- `make check` (lint, typecheck, test) must pass.
+- `make test-template` must pass when the change touches templates.
+
+## Pitfalls
+
+- Template changes read from the committed git state, not the working tree, so
+  an uncommitted template edit will not show up in a freshly generated project.
+- A vague frontmatter `description` means the skill never loads, because the
+  description is the only thing an agent reads when deciding to use it.

--- a/.claude/skills/execute-issue/SKILL.md
+++ b/.claude/skills/execute-issue/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: execute-issue
+description: Use when handed a GitHub issue (number or URL) to execute end to end. Reads the issue, classifies the work, loads the matching workflow skill, runs it against the stated acceptance criteria, and reports results without performing any git operations.
+---
+
+# Execute issue
+
+Turn a detailed GitHub issue into an executed change. This skill is the router:
+it does not itself know how to add a service or cut a release, it classifies the
+work and hands off to the workflow skill that does, then holds the run to the
+issue's acceptance criteria. Issues authored with the agent-task template
+(`.github/ISSUE_TEMPLATE/agent-task.yml`) map field-for-field onto this run.
+
+## When to use
+
+Use when given an issue number or URL and asked to execute, implement, or "do"
+it.
+
+Do NOT use to triage, comment on, or plan an issue without implementing it, and
+do NOT use it to open, branch, commit, or PR anything (those stay
+human-triggered; see Pitfalls). If the issue is vague enough that the scope or
+acceptance criteria cannot be restated concretely, stop and ask rather than
+guess.
+
+## Files that change
+
+This skill owns no fixed file list. The files that change are whatever the
+classified workflow skill dictates. Reading order:
+
+- The issue body and comments (via `gh issue view <n> --comments`).
+- The matching workflow skill under `.claude/skills/<name>/SKILL.md`, whose
+  `## Files that change` section is the authoritative list for the run.
+
+Classification map (issue work type to skill):
+
+- New business capability (auth, AI, payment, blog, finance): `add-service`
+- New infrastructure or a variant axis (worker, scheduler, database, redis, a
+  `*_backend` option): `add-component`
+- Locale strings, translations: `i18n`
+- A command on the `aegis` tool CLI: `add-cli-command`
+- Version or rc release: `release`
+- Template edits or backporting from a generated project: `template-dev`
+
+An issue may span more than one type (a service that adds a CLI command and
+locale strings). Load every matching skill and follow each for its slice.
+
+## Procedure
+
+1. Read the issue: `gh issue view <n> --comments`. Read the comments; they often
+   correct the body (a burned-rc note, a moved file). Where a comment and the
+   body disagree, the comment usually wins, but verify against the code.
+2. Classify the work against the map above and name the skill(s) you will load.
+   State the classification back to the user in one line.
+3. Load each matching workflow skill and read its `## Files that change`,
+   `## Procedure`, `## Gates`, and `## Pitfalls`.
+4. Restate the issue's acceptance criteria in the session as an explicit
+   checklist. This is the contract the run is measured against.
+5. Verify the issue's claims against the code before writing anything. If the
+   issue names a file, function, or flag that does not exist or has moved, stop
+   and surface the contradiction rather than coding to a false premise.
+6. Write the failing test first (per the loaded skill's TDD step), then
+   implement following that skill's Procedure.
+7. Run the loaded skill's gates. Fix what goes red.
+8. Report results against each acceptance-criterion line one by one: met, not
+   met, or blocked, with the evidence (test name, gate output). Do not claim a
+   criterion is met without having exercised it.
+9. Stop before any git operation and hand back to the user for review.
+
+## Gates
+
+The gates are whichever the loaded workflow skill specifies (for example
+`make check` plus a `test-stacks` or `test-template` target). Run exactly those;
+do not substitute a lighter target for the one the skill names as the
+before-done gate.
+
+## Pitfalls
+
+- No git operations: branching, committing, and PRs stay human-triggered even
+  when the issue implies them, because the repo's git policy forbids unrequested
+  git actions.
+- An issue is a claim about the code, not the code itself; coding to the issue's
+  described state without checking the real tree ships fixes for problems that
+  do not exist. Surface the mismatch instead.
+- Reporting a criterion as met because the code "should" satisfy it is not
+  evidence; a criterion counts as met only after its test or gate has actually
+  run green.
+- Skipping the classification step and improvising the file list loses the
+  hard-won completeness the workflow skills encode; always route through a
+  skill, never freehand a workflow the skills already cover.
+- A multi-type issue that loads only one skill misses a slice; re-scan the issue
+  for CLI, i18n, and docs work that rides along with the main change.

--- a/.claude/skills/i18n/SKILL.md
+++ b/.claude/skills/i18n/SKILL.md
@@ -1,0 +1,137 @@
+---
+name: i18n
+description: Use when a code or template change introduces a new translation message key, in either the framework CLI (aegis/i18n/locales/) or a generated project's CLI (the app/i18n/locales/ template tree). Covers adding the real English string, stubbing the same key into every other locale for parity, and the separate translation PR that later replaces placeholders with reviewed native text.
+---
+
+# i18n
+
+Adds a new i18n message key so `tests/core/test_i18n.py` (framework side) or
+the generated project's own `tests/test_i18n.py` keeps passing. Both trees
+share the same rule: a key that exists in English must exist, with some
+value, in every other locale file, or the completeness test fails by name.
+
+## When to use
+
+Use when a feature or fix needs a brand-new string shown through the
+translation layer (`t("some.key")` or `lazy_t("some.key")`), in either:
+
+- The framework's own CLI (`aegis ...` commands), backed by
+  `aegis/i18n/locales/`.
+- A generated project's CLI (`app/i18n/locales/` under the copier template),
+  which is a separate, parallel i18n tree with the same shape.
+
+Do NOT use this skill to perform the actual translation work into
+non-English languages; that is a separate, later PR (see Procedure below).
+Do NOT use it for changing the wording of an existing English string without
+adding a key; that is ordinary feature work, though it still needs the
+placeholder value updated in every other locale if the value materially
+changes (rare - most wording tweaks are English-only maintenance and do not
+require this skill).
+
+## Files that change
+
+Framework i18n (`aegis/i18n/`):
+
+- `aegis/i18n/locales/en.py`: canonical `MESSAGES: dict[str, str]`. Add the
+  key with its real English value under the matching section-comment banner
+  (e.g. `# --- Validation ---`, `# --- Interactive: AI service ---`). Keys are
+  dot-separated `<area>.<name>`, matching existing groups such as
+  `service.<name>`, `component.<name>`, `interactive.*`, `projectmap.*`,
+  `add_service.*`, `deploy.*`.
+- `aegis/i18n/locales/{de,es,fr,ja,ko,ru,zh,zh_hant}.py`: add the SAME key to
+  each file, value = the English string, unmodified (a placeholder, not a
+  translation).
+- `aegis/i18n/locales/__init__.py`: `AVAILABLE_LOCALES` set; only touch this
+  if adding a whole new locale, not a new key.
+- `aegis/i18n/registry.py`: `translate()` does the lookup and fallback; no
+  edit needed for a new key, it is generic over the dict.
+- `tests/core/test_i18n.py`: `TestMessageCompleteness` is the gate. A missing
+  key fails with a message like `Keys in en but not de: {'the.new.key'}`; an
+  extra key (present in a locale but not English) fails the mirror-image
+  assertion.
+
+Generated-project i18n (a template change, see the template-dev skill for
+the commit/render caveat):
+
+- `aegis/templates/copier-aegis-project/{{ project_slug }}/app/i18n/locales/en.py`
+- `aegis/templates/copier-aegis-project/{{ project_slug }}/app/i18n/locales/{de,es,fr,ja,ko,ru,zh,zh_hant}.py`
+- `aegis/templates/copier-aegis-project/{{ project_slug }}/app/i18n/registry.py.jinja`:
+  same fallback-chain `translate()`; no edit needed for a new key.
+- `aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_i18n.py`:
+  the generated project's own completeness test. It imports only `en` and
+  `zh` explicitly and asserts those two key sets match; it does not loop over
+  all nine locales the way the framework's test does. Stub the key into all
+  eight non-English locales anyway, for consistency with the framework rule
+  and to keep every locale file real (no dangling English-only keys).
+
+## Procedure
+
+Adding a new key:
+
+1. Decide which tree owns the string (framework CLI vs generated-project
+   CLI). If both need it independently, repeat the rest of these steps once
+   per tree.
+2. Write or adjust the consuming code to call `t("<area>.<name>", ...)` or
+   `lazy_t("<area>.<name>", ...)` at the call site.
+3. Add the key with its real English string to that tree's `en.py`, under
+   the appropriate section-comment banner, following the existing
+   `<area>.<name>` naming.
+4. Add the same key to every other locale file in that tree, using the
+   English string as the value (a placeholder, not a translation).
+5. Run the gates (see Gates below) and confirm the completeness test passes.
+6. If the generated-project tree changed, treat it as a template change:
+   commit it (or use `aegis init --dev`) before validating with
+   `make test-template`, per the template-dev skill.
+
+Translation PR (separate flow, later):
+
+1. Take the placeholder (English-value) entries in the non-English locale
+   files and replace them with real, native translations.
+2. The agent produces the initial translation pass.
+3. A human translator reviews and corrects it; iterate back and forth until
+   the wording reads native, not like a literal translation. Mandarin is the
+   main quality bar for "does this sound native."
+4. Keep phrasing compact: these are CLI strings rendered in a terminal.
+   Prefer a compact, natural phrase over a longer one that is technically
+   clearer; skip "clearer but longer" rewrites suggested along the way.
+5. Run the same gates again; only wording changed, so the completeness test
+   should already pass, but confirm no key was dropped in the edit.
+
+## Gates
+
+- `make check` (framework side: lint, typecheck, `tests/core/test_i18n.py`
+  included in the default test run) must pass whenever
+  `aegis/i18n/locales/` changed.
+- `make test-template` when the generated-project locale files under
+  `aegis/templates/copier-aegis-project/{{ project_slug }}/app/i18n/locales/`
+  changed; this generates a project and runs its own test suite, including
+  `tests/test_i18n.py`.
+
+## Pitfalls
+
+- Adding a key to `en.py` only fails `tests/core/test_i18n.py`, which checks
+  both directions (missing keys and extra keys) for every locale, so the
+  key must exist everywhere before `make check` is green.
+- Do not write real translations in the same change that introduces the key;
+  that is the separate translation PR's job, done with a human translator in
+  the loop, not invented inline.
+- Word-for-word translations read wrong to native speakers; the bar is
+  natural, native phrasing, and Mandarin is where this has mattered most in
+  review.
+- CLI strings render in a fixed terminal width; prefer the compact phrasing
+  and skip "clearer but longer" rewrites even when they read a bit better in
+  isolation.
+- Generated-project locale edits are template changes: Copier renders from
+  the committed git state (or the working tree only under `aegis init
+  --dev`), so an uncommitted edit under `app/i18n/locales/` will not show up
+  in a freshly generated project until it is committed.
+- The runtime fallback in `translate()` (current locale, then English, then
+  the raw key) means a missing locale entry would still show something
+  reasonable at runtime, but `tests/core/test_i18n.py` does not rely on
+  runtime behavior; it asserts exact key-set equality, so relying on the
+  fallback instead of stubbing the key still fails the gate.
+- The generated project's own `tests/test_i18n.py` only compares `en` against
+  `zh` by name; it will not catch a key missing from `de`, `es`, `fr`, `ja`,
+  `ko`, `ru`, or `zh_hant`. Stub the key into all eight non-English locales
+  regardless, since that test's narrower coverage is not a license to skip
+  the others.

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: release
+description: Use when cutting a release of the aegis-stack package. Covers the version-bump file set, the changelog cut, the three release gates, TestPyPI rc verification, and the tag-push mechanics that trigger the publish workflow.
+---
+
+# Release
+
+Cuts a new version of the `aegis-stack` package itself (not a generated
+project). Bumps the version string, cuts the changelog, runs three
+independent gates, verifies an rc on TestPyPI, then tags for a real PyPI
+publish and verifies again against the published package.
+
+## When to use
+
+Use when the task is "release a new version of aegis-stack" (bump the
+version, publish to PyPI, cut a GitHub release).
+
+Do NOT use for ordinary feature or fix work with no release attached, and do
+NOT use for generated-project releases (those follow the target project's own
+process, not this one).
+
+## Files that change
+
+Version bump (all five must be touched together; verify each file actually
+contains the version string before editing it, since it is easy to assume a
+file participates when it does not):
+
+- `aegis/__init__.py`: `__version__ = "X.Y.Z"`.
+- `pyproject.toml`: `version = "X.Y.Z"` under `[project]`.
+- `copier.yml` (repo root): `_version: "X.Y.Z"`.
+- `CHANGELOG.md`: the version also appears here as the new dated section
+  heading (see the changelog cut step in Procedure).
+- `uv.lock`: the `[[package]] name = "aegis-stack"` entry's own `version =
+  "X.Y.Z"` field. This one is not hand-edited; the pre-commit `ty` hook
+  rewrites it, so stage it in a second commit pass (see Procedure).
+
+Every other match of the old version string in the repo is test data or an
+unrelated coincidence; leave it alone.
+
+Gate-relevant files (read, not edited, unless a gate fails):
+
+- `Makefile` (repo root): `check`, `test-stacks-full`, `test-stacks-quick`
+  targets.
+- `tests/test_runtime_dependencies.py`: guards that `ruff` (and any other
+  binary the updater shells out to at runtime) stays in
+  `[project].dependencies`, not only a dev extra.
+- `.github/workflows/release.yml`: the tag-triggered publish workflow (`v*.*.*-rc*`
+  routes to TestPyPI, bare `v*.*.*` routes to PyPI); read this if tagging
+  behavior is ever in question.
+
+## Procedure
+
+1. Confirm the target version and the previous released tag.
+2. Bump the version string in all five files listed above. Open each file and
+   grep for the old version string to confirm the edit landed; do not assume
+   a file needs changing just because a prior release touched it.
+3. Cut the changelog in `CHANGELOG.md`: identify which items under
+   `[Unreleased]` actually shipped in this release (cross-check with `git log
+   --first-parent <prev-tag>..HEAD` so nothing merged after the branch point
+   is mis-attributed), rename that content into a new dated `[X.Y.Z] -
+   YYYY-MM-DD` section, draft the section body from the PR history for this
+   range, and leave a fresh, empty `## [Unreleased]` heading above it. This
+   step is required and routinely forgotten; do not skip it.
+4. Commit the version bump and changelog cut. If the pre-commit `ty` hook
+   rewrites `uv.lock` during this commit, `git add uv.lock` and commit again
+   so the lockfile's own version field matches.
+5. Run the three gates (see Gates). Fix anything red before proceeding.
+6. Tag the release commit as a release candidate: `git tag vX.Y.Z-rcN && git
+   push origin vX.Y.Z-rcN`. This is what actually triggers the publish
+   workflow; merging the version-bump PR alone publishes nothing.
+7. Once the workflow is green, verify the rc via the TestPyPI upgrade-path
+   recipe (see Gates, gate 3) run against the published rc rather than a
+   local wheel.
+8. If the rc verification finds a problem, fix it, bump to the next rc number
+   (never reuse or re-tag a burned rc, see Pitfalls), and repeat from step 5.
+9. Once an rc is clean, tag the same commit for the real release: `git tag
+   vX.Y.Z && git push origin vX.Y.Z`. This publishes to PyPI and drafts a
+   GitHub release.
+10. Post-publish, repeat the TestPyPI-style upgrade recipe once more against
+    the now-published PyPI package (init the previous release, `update` to
+    the new version) and grep the resulting project for conflict markers to
+    confirm a clean upgrade path for real users.
+
+## Gates
+
+All three are required; each independently catches a class of failure the
+others miss.
+
+- `make check`: framework lint, typecheck, and pytest. Catches a
+  constant/config change made without updating the test that asserts on it.
+- `make test-stacks-full`: the full stack generation matrix (generate,
+  install, lint, typecheck, pytest per stack combination). Catches template
+  drift on stacks that no single local test generates on its own.
+  `make test-stacks-quick` (base/everything/insights subset) is for iteration
+  only; it never substitutes for the full run before a release.
+- Production-mode wheel test: the repo's own test venv installs
+  `--all-extras`, so a dependency that lives only in the dev extra looks fine
+  locally but is missing from a real `uvx`/`pip` install. Before tagging,
+  run `uv build`, then `uvx --from ./dist/aegis_stack-<ver>-py3-none-any.whl
+  aegis update -y -p <fresh prev-release project> -t <repo> --to-version
+  HEAD`, and assert zero conflict markers and a completed post-gen run.
+  Confirm `tests/test_runtime_dependencies.py` exists and passes; it guards
+  `ruff` specifically for this exact failure mode.
+
+TestPyPI upgrade-path verification recipe (used in Procedure steps 7 and 10):
+
+```bash
+uvx --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    --index-strategy unsafe-best-match \
+    aegis-stack@<prev-version> init test-upgrade-project --no-interactive -y
+
+cd test-upgrade-project
+uvx --index-url https://test.pypi.org/simple/ \
+    --extra-index-url https://pypi.org/simple/ \
+    --index-strategy unsafe-best-match \
+    aegis-stack@<rc-version> update -y
+```
+
+## Pitfalls
+
+- This procedure describes `git add`, `git commit`, `git tag`, and `git push`
+  as the steps that must happen, but per the repo git policy the agent runs no
+  git command without explicit user approval; stop and ask before each, the
+  same as any other workflow.
+- A burned rc version string (any rc that ever reached TestPyPI) can never be
+  reused, even after deletion: PyPI/TestPyPI reject the filename permanently,
+  and re-running the same tag replays the same HTTP 400. Always increment to
+  the next rc number instead of re-tagging.
+- Never pass `skip-existing` to the publish step: TestPyPI would then keep
+  serving the stale build under that filename instead of failing loudly,
+  and the smoke test would silently verify the wrong artifact.
+- The release workflow triggers only on a tag push, not on a merge. Merging
+  the version-bump PR into main publishes nothing; the actual publish and
+  GitHub-release steps only run after `git push origin vX.Y.Z[-rcN]` against
+  the merged commit.
+- A dependency that lives only in the dev extra (`--all-extras` in the repo's
+  own test venv) passes every local and CI test yet is silently absent from a
+  real `uvx`/`pip` install; this is exactly what the production-mode wheel
+  test gate exists to catch, so do not skip it even when the other two gates
+  are green.
+- `UV_PYTHON=3.11` is tool-only: it belongs in the release/CI/canary jobs
+  that build and test this CLI, and must never be set globally in the stack
+  matrix, because generated projects require Python >= 3.13. Pair it with
+  `UV_LINK_MODE=copy` to avoid broken cache hardlinks.
+- The changelog cut is easy to forget entirely since nothing fails loudly if
+  it is skipped; verify the dated section exists and `[Unreleased]` is empty
+  again before tagging, not just that the version files were bumped.

--- a/.claude/skills/template-dev/SKILL.md
+++ b/.claude/skills/template-dev/SKILL.md
@@ -1,0 +1,159 @@
+---
+name: template-dev
+description: Use when developing or modifying Copier templates in aegis/templates, or backporting a change from a generated project (e.g. a prototype scratch project) back into the templates. Covers the two development workflows, the three rendering modes that resolve where Copier reads template content from, and the template-specific gotchas that silently break generation or update.
+---
+
+# Template dev
+
+Develops and backports changes to the Copier templates that every generated
+Aegis Stack project is rendered from. This is the general template-editing
+workflow: how to iterate, how rendering picks up (or ignores) your edits, and
+the traps that only show up on `aegis update`, not on a fresh `aegis init`.
+
+## When to use
+
+Use when the task touches template content directly (`docker-compose.yml.jinja`,
+`Makefile.jinja`, any file under `app/`, `pyproject.toml.jinja`, `copier.yml`,
+etc.) or when a fix was made inside a generated project and needs to be
+carried back into the templates.
+
+Do NOT use this skill for adding a brand-new component or service (a
+`ComponentSpec`/`ServiceSpec` entry, its `FileManifest`, and its
+generation/update plumbing) - use the `add-component` or `add-service` skill
+instead; they cover the plugin-spec registry work this skill assumes is
+already done. Do NOT use for ordinary feature work inside the CLI tool itself
+(`aegis/commands/`, `aegis/core/` logic unrelated to rendering) unless that
+work is specifically about how templates render or update.
+
+## Files that change
+
+Source-of-truth law: templates ship, generated projects are prototypes. The
+templates live under:
+
+- `aegis/templates/copier-aegis-project/{{ project_slug }}/`: every file a
+  generated project contains, one-to-one. A plain file with no Jinja logic
+  ships as-is (e.g. `app/components/worker/registry.py`); a file with
+  conditional content ships with a `.jinja` suffix (e.g.
+  `app/components/worker/events.py.jinja`).
+- `copier.yml` (repo root, not under `templates/`): the question set Copier
+  prompts for or reads answers from.
+- `aegis/templates/copier-aegis-project/{{ project_slug }}/.copier-answers.yml.jinja`:
+  the answers file template; see Pitfalls for which fields belong here.
+- `aegis/core/copier_manager.py`: renders a new project (`aegis init`),
+  including the dev-mode/git-mode source selection and the post-generation
+  answers backfill.
+- `aegis/core/copier_updater.py`: resolves the template source and version
+  ref for `aegis update`.
+- `aegis/core/manual_updater.py`: adds/removes a single component or service
+  on an existing project without a full Copier update.
+- `Makefile` (repo root): the `test-template*` and `test-stacks*` targets used
+  to validate template changes.
+
+Backport target mapping: any file you edit inside a generated project at
+`<project>/<path>` has its template source at
+`aegis/templates/copier-aegis-project/{{ project_slug }}/<path>` (or
+`<path>.jinja` if that file needs Jinja conditionals). Backport with:
+
+```bash
+cp my-app/app/components/worker/registry.py \
+  "aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/worker/registry.py"
+```
+
+Quote the destination path; the directory name contains the literal `{{ project_slug }}`
+placeholder, which a shell would otherwise try to expand.
+
+## Procedure
+
+Pick one of two workflows, then apply the rendering mode that matches it.
+
+**Template-first** (the change is already known):
+
+1. Edit the file(s) directly under
+   `aegis/templates/copier-aegis-project/{{ project_slug }}/...`.
+2. Generate a test project with `aegis init test-project --dev` (working
+   tree, no commit needed) or `make test-template-quick`/`make test-template`
+   (committed state, see rendering modes below).
+3. Verify the generated project behaves as expected.
+4. Clean up with `make clean-test-projects`.
+
+**Prototype-first** (exploratory, the fix is easier to find by iterating
+directly on generated code):
+
+1. Generate a test project (`aegis init <name> --dev`, or any
+   `make test-template*` target).
+2. Iterate directly in the generated project until it works.
+3. Backport immediately, in the same session, using the `cp` pattern above
+   for every file you touched. Do not defer this; changes left only in a
+   generated project are lost on the next `aegis init`.
+4. Regenerate a fresh project from the templates to confirm the backport is
+   correct, then clean up.
+
+Rendering modes (this resolves which template content Copier actually reads):
+
+- Default (installed package, or local git repo without `--dev`): Copier
+  renders the COMMITTED git state, either via a GitHub URL (pip/uvx install)
+  or a `git+file://` URL pointing at the local repo (`aegis/core/copier_manager.py`,
+  the `is_git_repo(template_root)` branch). Uncommitted template edits are
+  invisible even though the files look changed locally.
+- `aegis init --dev`: renders the WORKING TREE. `aegis/core/copier_manager.py`'s
+  `dev_mode` branch copies `copier.yml` and
+  `aegis/templates/copier-aegis-project` from the working tree into a
+  temporary directory and generates from that plain path, so uncommitted
+  edits show up immediately. Use this for local iteration; no commit
+  required. Projects generated this way have no `_commit` pin and cannot run
+  `aegis update` later.
+- External project update: `aegis update -y -p <project> -t <aegis-stack repo> --to-version HEAD`.
+  `-p`/`--project-path` points at the target project, `-t`/`--template-path`
+  points Copier at a local aegis-stack checkout instead of the installed
+  package, and `--to-version HEAD` resolves to the latest commit on the
+  current branch instead of a version tag. This still reads the COMMITTED
+  state of that checkout, not its working tree, so template changes must be
+  committed first.
+
+## Gates
+
+- `make test-template` after any template edit (generates a project and runs
+  its full validation, including `make check` inside the generated project).
+- Whichever narrower target matches the touched component or service, for
+  faster iteration: `make test-template-quick` (no validation),
+  `make test-template-with-components`, `make test-template-auth`,
+  `make test-template-worker`, `make test-template-database`,
+  `make test-template-full`, `make test-template-ai`,
+  `make test-template-ai-memory`, `make test-template-ai-sqlite`.
+- `make test-stacks-quick` while iterating on a cross-cutting template change
+  (fast feedback against a representative subset: base, everything, insights).
+- `make test-stacks-full` before calling multi-component template work done
+  (generation-only pass, the slow build/validation pass, and the kitchen-sink
+  `everything` stack).
+- `make check` for any non-template Python change made along the way (for
+  example, editing `copier_manager.py` or `manual_updater.py`).
+- `make clean-test-projects` to remove generated test project directories
+  once verification is done.
+
+## Pitfalls
+
+- Gate conditional content with a full-body `{% if %}...{% endif %}` wrap
+  only. Never use Copier conditional filenames; that convention broke on
+  Windows and is banned outright.
+- Carry no inline comments in `docker-compose.yml.jinja` or its `.dev`/`.prod`
+  variants. Which components a given project selects varies per stack, so a
+  comment written for one combination misleads for another; state conditions
+  through the Jinja gate itself.
+- Every new `copier.yml` question needs a matching line in
+  `.copier-answers.yml.jinja`, except fields gated by a `when:` clause.
+  Copier itself drops `when`-gated answers from the rendered answers file
+  (observed for `worker_backend`, `scheduler_backend`, `include_oauth`), so
+  the actual persistence path for those is `copier_manager.py`'s
+  post-generation backfill loop, which patches any `copier_data` key Copier
+  dropped directly into the written `.copier-answers.yml`. Adding a
+  `when`-gated field to the `.jinja` list anyway is harmless but is not what
+  makes it survive.
+- `copier` is pinned below 9.15 in `pyproject.toml` (9.15+ relocates
+  `.copier-answers.yml` out of the generated project directory, breaking
+  `aegis update`). A dependabot ignore rule blocks upgrade PRs past that
+  ceiling; do not bump the pin even if a bot proposes it.
+- `uv.lock` hides fresh-install dependency drift. Validate a template
+  dependency change (new `pyproject.toml.jinja` gates, new packages) with
+  `uvx` or a fresh `uv sync` inside a freshly generated project, not the
+  locally locked dev environment, since the lock file can mask a resolution
+  that only fails on a clean install.

--- a/.github/ISSUE_TEMPLATE/agent-task.yml
+++ b/.github/ISSUE_TEMPLATE/agent-task.yml
@@ -1,0 +1,86 @@
+name: Agent task
+description: A task written to be executed by a coding agent via the execute-issue skill.
+title: "[Agent task] "
+labels: ["agent"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Write this issue so an agent can execute it end to end without
+        rediscovering the file list. Each field maps onto the execute-issue run
+        contract. Be exact: name real files, restate acceptance as checkable
+        lines, and state what is out of scope.
+
+  - type: dropdown
+    id: task_type
+    attributes:
+      label: Task type
+      description: Determines which workflow skill the agent loads. Pick all that apply.
+      multiple: true
+      options:
+        - New service (add-service)
+        - New component or variant axis (add-component)
+        - i18n / locale strings (i18n)
+        - aegis CLI command (add-cli-command)
+        - Release / version bump (release)
+        - Template change or backport (template-dev)
+        - Other (state which skill, or that none fits)
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Why this work exists and any background the agent needs. Link prior work if relevant.
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Exact scope
+      description: Precisely what to build or change. Concrete behavior, names, and shapes, not a vague goal.
+    validations:
+      required: true
+
+  - type: textarea
+    id: files
+    attributes:
+      label: Files expected to change
+      description: Repo-relative paths the change should touch, grouped by role (registry, CLI, template, tests, docs, i18n). The loaded skill's file list is authoritative; this is the issue author's expectation to check against.
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: One checkable line per criterion. The agent restates these and reports each as met, not met, or blocked, with evidence.
+      value: |
+        - [ ]
+        - [ ]
+    validations:
+      required: true
+
+  - type: textarea
+    id: gates
+    attributes:
+      label: Gates
+      description: The exact make targets that must pass before the work counts as done (for example `make check`, `make test-stacks-full`). If omitted, the agent uses the loaded skill's gates.
+    validations:
+      required: false
+
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of scope
+      description: What NOT to do, so the agent does not scope-creep. Include anything deliberately deferred.
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        The agent executes this via the execute-issue skill and stops before any
+        git operation. Branching, committing, and PRs stay human-triggered.

--- a/.gitignore
+++ b/.gitignore
@@ -136,8 +136,9 @@ data/
 # Demos
 demos/recordings
 
-# Claude Stuff
-.claude/
+# Claude Stuff (track shared skills + agents; ignore only local/personal settings)
+.claude/settings.local.json
+.claude/*.local.json
 
 # Typical generated stack folders
 my-app/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,283 +1,79 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code when working with code in this repository.
-
-## ⚠️ CRITICAL: No Git Operations
-
-**DO NOT perform git operations unless explicitly requested.** This includes:
-- No `git add`, `git commit`, or `git push` commands
-- No `git status`, `git diff`, or `git log` for preparation purposes
-- No creating pull requests
-- No staging files
-
-**Wait for explicit user approval before ANY git operations.**
-
----
-
-## Project Architecture
-
-**Aegis Stack is a modular platform for building and evolving production-ready Python applications.**
-
-What you get:
-- **CLI Tool** (`aegis`): Create, modify, and update projects
-- **Component System**: Add/remove building blocks (database, worker, scheduler, redis)
-- **Service System**: Add/remove business capabilities (auth, AI, payment, analytics)
-- **Living Projects**: Generated projects can pull updates, bug fixes, and new features via `aegis update`
-
-Each generated project includes:
-- Project-specific CLI
-- FastAPI backend
-- Full test suite
-- Docker containerization
-
-## Installation
-
-**Current Version**: 0.9.1
-
-```bash
-pip install aegis-stack
-```
-
-**Links**:
-- PyPI: https://pypi.org/project/aegis-stack/
-- GitHub: https://github.com/lbedner/aegis-stack
-
-## Development Commands
-
-This project uses `uv` for dependency management and a `Makefile` for CLI development tasks.
-
-### CLI Development Commands
-- `make test` - Run the CLI test suite with pytest
-- `make lint` - Run linting with ruff
-- `make typecheck` - Run type checking with ty
-- `make check` - Run all checks (lint + typecheck + test) - **run this before committing**
-- `make install` or `uv sync --all-extras` - Install/sync dependencies
-- `make cli-test` - Test CLI commands locally
-- `make docs-serve` - Serve tool documentation locally on port 8001
-
-### Template Development & Testing
-- `make test-template-quick` - Quick template test without validation
-- `make test-template` - Full template test with validation
-- `make test-template-with-components` - Test template with scheduler component
-- `make test-template-auth` - Test auth service template
-- `make test-template-worker` - Test worker component template
-- `make test-template-database` - Test database component template
-- `make test-template-full` - Test template with all components
-- `make clean-test-projects` - Remove generated test projects
-
-**Template testing is critical** - always run `make test-template` after modifying templates to ensure generated projects work correctly.
-
-### Pre-RC verification (REQUIRED before any version bump)
-
-Before suggesting a version/rc bump, run BOTH locally:
-
-1. **`make check`** — the aegis-stack repo's OWN test suite (lint +
-   typecheck + pytest). Catches bugs in the CLI / core code itself,
-   including config tests that gate on constants like
-   ``DEFAULT_PYTHON_VERSION``. Without this, changing a constant
-   without updating its assertion test passes locally but fails CI.
-
-2. **`make test-stacks-full`** — the matrix that runs each generated
-   stack through generation → install → lint → typecheck → pytest.
-   Catches drift in templates / cross-stack issues.
-
-History shows multiple rcs in a row were "green locally" by `aegis init` +
-`make check` (on the GENERATED project) on a single stack, but failed CI
-because either:
-- The matrix was never run (caught template drift on stacks the local
-  test didn't generate), or
-- The aegis-stack repo's own tests were never run (caught constant /
-  config changes without test updates).
-
-Running both targets is the only way to match what CI actually runs.
-
-If the matrix takes too long during iteration, use `make test-stacks-quick`
-for fast feedback (3 representative stacks: base, everything, insights),
-then run the full matrix once at the end.
-
-### TestPyPI Release Testing
-Test upgrade paths using TestPyPI before publishing to PyPI:
-
-```bash
-# 1. Install old version from TestPyPI and create project
-uvx --index-url https://test.pypi.org/simple/ \
-    --extra-index-url https://pypi.org/simple/ \
-    --index-strategy unsafe-best-match \
-    aegis-stack@0.5.3 init test-upgrade-project --no-interactive -y
-
-# 2. Install new RC version and test update
-cd test-upgrade-project
-uvx --index-url https://test.pypi.org/simple/ \
-    --extra-index-url https://pypi.org/simple/ \
-    --index-strategy unsafe-best-match \
-    aegis-stack@0.5.4rc1 update -y
-```
-
-**Key uvx flags:**
-- `--index-url` - Primary source: TestPyPI
-- `--extra-index-url` - Fallback: PyPI (for dependencies not on TestPyPI)
-- `--index-strategy unsafe-best-match` - Allows mixing packages from different indexes
-
-### Updating External Projects with Local Committed Template Changes
-To test local committed template changes against an external Aegis project, use the `--template-path` and `--to-version HEAD` flags:
-
-```bash
-# From the aegis-stack root (where .venv lives):
-aegis update -y -p /path/to/project -t /path/to/aegis-stack --to-version HEAD
-```
-
-**Key flags:**
-- `-p` / `--project-path` - Path to the target Aegis project
-- `-t` / `--template-path` - Points Copier at the local aegis-stack repo instead of the installed package
-- `--to-version HEAD` - Uses the latest commit on the current branch (not the version tag)
-
-**Note:** Template changes must be committed to git first — Copier reads from the git state, not the working tree.
-
-## Code Navigation (LSP-First)
-
-Use the Language Server (Pyright) for code navigation instead of grep/glob:
-
-**Prefer LSP:**
-- `LSP(findReferences)` - Find all usages of a symbol
-- `LSP(goToDefinition)` - Jump to where something is defined
-- `LSP(hover)` - Get type info and docstrings
-- `LSP(documentSymbol)` - List all symbols in a file
-
-**Use grep/glob when:**
-- Searching for text patterns (not symbol names)
-- Searching in non-Python files (yaml, md, json, jinja)
-- LSP server not available
-
-**Why LSP is better:**
-- Semantic understanding - knows actual references, not text matches
-- Type-aware - hover shows full type signatures
-
-## Test Project Location
-
-**When prototyping, check `my-app/` under the aegis-stack root first.**
-
-The user often has a test project at `/Users/leonardbedner/Workspace/house_bedner/aegis-stack/my-app/` for iterating on changes before backporting to templates. When making fixes:
-1. Look in `my-app/` first for the generated project code
-2. Test changes there
-3. Backport working changes to templates in `aegis/templates/`
-
-## Template Development Workflow
-
-### ⚠️ CRITICAL: Always Backport Immediately
-
-**When editing code in `my-app/` or any generated project, ALWAYS backport changes to templates immediately.**
-
-- Edit both `my-app/` AND templates in the same session
-- Copy fixed files: `cp my-app/path/to/file.py "aegis/templates/copier-aegis-project/{{ project_slug }}/path/to/file.py"`
-- Never leave changes only in `my-app/` - they will be lost on next `aegis init`
-
-### Two Approaches
-
-**1. Template-First** (for known changes)
-Edit templates directly, then generate to verify:
-1. Edit template files in `aegis/templates/copier-aegis-project/{{ project_slug }}/`
-2. Generate: `make test-template` or `aegis init test-project`
-3. Verify it works
-4. Clean up: `make clean-test-projects`
-
-**2. Prototype-First** (for exploratory work)
-Get it working in a real project, then backport:
-1. Generate a test project: `aegis init test-project`
-2. Make changes in the generated project until it works
-3. **Backport immediately** - copy working changes to template files
-4. Regenerate fresh to verify templates are correct
-5. Clean up test project
-
-### Key Principle
-Template files are the source of truth. Any changes you want to persist across future `aegis init` commands **must** be backported to templates.
-
-**Remember**: Generated projects are for validation/prototyping. Templates are what ships.
-
-### Important: Template Changes Require Git Commit
-
-**Copier uses `git+file://` in development mode**, which means it reads templates from the **committed git state**, not the working tree. After modifying template files:
-
-1. **Ask the user to commit** the template changes (Claude should NOT commit per the git policy above)
-2. Then regenerate test projects to verify the changes
-
-Without committing, `aegis init` will use the old template content even though the files appear modified locally.
-
-## Design Principles
-
-### Core Philosophy
-- **Composable systems** - Components combine in powerful, sometimes unexpected ways
-- **Small, focused components** - Each does one thing excellently
-- **No abstraction for abstraction's sake** - Direct access to tools, not wrappers
-- **Test-first development** - Comprehensive testing as a core requirement
-
-### Component Combinations
-Components create emergent capabilities when combined:
-- **AI + Auth**: User-specific conversations, protected endpoints
-- **AI + Database**: Persistent history, analytics
-- **AI + Worker**: Background AI processing, batch operations
-- **Scheduler + Database**: Persistent job scheduling
-
-### Development Approach
-1. **Foundation-first** - Build capabilities others can build on
-2. **Battle-tested patterns** - Everything exists because it solved a real problem
-3. **Agent-ready architecture** - Predictable, testable, extendable
-
-## Coding Standards
-
-### Python Style Guidelines
-
-**Type Hints (MANDATORY - Fortress-Level Type Safety):**
-- **NEVER** write untyped functions - all functions MUST have complete type annotations
-- Use `str | None` instead of `Optional[str]` (Union syntax preferred)
-- **ALWAYS** include return type hints on functions (use `-> None` if no return value)
-- **ALWAYS** type function parameters, including `ctx` parameters: `ctx: dict[str, Any]`
-- Use `dict[str, Any]` instead of `Dict[str, Any]` (modern Python syntax)
-- Prefer `list[str]` over `List[str]` (built-in generics)
-
-**Function Design:**
-- Keep functions small and focused (max ~20 lines)
-- Use descriptive names: `get_user_health_status()` not `get_data()`
-- Return early for error conditions (guard clauses)
-- Prefer pure functions when possible
-
-**Error Handling:**
-- Use specific exception types, not bare `except:`
-- Raise meaningful exceptions with context
-- Use `from None` to suppress chaining when appropriate
-- Log errors at appropriate levels
-
-**Database Queries (Avoid N+1):**
-- **NEVER** query inside a loop - this causes N+1 query problems
-- Batch-fetch related data using `WHERE id IN (...)` or JOINs
-- Use `selectinload()` or `joinedload()` for eager loading relationships
-- Example of what NOT to do:
-  ```python
-  # BAD: N+1 queries (1 query + N queries in loop)
-  for model in models:
-      price = session.exec(select(Price).where(Price.model_id == model.id)).first()
-
-  # GOOD: Batch fetch (2 queries total)
-  model_ids = [m.id for m in models]
-  prices = session.exec(select(Price).where(Price.model_id.in_(model_ids))).all()
-  price_map = {p.model_id: p for p in prices}
-  ```
-
-### DRY Principle (Don't Repeat Yourself)
-**Always look for existing code being used in multiple places.** Before writing new code, heavily weigh towards creating a single function imported to other places rather than duplicating logic.
-
-### Scope Control: Stay Focused
-**Keep changes minimal and targeted.** When fixing a specific issue:
-
-1. **Identify the core problem** - Fix exactly what's broken, nothing more
-2. **Avoid scope creep** - Don't add extensive test suites unless specifically requested
-3. **Make minimal viable fixes** - Simple, working solutions over complex architectures
-4. **Test the fix works** - Verify the original issue is resolved
-
-## Components vs Services (in Generated Projects)
-
-When editing templates, understand where code belongs:
-
-**Components** (`app/components/`): Infrastructure - scheduler, worker, database, backend, frontend
-**Services** (`app/services/`): Business logic - auth, AI, payment, etc.
-
-Components define WHEN/WHERE (routes, jobs). Services define WHAT (logic).
+Guidance for Claude Code working in this repository. This file carries only
+always-true rules and a skills index. Task procedures live in `.claude/skills/`
+and load on demand; see the index at the bottom.
+
+## Hard rules
+
+### No git operations without explicit request
+Never run `git add`, `commit`, `push`, or create PRs, and do not run
+`git status`/`diff`/`log` as preparation, unless the user explicitly asks. Wait
+for explicit approval before any git operation.
+
+### TDD: failing test first
+Write the failing test before the implementation, always. Confirm it fails for
+the right reason, then implement.
+
+### Templates are the source of truth; backport immediately
+`aegis/templates/copier-aegis-project/{{ project_slug }}/` is what ships;
+generated projects (often a scratch `my-app/`) are prototypes. Any change made
+in a generated project MUST be backported to its template in the same session,
+or it is lost on the next `aegis init`. Full workflow: the template-dev skill.
+
+### Scope control
+Fix exactly what is asked. No scope creep, no unrequested test suites, minimal
+viable change, and verify it works.
+
+### DRY
+Before writing new code, look for existing logic used elsewhere; prefer a single
+shared function over duplicating it.
+
+## Coding standards
+
+- Types are mandatory: every function fully annotated, including return types
+  (`-> None` if none) and parameters (`ctx: dict[str, Any]`). Use `str | None`,
+  `dict[str, Any]`, `list[str]` (modern generics), never `Optional`/`Dict`/`List`.
+- Functions: small and focused (~20 lines), descriptive names, guard clauses,
+  prefer pure functions.
+- Errors: specific exception types (never bare `except:`), meaningful messages,
+  `from None` where apt, log at the right level. Never silently swallow an error.
+- No N+1 queries: never query inside a loop; batch with `WHERE id IN (...)` or
+  eager-load with `selectinload()`/`joinedload()`.
+
+## Components vs services
+
+Components (`app/components/`) are infrastructure (backend, frontend, worker,
+scheduler, database, redis) and define WHEN/WHERE. Services (`app/services/`)
+are business logic (auth, AI, payment, blog, finance) and define WHAT. Both ride
+the shared plugin-spec machinery.
+
+## Code navigation
+
+Prefer the language server (Pyright) over grep for symbols: `findReferences`,
+`goToDefinition`, `hover`, `documentSymbol`. Use grep/glob for text patterns,
+non-Python files, or when the LSP is unavailable.
+
+## Daily commands
+
+- `make check` - lint + typecheck + test; run before considering work done
+- `make test-template` - generate and validate a project after template changes
+- `make test-stacks-quick` - fast multi-stack smoke (base, everything, insights)
+
+The Makefile documents the rest (per-component template tests, the full stack
+matrix, release targets).
+
+## Skills index
+
+Procedures load on demand from `.claude/skills/<name>/SKILL.md` when the task
+matches the skill's description. Reach for:
+
+- `add-service` - add a new business-capability service to the framework
+- `add-component` - add a new component, or a variant axis on an existing one
+- `i18n` - add or translate locale strings (en.py first, parity across locales)
+- `add-cli-command` - add a command to the `aegis` tool CLI
+- `release` - cut a version or rc release (bump, gates, TestPyPI, tagging)
+- `template-dev` - modify templates, or backport a change from a generated project
+
+See `.claude/skills/README.md` for the skill format; `example-skill` is the
+copy-from template.


### PR DESCRIPTION
Add .claude/skills/ with the house skill format and the Milestone 1 workflow skills, and slim CLAUDE.md to hard rules plus a skills index that points at them.

- README.md + example-skill: the skill format (frontmatter, required sections, style and portability rules) and a copy-from skeleton.
- add-service: the full add-a-service checklist, hardened by a real dry-run that surfaced the generation/update plumbing and i18n all-locale parity gaps.
- add-component: new component and new variant axis (worker_backend, database_engine), with the post-gen suffix-rename branch and copier <9.15 pin.
- i18n: en.py-first with English-placeholder stubs across all locales for test_i18n.py parity; real translation is a separate PR.
- add-cli-command: Typer registration, sync + asyncio.run, brand help theming, i18n strings, optional guided/interactive wiring, tests, CLI reference doc.
- release: 6-file version bump, changelog cut, three gates (make check, test-stacks-full, production-mode wheel test), TestPyPI verification, burned-rc rule, tag-push mechanics.
- template-dev: templates-are-source-of-truth with the cp backport pattern, the three rendering modes (committed / init --dev / update --to-version HEAD), the test-template matrix, and the template gotchas.
- execute-issue: the router that reads an issue, classifies it to a workflow skill, holds the run to the acceptance criteria, and stops before git.
- .github/ISSUE_TEMPLATE/agent-task.yml: issue form mapping onto the run contract.
- CLAUDE.md: slimmed 283 -> 79 lines (hard rules + skills index); procedures moved into the skills; also unignores .claude/skills in .gitignore.