### PR TITLE
Code mode: per-agent sandboxed script execution + finance host tools

### DIFF
--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -592,6 +592,9 @@ AGENTS_MIGRATION = ServiceMigrationSpec(
                     "knowledge_base_ids", "sa.JSON()", nullable=False, default="[]"
                 ),
                 ColumnSpec("is_active", "sa.Boolean()", nullable=False, default="True"),
+                ColumnSpec(
+                    "code_mode", "sa.Boolean()", nullable=False, default="False"
+                ),
                 ColumnSpec("created_at", "sa.DateTime()", nullable=False),
                 ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
             ],

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -480,6 +480,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 # copies the dir and the modal's catalog tab 404s (issue #814).
                 "app/components/backend/api/llm",
                 "app/services/ai",
+                "docs/services/ai",
                 "app/cli/ai.py",
                 "app/cli/agents.py",
                 "app/cli/ai_rendering.py",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/agent_loader.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/agent_loader.py.jinja
@@ -73,6 +73,7 @@ class AgentConfig:
     tool_names: tuple[str, ...] = ()
     memory_modules: tuple[str, ...] = ()
     knowledge_base_ids: tuple[str, ...] = ()
+    code_mode: bool = False
 
 
 def default_agent_config() -> AgentConfig:
@@ -115,6 +116,7 @@ def _to_config(row: Agent) -> AgentConfig:
         tool_names=tuple(t.name for t in row.tools if t.is_active),
         memory_modules=tuple(row.memory_modules),
         knowledge_base_ids=tuple(row.knowledge_base_ids),
+        code_mode=row.code_mode,
     )
 
 
@@ -185,6 +187,13 @@ async def resolve_agent(
 {% if ai_backend != "memory" and ai_framework == "pydantic-ai" %}
 
 
+# Per-turn tool-call budgets. Chat stays briefing-first and snappy; code
+# mode's loop is script -> observe -> script, so its budget must cover a
+# real investigation without letting a runaway loop stack latency forever.
+DEFAULT_TOOL_CALLS_LIMIT = 4
+CODE_MODE_TOOL_CALLS_LIMIT = 16
+
+
 def build_chat_agent(
     config: AgentConfig,
     *,
@@ -193,8 +202,9 @@ def build_chat_agent(
     deps_type: type[Any],
     context_providers: Sequence[ContextProvider[Any]] = (),
     module_token_budget: int | None = None,
-    tool_calls_limit: int = 4,
+    tool_calls_limit: int | None = None,
     recorder: Callable[..., float] = record_usage,
+    capabilities: Sequence[Any] = (),
 ) -> ToolChatAgent[Any]:
     """Hydrate a ``ToolChatAgent`` from a resolved agent config.
 
@@ -204,7 +214,13 @@ def build_chat_agent(
     in as a context provider when non-empty; deps must expose
     ``user_id`` for module fetchers to see the user). The caller
     supplies the runtime pieces the config doesn't know about (model
-    instance, deps type, extra context providers).
+    instance, deps type, extra context providers, capabilities).
+
+    A ``code_mode`` config additionally grants a ``CodeMode`` capability
+    scoped to exactly the agent's granted tool names: the model writes
+    Python that calls those tools as functions, executed in the Monty
+    sandbox. ``tool_calls_limit=None`` means "pick the right default" -
+    4 for chat, 16 for code mode; an explicit value always wins.
     """
     providers: list[ContextProvider[Any]] = list(context_providers)
     if config.memory_modules:
@@ -213,6 +229,19 @@ def build_chat_agent(
                 config.memory_modules, token_budget=module_token_budget
             )
         )
+    effective_capabilities: list[Any] = list(capabilities)
+    effective_limit = tool_calls_limit
+    if config.code_mode:
+        # Lazy import: the harness (and the Monty interpreter it embeds)
+        # loads only for flagged agents, so unflagged installs never pay
+        # for or expose the capability.
+        from pydantic_ai_harness import CodeMode
+
+        effective_capabilities.append(CodeMode(tools=list(config.tool_names)))
+        if effective_limit is None:
+            effective_limit = CODE_MODE_TOOL_CALLS_LIMIT
+    if effective_limit is None:
+        effective_limit = DEFAULT_TOOL_CALLS_LIMIT
     return ToolChatAgent(
         model=model,
         model_name=model_name,
@@ -224,8 +253,9 @@ def build_chat_agent(
             temperature=config.temperature,
             max_tokens=config.max_tokens,
         ),
-        tool_calls_limit=tool_calls_limit,
+        tool_calls_limit=effective_limit,
         action=f"chat:{config.slug}",
         recorder=recorder,
+        capabilities=effective_capabilities,
     )
 {% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/agent_registry.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/agent_registry.py
@@ -37,6 +37,7 @@ EDITABLE_FIELDS = frozenset(
         "max_tokens",
         "system_prompt",
         "is_active",
+        "code_mode",
     }
 )
 
@@ -44,7 +45,7 @@ EDITABLE_FIELDS = frozenset(
 # Editable fields whose columns reject NULL; description/category/model_id
 # stay nullable (model_id None = follow the active default).
 _NON_NULLABLE_FIELDS = frozenset(
-    {"name", "temperature", "max_tokens", "system_prompt", "is_active"}
+    {"name", "temperature", "max_tokens", "system_prompt", "is_active", "code_mode"}
 )
 
 
@@ -140,6 +141,7 @@ def serialize_agent(agent: Agent) -> dict[str, Any]:
         "max_tokens": agent.max_tokens,
         "system_prompt": agent.system_prompt,
         "is_active": agent.is_active,
+        "code_mode": agent.code_mode,
         "tools": [tool.name for tool in agent.tools],
         "memory_modules": list(agent.memory_modules),
         "knowledge_base_ids": list(agent.knowledge_base_ids),

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/chat_kit/agent.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/chat_kit/agent.py
@@ -85,6 +85,7 @@ class ToolChatAgent(Generic[DepsT]):
         tool_calls_limit: int = 4,
         action: str = "chat:generic",
         recorder: Callable[..., float] = record_usage,
+        capabilities: Sequence[Any] = (),
     ) -> None:
         """
         Args:
@@ -100,13 +101,20 @@ class ToolChatAgent(Generic[DepsT]):
                 latency — the whole reason the design is briefing-first).
             action: Ledger action family for these turns (e.g. "chat:metrics").
             recorder: Usage-recording hook; injected in tests to assert cost.
+            capabilities: pydantic-ai capabilities (e.g. code mode). Passed to
+                the ``Agent`` only when non-empty, so stacks pinned to
+                pre-capability pydantic-ai versions never see the kwarg.
         """
+        agent_kwargs: dict[str, Any] = {}
+        if capabilities:
+            agent_kwargs["capabilities"] = list(capabilities)
         self._agent: Agent[DepsT] = Agent(
             model,
             instructions=instructions,
             deps_type=deps_type,
             tools=list(tools),
             model_settings=model_settings,
+            **agent_kwargs,
         )
         self._model_name = model_name
         self._providers = tuple(context_providers)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/fixtures/agent_fixtures.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/fixtures/agent_fixtures.py
@@ -13,7 +13,8 @@ from sqlmodel import Session, select
 
 from app.core.log import logger
 from app.services.ai.domains.chat.agent_loader import DEFAULT_AGENT_SLUG, default_agent_config
-from app.services.ai.models.agents import Agent
+from app.services.ai.domains.chat.tools import get_tool, registered_tool_names
+from app.services.ai.models.agents import Agent, Tool
 
 __all__ = ["DEFAULT_AGENT_SLUG", "default_agent_definition", "load_agent_fixtures"]
 
@@ -38,6 +39,7 @@ def default_agent_definition() -> dict[str, Any]:
         "memory_modules": list(config.memory_modules),
         "knowledge_base_ids": list(config.knowledge_base_ids),
         "is_active": True,
+        "code_mode": config.code_mode,
     }
 
 
@@ -51,7 +53,7 @@ def load_agent_fixtures(session: Session) -> dict[str, int]:
         session: Database session
 
     Returns:
-        dict with counts: {"agents": N added}
+        dict with counts: {"agents": N added, "tools": N added}
     """
     added = 0
     definition = default_agent_definition()
@@ -66,4 +68,22 @@ def load_agent_fixtures(session: Session) -> dict[str, int]:
     else:
         logger.debug(f"Default agent '{definition['slug']}' already present")
 
-    return {"agents": added}
+    # Sync registered tools into grantable rows: every callable in the
+    # Python registry gets a matching ``tool`` row (by name) so the agent
+    # CRUD can attach it. Rows are never mutated or deleted here - a
+    # stale row degrades to a skipped-name warning at resolve time.
+    tools_added = 0
+    present = set(session.exec(select(Tool.name)).all())
+    for name in registered_tool_names():
+        if name in present:
+            continue
+        entry = get_tool(name)
+        session.add(
+            Tool(name=name, description=entry.description if entry else None)
+        )
+        tools_added += 1
+    if tools_added:
+        session.commit()
+        logger.info(f"Seeded {tools_added} tool row(s) from the registry")
+
+    return {"agents": added, "tools": tools_added}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/models/agents/agent.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/models/agents/agent.py
@@ -35,6 +35,11 @@ class Agent(SQLModel, table=True):
     memory_modules: list[str] = Field(default_factory=list, sa_column=Column(JSON))
     knowledge_base_ids: list[str] = Field(default_factory=list, sa_column=Column(JSON))
     is_active: bool = Field(default=True)
+    # Grants this agent sandboxed code execution (code mode): the model
+    # writes Python that calls the agent's granted tools as functions and
+    # runs it in the Monty interpreter. Off by default; flipping it is a
+    # capability grant, deliberately DB-driven like tool attachments.
+    code_mode: bool = Field(default=False)
     created_at: datetime = Field(default_factory=utcnow_naive)
     updated_at: datetime = Field(default_factory=utcnow_naive)
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
@@ -26,6 +26,12 @@ from app.services.ai.service.prompt import PromptMixin
 {%- if ai_backend != "memory" %}
 from app.services.ai.domains.chat.user_memory import build_user_memory_context
 {%- endif %}
+{%- if include_finance and ai_backend != "memory" %}
+# Importing registers the finance host tools (ledger_summary, positions,
+# quote, ...) so DB-granted names resolve in every process that serves
+# chat - the API, the CLI, and code-mode agents alike.
+import app.services.finance.ai_tools  # noqa: F401
+{%- endif %}
 {% if ai_rag %}
 from app.services.ai.domains.chat.rag_context import RAGContext
 {% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_tools.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_tools.py.jinja
@@ -1,0 +1,182 @@
+{% if include_ai and ai_backend != "memory" %}"""Finance host tools: the data surface code-mode agents compute over.
+
+Thin, fully-typed wrappers over existing domain queries, registered into
+the agent tool registry at import time. A code-mode agent granted these
+names can call them as functions from inside its sandboxed script; a
+plain agent can call them as ordinary tools. Owned data is pushed by
+code - each tool reads the ledger directly - so the model never has to
+"fetch" what the app already knows; ``quote`` is the one genuinely
+dynamic lookup.
+
+Returns are plain JSON-safe dicts (cents-integer money, ISO dates) so
+values traverse the sandbox boundary without model-object baggage.
+
+Owner scoping: tools read unscoped (``owner_user_id=None``), matching
+the single-tenant default-open posture of generated stacks. A
+multi-tenant deployment should thread its user context here before
+granting these tools to shared agents.
+"""
+
+from datetime import date
+from typing import Any
+
+from app.core.db import get_async_session
+from app.services.ai.domains.chat.tools import register_tool
+from app.services.finance.domains.investments import queries as investment_queries
+from app.services.finance.domains.investments.securities import (
+    list_current_holdings,
+)
+from app.services.finance.domains.ledger.transactions import monthly_cashflow
+from app.services.finance.domains.planning.envelopes import (
+    envelope_metadata,
+    list_envelopes,
+)
+from app.services.finance.domains.planning.goals import goal_metadata, list_goals
+
+
+async def ledger_summary(months: int = 3) -> dict[str, Any]:
+    """Income, spend and net per calendar month, oldest first.
+
+    Args:
+        months: How many months back to include (1-24).
+    """
+    span = max(1, min(int(months), 24))
+    async with get_async_session() as session:
+        rows = await monthly_cashflow(session, months=span)
+    return {
+        "months": [
+            {
+                "month": row.month,
+                "income_cents": row.income,
+                "spend_cents": row.expense,
+                "net_cents": row.net,
+            }
+            for row in rows
+        ]
+    }
+
+
+async def positions() -> list[dict[str, Any]]:
+    """Current investment holdings with quantity and market value."""
+    async with get_async_session() as session:
+        holdings = await list_current_holdings(session)
+    return [
+        {
+            "ticker": security.ticker if security else None,
+            "name": security.name if security else None,
+            "account_id": holding.account_id,
+            "quantity": holding.quantity_e8 / 1e8,
+            "market_value_cents": market_value_cents,
+        }
+        for holding, security, market_value_cents in holdings
+    ]
+
+
+async def envelope_state() -> list[dict[str, Any]]:
+    """Every envelope (virtual sub-account) with its allowance settings."""
+    async with get_async_session() as session:
+        envelopes = await list_envelopes(session)
+    out: list[dict[str, Any]] = []
+    for account in envelopes:
+        meta = envelope_metadata(account.metadata_)
+        out.append(
+            {
+                "name": account.name,
+                "balance_cents": account.current_balance or 0,
+                "monthly_credit_cents": meta.monthly_credit if meta else None,
+                "cadence": meta.cadence if meta else None,
+                "auto_credit": meta.auto_credit if meta else False,
+            }
+        )
+    return out
+
+
+async def goals_state() -> list[dict[str, Any]]:
+    """Every savings goal with target, progress and contribution plan."""
+    async with get_async_session() as session:
+        goals = await list_goals(session)
+    out: list[dict[str, Any]] = []
+    for account in goals:
+        meta = goal_metadata(account.metadata_)
+        if meta is None:
+            continue
+        out.append(
+            {
+                "name": account.name,
+                "saved_cents": account.current_balance or 0,
+                "target_cents": meta.target_amount,
+                "status": meta.status,
+                "monthly_contribution_cents": meta.monthly_contribution,
+                "priority": meta.priority,
+            }
+        )
+    return out
+
+
+async def quote(ticker: str) -> dict[str, Any]:
+    """Latest stored closing price for a ticker in the security catalog.
+
+    Args:
+        ticker: The security's ticker symbol, case-insensitive.
+    """
+    symbol = ticker.strip().upper()
+    async with get_async_session() as session:
+        security = await investment_queries.security_by_ticker(session, symbol)
+        if security is None or security.id is None:
+            return {"found": False, "ticker": symbol}
+        price = await investment_queries.latest_price_for_security(
+            session, security.id
+        )
+    if price is None:
+        return {"found": False, "ticker": symbol}
+    # Normalize to cents in integer arithmetic regardless of the row's
+    # stored scale; float exponents would drift on sub-cent scales.
+    if price.price_scale > 2:
+        divisor = 10 ** (price.price_scale - 2)
+        close_cents = (price.close_price + divisor // 2) // divisor
+    else:
+        close_cents = price.close_price * 10 ** (2 - price.price_scale)
+    as_of: date = price.price_date
+    return {
+        "found": True,
+        "ticker": symbol,
+        "name": security.name,
+        "close_cents": close_cents,
+        "as_of": as_of.isoformat(),
+    }
+
+
+# Built-in registration: importing this module makes the tools grantable
+# via the agent registry. replace=True keeps re-imports idempotent.
+register_tool(
+    "ledger_summary",
+    ledger_summary,
+    description="Monthly income, spend and net over recent months",
+    replace=True,
+)
+register_tool(
+    "positions",
+    positions,
+    description="Current investment holdings with market values",
+    replace=True,
+)
+register_tool(
+    "envelope_state",
+    envelope_state,
+    description="Envelope balances and allowance settings",
+    replace=True,
+)
+register_tool(
+    "goals_state",
+    goals_state,
+    description="Savings goals with targets and progress",
+    replace=True,
+)
+register_tool(
+    "quote",
+    quote,
+    description="Latest stored closing price for a ticker",
+    replace=True,
+)
+{% else %}"""Finance host tools ship only with the AI service on a persistent backend."""
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/investments/queries.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/investments/queries.py
@@ -86,6 +86,20 @@ async def security_price_by_key(
     ).first()
 
 
+async def latest_price_for_security(
+    db: AsyncSession, security_id: int
+) -> FinanceSecurityPrice | None:
+    """The most recent stored price row for a security, any source."""
+    return (
+        await db.exec(
+            select(FinanceSecurityPrice)
+            .where(FinanceSecurityPrice.security_id == security_id)
+            .order_by(FinanceSecurityPrice.price_date.desc())  # type: ignore[union-attr]
+            .limit(1)
+        )
+    ).first()
+
+
 async def holding_by_key(
     db: AsyncSession, *, account_id: int, security_id: int, as_of_date: date
 ) -> FinanceHolding | None:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/services/ai/code-mode.md
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/services/ai/code-mode.md
@@ -1,0 +1,64 @@
+# Code Mode
+
+Code mode gives an agent one powerful tool instead of many small ones: the
+ability to write a Python script that calls its granted tools as functions,
+executed in a sandboxed interpreter. Instead of the model making sequential
+tool calls (one round trip each), it writes a single script with loops,
+conditionals, and arithmetic, and only returns to the model when the script
+finishes.
+
+This is the right shape for questions that need computation over your data.
+Language models are unreliable at arithmetic in prose; they are good at
+writing the three lines of Python that compute the answer exactly.
+
+## Enabling it for an agent
+
+Code mode is a per-agent grant stored on the agent row, exactly like tool
+attachments:
+
+```python
+from app.services.ai.domains.chat.agent_registry import update_agent
+
+await update_agent("assistant", {"code_mode": True})
+```
+
+The flag hydrates through `resolve_agent` into `AgentConfig.code_mode`, and
+`build_chat_agent` then attaches a `CodeMode` capability scoped to exactly
+the tools attached to that agent. Nothing changes for agents without the
+flag: the capability is never constructed, and the sandbox never loads.
+
+## The security model
+
+Scripts run in [Monty](https://github.com/pydantic/monty), a minimal Python
+interpreter built for executing model-written code:
+
+- No filesystem, network, environment, or OS access exists in the sandbox.
+- The only way a script touches the outside world is by calling the tools
+  the agent was explicitly granted. An agent with no tools can compute, but
+  cannot reach anything.
+- Results cross the boundary as plain values; host code runs the tools with
+  full application access and hands back the return value.
+
+The grant model composes: `code_mode` decides whether scripts run at all,
+and the agent's tool attachments decide what those scripts can call.
+
+## Limits to know about
+
+- Monty implements a Python subset: functions, comprehensions, f-strings,
+  dataclasses, and async calls work; classes and third-party imports
+  (pandas, numpy) do not. Models occasionally reach for an unsupported
+  feature; the resulting error is fed back and the model rewrites the
+  script within the same turn.
+- The per-turn tool-call budget is raised for code-mode agents (16 rather
+  than chat's 4) because the working loop is script, observe, script. Pass
+  `tool_calls_limit` to `build_chat_agent` to override either default.
+- Tool results must be JSON-safe values (dicts, lists, strings, numbers)
+  to traverse the sandbox cleanly. Prefer cents-integer money fields and
+  ISO date strings over model objects.
+
+## When to prefer plain tool calls
+
+Code mode earns its keep when the answer requires combining or computing
+over data. For a single lookup ("what is my balance") a plain tool call is
+one round trip and needs no sandbox. Keep conversational agents unflagged
+and grant `code_mode` to the agents whose job is analysis.

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/services/ai/research-agent.md.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/services/ai/research-agent.md.jinja
@@ -1,0 +1,92 @@
+{% if include_finance %}# Building a Finance Research Agent
+
+A research agent answers open-ended questions about your money by writing
+code over your real data: "does my allocation still make sense given my
+envelope commitments?" is a novel computation, not a lookup, and code mode
+lets the agent compose it on the fly.
+
+## The pieces
+
+Three things make an agent a research agent:
+
+1. **The `code_mode` flag** on its agent row, which grants sandboxed
+   script execution (see [Code Mode](code-mode.md)).
+2. **The finance host tools**, registered by the finance service and
+   seeded as grantable rows: `ledger_summary`, `positions`,
+   `envelope_state`, `goals_state`, and `quote`.
+3. **Tool attachments** connecting that agent to those tools.
+
+## Setting one up
+
+Flag an agent and attach the finance tools. With the seeded default agent:
+
+```python
+from sqlmodel import select
+
+from app.core.db import get_async_session
+from app.services.ai.domains.chat.agent_registry import update_agent
+from app.services.ai.models.agents import Agent, AgentTool, Tool
+
+FINANCE_TOOLS = [
+    "ledger_summary",
+    "positions",
+    "envelope_state",
+    "goals_state",
+    "quote",
+]
+
+async with get_async_session() as session:
+    await update_agent("assistant", {"code_mode": True}, session=session)
+    agent = (
+        await session.exec(select(Agent).where(Agent.slug == "assistant"))
+    ).one()
+    tools = (
+        await session.exec(select(Tool).where(Tool.name.in_(FINANCE_TOOLS)))
+    ).all()
+    for tool in tools:
+        session.add(AgentTool(agent_id=agent.id, tool_id=tool.id))
+    await session.commit()
+```
+
+The tool rows exist because fixture seeding syncs every registered tool
+into a grantable row; if a name is missing, re-run the database seed.
+
+## What a turn looks like
+
+Ask the flagged agent an analysis question through any chat surface. The
+model sees a single `run_code` tool plus typed stubs for the granted
+finance tools, writes a script such as:
+
+```python
+holdings = await positions()
+total = sum(p["market_value_cents"] for p in holdings)
+by_ticker = {
+    p["ticker"]: round(100 * p["market_value_cents"] / total, 1)
+    for p in holdings
+}
+envelopes = await envelope_state()
+committed = sum(e["monthly_credit_cents"] or 0 for e in envelopes)
+{"allocation_pct": by_ticker, "monthly_committed_cents": committed}
+```
+
+and narrates the result. Data the app already holds is pushed into the
+script through the tools; the model never re-fetches what your code
+already knows. `quote` is the one dynamic lookup, for prices the model
+decides it needs mid-analysis.
+
+If a script fails (bad syntax, an unsupported Python feature), the
+traceback returns to the model as the tool result and it rewrites the
+script inside the same turn. Usage lands in the ledger as one row per
+turn under the agent's slug.
+
+## Owner scoping
+
+The finance tools read unscoped, matching the single-tenant default-open
+posture of generated stacks. Before granting these tools in a
+multi-tenant deployment, thread your user context into
+`app/services/finance/ai_tools.py`.
+{% else %}# Building a Finance Research Agent
+
+This guide applies to stacks generated with the finance service. Add it
+with the stack tooling, then regenerate the docs.
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
@@ -94,6 +94,10 @@ dependencies = [
 {#- Several providers collapse to "openai"; dedupe so the extras list stays clean (e.g. openai + mistral -> [openai], not [openai,openai]). #}
 {%- set pydantic_extras = _mapped_extras.split(",") | map("trim") | unique | join(",") %}
     "pydantic-ai-slim[{{ pydantic_extras }}]>=1.0.10",
+{#- Code mode: sandboxed Monty execution for agents flagged code_mode.
+    The capability only constructs for flagged agent rows, so unflagged
+    installs carry the dependency but never touch it. #}
+    "pydantic-ai-harness[codemode]>=0.24.0",
     "httpx>=0.27.0",
 {%- else %}
     # LangChain framework dependencies

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/chat_kit/test_code_mode.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/chat_kit/test_code_mode.py
@@ -1,0 +1,237 @@
+"""Code mode: capabilities plumb through the kit into the pydantic-ai Agent.
+
+Lives in the chat_kit test package: capabilities target the pydantic-ai
+loop, and this directory is what langchain-framework and memory-backend
+stacks prune.
+"""
+
+from collections.abc import Generator
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic_ai.models.function import AgentInfo, DeltaToolCall, FunctionModel
+from pydantic_ai.models.test import TestModel
+import pytest
+
+import app.services.ai.domains.chat.chat_kit.agent as kit_agent
+from app.services.ai.domains.chat.agent_loader import AgentConfig, build_chat_agent
+from app.services.ai.domains.chat.chat_kit import (
+    ChatScope,
+    DeltaFrame,
+    DoneFrame,
+    ErrorFrame,
+    ToolChatAgent,
+)
+from app.services.ai.domains.chat.tools import register_tool, unregister_tool
+
+
+@dataclass
+class _Deps:
+    subject_id: int
+
+
+class _RecordingAgent:
+    """Stands in for pydantic_ai.Agent; records constructor kwargs."""
+
+    captured: dict[str, Any] = {}
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        type(self).captured = dict(kwargs)
+
+
+class _FakeCapability:
+    """Opaque capability object; the kit must not inspect it."""
+
+
+@pytest.fixture
+def recording_agent(monkeypatch: pytest.MonkeyPatch) -> Generator[type]:
+    _RecordingAgent.captured = {}
+    monkeypatch.setattr(kit_agent, "Agent", _RecordingAgent)
+    yield _RecordingAgent
+
+
+def _config(**overrides: object) -> AgentConfig:
+    data: dict[str, object] = {
+        "slug": "assistant",
+        "name": "Assistant",
+        "system_prompt": "You are a test persona.",
+        "model_id": None,
+        "temperature": 0.3,
+        "max_tokens": 256,
+    }
+    data.update(overrides)
+    return AgentConfig(**data)  # type: ignore[arg-type]
+
+
+def test_kit_forwards_capabilities_to_the_agent(recording_agent: type) -> None:
+    """Capabilities handed to the kit reach the pydantic-ai constructor."""
+    cap = _FakeCapability()
+    ToolChatAgent(
+        model=TestModel(),
+        model_name="test",
+        instructions="persona",
+        deps_type=_Deps,
+        capabilities=[cap],
+    )
+    assert recording_agent.captured.get("capabilities") == [cap]
+
+
+def test_kit_omits_capabilities_when_none_given(recording_agent: type) -> None:
+    """No capabilities -> the kwarg is not sent at all (old-version safety)."""
+    ToolChatAgent(
+        model=TestModel(),
+        model_name="test",
+        instructions="persona",
+        deps_type=_Deps,
+    )
+    assert "capabilities" not in recording_agent.captured
+
+
+def test_build_chat_agent_forwards_capabilities(recording_agent: type) -> None:
+    """The hydrator threads capabilities through to the kit."""
+    cap = _FakeCapability()
+    build_chat_agent(
+        _config(),
+        model=TestModel(),
+        model_name="test",
+        deps_type=_Deps,
+        capabilities=[cap],
+    )
+    assert recording_agent.captured.get("capabilities") == [cap]
+
+
+def _build(config: AgentConfig, **kwargs: Any) -> Any:
+    return build_chat_agent(
+        config,
+        model=TestModel(),
+        model_name="test",
+        deps_type=_Deps,
+        **kwargs,
+    )
+
+
+def test_code_mode_config_grants_scoped_code_execution(
+    recording_agent: type,
+) -> None:
+    """A code_mode row yields a CodeMode capability scoped to granted tools."""
+    _build(_config(code_mode=True, tool_names=("lookup", "quote")))
+
+    caps = recording_agent.captured.get("capabilities")
+    assert caps is not None and len(caps) == 1
+    assert type(caps[0]).__name__ == "CodeMode"
+    assert list(caps[0].tools) == ["lookup", "quote"]
+
+
+def test_code_mode_raises_the_default_tool_call_budget(
+    recording_agent: type,
+) -> None:
+    """The script -> observe -> script loop needs more turns than chat's 4."""
+    kit = _build(_config(code_mode=True))
+
+    assert kit._limits.tool_calls_limit == 16
+
+
+def test_explicit_limit_wins_over_the_code_mode_default(
+    recording_agent: type,
+) -> None:
+    kit = _build(_config(code_mode=True), tool_calls_limit=6)
+
+    assert kit._limits.tool_calls_limit == 6
+
+
+def test_plain_config_gets_no_capability_and_keeps_the_chat_budget(
+    recording_agent: type,
+) -> None:
+    kit = _build(_config())
+
+    assert "capabilities" not in recording_agent.captured
+    assert kit._limits.tool_calls_limit == 4
+
+
+# --- The live loop: scripts run in the sandbox, failures retry in-turn ----
+
+
+@pytest.fixture
+def registered_lookup() -> Generator[str]:
+    async def lookup(key: str) -> str:
+        """Look up a value for a key."""
+        return f"val-{key}"
+
+    register_tool("lookup", lookup, replace=True)
+    yield "lookup"
+    unregister_tool("lookup")
+
+
+async def _drain(agent: ToolChatAgent[Any], message: str) -> list[Any]:
+    return [
+        frame
+        async for frame in agent.stream_turn(
+            scope=ChatScope(user_id="u1", surface="test"),
+            deps=_Deps(1),
+            message=message,
+        )
+    ]
+
+
+BROKEN_SCRIPT = '{"code": "v = await lookup(key=+broken"}'
+FIXED_SCRIPT = '{"code": "v = await lookup(key=\\"a\\")\\nv"}'
+
+
+async def test_failing_script_recovers_inside_one_turn(
+    registered_lookup: str,
+) -> None:
+    """Bad script -> traceback -> corrected script -> answer, one turn."""
+    requests: list[int] = []
+
+    async def scripted(messages: Any, info: AgentInfo) -> Any:
+        requests.append(len(messages))
+        if len(requests) == 1:
+            yield {0: DeltaToolCall(name="run_code", json_args=BROKEN_SCRIPT)}
+        elif len(requests) == 2:
+            yield {0: DeltaToolCall(name="run_code", json_args=FIXED_SCRIPT)}
+        else:
+            yield "the value is "
+            yield "val-a"
+
+    recorded: list[dict[str, Any]] = []
+
+    def recorder(**kwargs: Any) -> float:
+        recorded.append(kwargs)
+        return 0.0
+
+    agent = build_chat_agent(
+        _config(code_mode=True, tool_names=(registered_lookup,)),
+        model=FunctionModel(stream_function=scripted),
+        model_name="scripted",
+        deps_type=_Deps,
+        recorder=recorder,
+    )
+
+    frames = await _drain(agent, "look up a for me")
+
+    assert isinstance(frames[-1], DoneFrame)
+    assert frames[-1].answer == "the value is val-a"
+    assert any(isinstance(f, DeltaFrame) for f in frames)
+    assert len(requests) == 3  # broken script, fixed script, final answer
+    assert len(recorded) == 1  # one usage row for the whole turn
+
+
+async def test_unrecoverable_script_surfaces_an_error_frame(
+    registered_lookup: str,
+) -> None:
+    """A model that never fixes its script ends in ErrorFrame, not a raise."""
+
+    async def hopeless(messages: Any, info: AgentInfo) -> Any:
+        yield {0: DeltaToolCall(name="run_code", json_args=BROKEN_SCRIPT)}
+
+    agent = build_chat_agent(
+        _config(code_mode=True, tool_names=(registered_lookup,)),
+        model=FunctionModel(stream_function=hopeless),
+        model_name="scripted",
+        deps_type=_Deps,
+        recorder=lambda **kwargs: 0.0,
+    )
+
+    frames = await _drain(agent, "look up a for me")
+
+    assert isinstance(frames[-1], ErrorFrame)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_agent_loader.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_agent_loader.py.jinja
@@ -63,6 +63,22 @@ class TestResolveFromDb:
             max_tokens=512,
         )
 
+    async def test_code_mode_flag_survives_resolution(
+        self, session: AsyncSession
+    ) -> None:
+        await _add_agent(session, code_mode=True)
+
+        config = await resolve_agent("support", session=session)
+
+        assert config.code_mode is True
+
+    async def test_code_mode_defaults_off(self, session: AsyncSession) -> None:
+        await _add_agent(session)
+
+        config = await resolve_agent("support", session=session)
+
+        assert config.code_mode is False
+
     async def test_only_active_tools_are_exposed(self, session: AsyncSession) -> None:
         agent = await _add_agent(session)
         active = Tool(name="lookup")

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_agent_models.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_agent_models.py.jinja
@@ -30,7 +30,7 @@ class TestAgentSeed:
     def test_seeds_default_agent(self, session: Session) -> None:
         counts = load_agent_fixtures(session)
 
-        assert counts == {"agents": 1}
+        assert counts["agents"] == 1
         agent = session.exec(
             select(Agent).where(Agent.slug == DEFAULT_AGENT_SLUG)
         ).one()
@@ -43,9 +43,27 @@ class TestAgentSeed:
         load_agent_fixtures(session)
         counts = load_agent_fixtures(session)
 
-        assert counts == {"agents": 0}
+        assert counts["agents"] == 0
+        assert counts["tools"] == 0
         agents = session.exec(select(Agent)).all()
         assert len(agents) == 1
+
+    def test_registered_tools_get_grantable_rows(self, session: Session) -> None:
+        """Every name in the Python tool registry gets a ``tool`` row."""
+
+        async def probe() -> str:
+            """Probe tool."""
+            return "ok"
+
+        register_tool("cm_probe", probe, description="Probe tool", replace=True)
+        try:
+            counts = load_agent_fixtures(session)
+            assert counts["tools"] >= 1
+            rows = {t.name: t for t in session.exec(select(Tool)).all()}
+            assert "cm_probe" in rows
+            assert rows["cm_probe"].description == "Probe tool"
+        finally:
+            unregister_tool("cm_probe")
 
     def test_seed_never_overwrites_edited_agent(self, session: Session) -> None:
         load_agent_fixtures(session)
@@ -72,9 +90,8 @@ class TestAgentToolLink:
         agent = session.exec(
             select(Agent).where(Agent.slug == DEFAULT_AGENT_SLUG)
         ).one()
-        tool = Tool(name="save_memory", description="Persist a user fact")
-        session.add(tool)
-        session.commit()
+        # The registry sync seeded the row; attaching reuses it by name.
+        tool = session.exec(select(Tool).where(Tool.name == "save_memory")).one()
         session.add(AgentTool(agent_id=agent.id, tool_id=tool.id))
         session.commit()
 
@@ -96,9 +113,8 @@ class TestAgentToolLink:
             agent = session.exec(
                 select(Agent).where(Agent.slug == DEFAULT_AGENT_SLUG)
             ).one()
-            tool = Tool(name="greet")
-            session.add(tool)
-            session.commit()
+            # Registered before the seed ran, so the sync created its row.
+            tool = session.exec(select(Tool).where(Tool.name == "greet")).one()
             session.add(AgentTool(agent_id=agent.id, tool_id=tool.id))
             session.commit()
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_agent_registry.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_agent_registry.py.jinja
@@ -164,4 +164,37 @@ class TestSerializeAgent:
         assert payload["memory_modules"] == ["diet"]
         assert payload["knowledge_base_ids"] == ["kb-food"]
         assert payload["system_prompt"] == "You are helpful."
+
+
+class TestCodeModeField:
+    async def test_update_accepts_code_mode_and_invalidates(
+        self, session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        await _add_agent(session, "assistant")
+        invalidated = MagicMock()
+        monkeypatch.setattr(
+            agent_registry_module, "invalidate_agent_cache", invalidated
+        )
+
+        updated = await update_agent(
+            "assistant", {"code_mode": True}, session=session
+        )
+
+        assert updated.code_mode is True
+        invalidated.assert_called_once_with("assistant")
+
+    async def test_code_mode_rejects_null(self, session: AsyncSession) -> None:
+        await _add_agent(session, "assistant")
+
+        with pytest.raises(InvalidAgentUpdateError):
+            await update_agent("assistant", {"code_mode": None}, session=session)
+
+    async def test_serialize_includes_code_mode(
+        self, session: AsyncSession
+    ) -> None:
+        await _add_agent(session, "assistant", code_mode=True)
+
+        agents = await list_agents(session=session)
+
+        assert serialize_agent(agents[0])["code_mode"] is True
 {% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_ai_tools.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_ai_tools.py.jinja
@@ -1,0 +1,194 @@
+{% if include_finance and include_ai and ai_backend != "memory" %}"""Finance host tools: the data surface code-mode agents compute over.
+
+Each tool opens its own session in production; tests point that at the
+transactional test session so factory-seeded rows are visible and rolled
+back per test.
+"""
+
+from contextlib import asynccontextmanager
+from datetime import date
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+import app.services.finance.ai_tools as ai_tools
+from app.services.ai.domains.chat.tools import registered_tool_names
+from app.services.finance.domains.planning.envelopes import create_envelope
+from app.services.finance.domains.planning.goals import set_goal_metadata
+from app.services.finance.models.investments import (
+    FinanceHolding,
+    FinanceSecurity,
+    FinanceSecurityPrice,
+)
+from app.services.finance.models.reference import FinanceCurrency
+from app.services.finance.service import FinanceService
+from tests.services._finance_factories import seed_account, seed_txn
+
+EXPECTED_TOOLS = {
+    "ledger_summary",
+    "positions",
+    "envelope_state",
+    "goals_state",
+    "quote",
+}
+
+
+@pytest.fixture
+def session(async_db_session: AsyncSession) -> AsyncSession:
+    return async_db_session
+
+
+@pytest.fixture
+def svc(session: AsyncSession) -> FinanceService:
+    return FinanceService(session)
+
+
+@pytest.fixture(autouse=True)
+def _tools_use_test_session(
+    session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    @asynccontextmanager
+    async def test_session():
+        yield session
+
+    monkeypatch.setattr(ai_tools, "get_async_session", test_session)
+
+
+def test_finance_tools_register_on_import() -> None:
+    """Importing the module makes every finance tool grantable by name."""
+    assert EXPECTED_TOOLS <= set(registered_tool_names())
+
+
+async def test_ledger_summary_reports_monthly_cashflow(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    account = await seed_account(svc)
+    today = date.today()
+    await seed_txn(svc, account.id, 250_00, today)
+    await seed_txn(svc, account.id, -100_00, today)
+
+    summary = await ai_tools.ledger_summary(months=1)
+
+    assert len(summary["months"]) == 1
+    month = summary["months"][0]
+    assert month["income_cents"] == 250_00
+    assert month["spend_cents"] == 100_00
+    assert month["net_cents"] == 150_00
+
+
+async def test_positions_lists_current_holdings(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    account = await seed_account(svc, name="Brokerage", account_type="investment")
+    security = FinanceSecurity(ticker="NVDA", name="NVIDIA Corp")
+    session.add(security)
+    await session.flush()
+    session.add(
+        FinanceHolding(
+            owner_user_id=1,
+            account_id=account.id,
+            security_id=security.id,
+            as_of_date=date.today(),
+            quantity_e8=4 * 10**8,
+            price=100_00,
+        )
+    )
+    await session.commit()
+
+    positions = await ai_tools.positions()
+
+    assert len(positions) == 1
+    assert positions[0]["ticker"] == "NVDA"
+    assert positions[0]["quantity"] == 4.0
+    assert positions[0]["market_value_cents"] == 400_00
+
+
+async def test_envelope_and_goal_state(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    await create_envelope(
+        session, owner_user_id=1, name="Groceries", monthly_credit=300_00
+    )
+    goal_account = await seed_account(
+        svc, name="Emergency Fund", account_type="savings"
+    )
+    goal_account.metadata_ = set_goal_metadata(
+        goal_account.metadata_, target_amount=10_000_00
+    )
+    session.add(goal_account)
+    await session.commit()
+
+    envelopes = await ai_tools.envelope_state()
+    goals = await ai_tools.goals_state()
+
+    assert [e["name"] for e in envelopes] == ["Groceries"]
+    assert envelopes[0]["monthly_credit_cents"] == 300_00
+    assert any(g["name"] == "Emergency Fund" for g in goals)
+    target = next(g for g in goals if g["name"] == "Emergency Fund")
+    assert target["target_cents"] == 10_000_00
+
+
+async def test_quote_returns_latest_stored_price(session: AsyncSession) -> None:
+    session.add(FinanceCurrency(code="usd", name="USD", decimals=2, kind="fiat"))
+    security = FinanceSecurity(ticker="VTI", name="Vanguard Total")
+    session.add(security)
+    await session.commit()
+    await session.refresh(security)
+    session.add(
+        FinanceSecurityPrice(
+            security_id=security.id,
+            price_date=date(2026, 1, 2),
+            close_price=200_00,
+            source="manual",
+        )
+    )
+    session.add(
+        FinanceSecurityPrice(
+            security_id=security.id,
+            price_date=date(2026, 2, 2),
+            close_price=210_00,
+            source="manual",
+        )
+    )
+    await session.commit()
+
+    result = await ai_tools.quote("vti")
+
+    assert result["found"] is True
+    assert result["ticker"] == "VTI"
+    assert result["close_cents"] == 210_00
+    assert result["as_of"] == "2026-02-02"
+
+
+async def test_quote_normalizes_sub_cent_scales_in_integer_math(
+    session: AsyncSession,
+) -> None:
+    """A scale-8 (crypto-style) price reaches cents without float drift."""
+    session.add(FinanceCurrency(code="usd", name="USD", decimals=2, kind="fiat"))
+    security = FinanceSecurity(ticker="SATS", name="Sub-cent Asset")
+    session.add(security)
+    await session.commit()
+    await session.refresh(security)
+    session.add(
+        FinanceSecurityPrice(
+            security_id=security.id,
+            price_date=date(2026, 3, 1),
+            close_price=123_456_789,  # 1.23456789 units at scale 8
+            price_scale=8,
+            source="manual",
+        )
+    )
+    await session.commit()
+
+    result = await ai_tools.quote("SATS")
+
+    assert result["close_cents"] == 123  # 123.456789 cents, rounded half up
+
+
+async def test_quote_unknown_ticker_reports_not_found(
+    session: AsyncSession,
+) -> None:
+    result = await ai_tools.quote("ZZZZ")
+
+    assert result["found"] is False
+{% endif %}


### PR DESCRIPTION
## What

Code Mode: an agent row flagged `code_mode` can write Python that calls its DB-granted tools as functions, executed in the Monty sandbox. Instead of N sequential tool round-trips, the model writes one script with loops and arithmetic; a failing script gets its traceback back and is rewritten inside the same turn. This is the capability that turns a chat agent into a research agent: novel questions get novel computations without shipping a new calculator tool per question.

Closes #952, closes #953, closes #954, closes #955, closes #956, closes #957 (tracker #958).

### How it hangs together

- **CM-01 (#952)** `pydantic-ai-harness[codemode]` dependency for pydantic-ai stacks; `capabilities` pass-through `build_chat_agent` -> `ToolChatAgent` -> `Agent(...)`, sent only when non-empty so pre-capability pins never see the kwarg.
- **CM-02 (#953)** `agent.code_mode` bool: model column, migration TableSpec, `AgentConfig` hydration, CRUD (editable, non-nullable, cache-invalidating), `serialize_agent`, seeded default false.
- **CM-03 (#954)** flagged config -> `CodeMode(tools=<granted names>)`, lazily imported so unflagged installs never load the sandbox; per-turn tool-call budget becomes `None -> 4 chat / 16 code-mode`, explicit value wins.
- **CM-04 (#955)** finance host tools (`ledger_summary`, `positions`, `envelope_state`, `goals_state`, `quote`) as thin typed wrappers over existing domain queries, self-registering, imported by the chat facade in finance stacks; fixture seeding now syncs every registered tool into a grantable `tool` row. One new query (`latest_price_for_security`) in the investments queries module.
- **CM-05 (#956)** the live loop pinned by tests: broken script -> traceback -> corrected script -> streamed answer, one `stream_turn`, one usage row; an unrecoverable script ends in `ErrorFrame`, never a raise.
- **CM-06 (#957)** docs: `docs/services/ai/code-mode.md` (grant model, sandbox security, subset limits, when plain tools are better) and `research-agent.md` (end-to-end finance research agent setup).

### Decision on record

Core pydantic-ai was the preferred route for the execution toolset, but its `CodeExecutionToolset` PR was closed unmerged upstream; shipped pydantic-ai 2.33 has only provider-native code execution (server-side, useless for local models). The harness `CodeMode` capability is the maintained first-party integration, verified end-to-end before building: model sees one `run_code` tool, scripts call host tools inside Monty, results flow back.

## Validation

- Repo guards: 269 tests (parser, cleanup, manifest, size budget, migration generator, update detection)
- Generated `ai[sqlite,rag,voice]+finance` project: 2,660 tests passing, ruff clean, ty clean; the only failures are the 3 known pre-existing drift issues (TTS mock strictness x2, `voice_usage` signature), previously confirmed identical on unmodified templates
- Live my-app mirror: 468 tests passing, `005 -> 006` migration applied by the running webserver, clean startup
