### PR TITLE
Add the finance write surface: propose/approve queue, agent matching and tags

### DIFF
--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -1900,6 +1900,36 @@ FINANCE_MIGRATION = ServiceMigrationSpec(
             ],
         ),
         TableSpec(
+            name="finance_pending_change",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("change_type", "sa.String(64)", nullable=False),
+                ColumnSpec("payload", "sa.JSON()", nullable=False),
+                ColumnSpec("proposed_by_agent", "sa.String(64)", nullable=True),
+                ColumnSpec("conversation_id", "sa.String(64)", nullable=True),
+                ColumnSpec("batch_id", "sa.String(36)", nullable=True),
+                ColumnSpec(
+                    "status", "sa.String(16)", nullable=False, default="'pending'"
+                ),
+                ColumnSpec("result", "sa.JSON()", nullable=False),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("resolved_at", "sa.DateTime()", nullable=True),
+            ],
+            indexes=[
+                IndexSpec("ix_finance_pending_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_pending_status", ["status"]),
+                IndexSpec("ix_finance_pending_change_batch_id", ["batch_id"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    "ck_finance_pending_status",
+                    "status IN ('pending', 'approved', 'rejected', 'expired')",
+                ),
+            ],
+        ),
+        TableSpec(
             name="finance_balance_snapshot",
             columns=[
                 ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -1060,6 +1060,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 "tests/components/frontend/test_finance_view_state.py",
                 "app/components/frontend/state/finance_view_state.py",
                 "tests/components/frontend/test_import_preview_body.py",
+                "tests/components/frontend/test_pending_changes_section.py",
                 "tests/components/frontend/test_payees_tab.py",
                 "tests/components/frontend/test_register_columns.py",
                 "tests/components/frontend/test_register_header.py",

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -1026,6 +1026,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 "tests/components/frontend/test_property_details_ui.py",
                 "tests/components/frontend/test_stat_details.py",
                 "tests/components/frontend/test_budget_panel_render.py",
+                "tests/services/test_finance_pending_changes.py",
                 "tests/components/frontend/_payloads.py",
                 "tests/services/test_finance_envelopes.py",
                 "tests/services/test_finance_tags.py",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/finance/changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/finance/changes.py
@@ -1,0 +1,159 @@
+"""The propose/approve queue's HTTP surface (FW-05).
+
+Approval is the only execution path, and it lives here - behind the
+app user - never in a tool. A proposal that fails execution stays
+pending with its error in the payload the card renders.
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, Query, status
+
+from app.services.finance.deps import (
+    get_finance_service,
+    get_owner_user_id,
+)
+from app.services.finance.domains import writes
+from app.services.finance.models import FinancePendingChange
+from app.services.finance.schemas import (
+    BatchResolveRequest,
+    BatchResolveResponse,
+    ChangeProposal,
+    PendingChangeListResponse,
+    PendingChangeResponse,
+)
+from app.services.finance.service import FinanceService
+
+router = APIRouter()
+
+
+async def _to_response(
+    service: FinanceService, row: FinancePendingChange
+) -> PendingChangeResponse:
+    executor = writes.executor_for(row.change_type)
+    display = await service.describe_pending_change(row)
+    return PendingChangeResponse.from_row(row, title=executor.title, display=display)
+
+
+@router.post("/changes", response_model=PendingChangeResponse)
+async def propose_change(
+    body: ChangeProposal,
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> PendingChangeResponse:
+    """Record a proposal. Nothing in the ledger moves here."""
+    try:
+        row = await service.propose_change(
+            body.change_type,
+            body.payload,
+            owner_user_id=owner_user_id,
+            proposed_by_agent=body.proposed_by_agent,
+            conversation_id=body.conversation_id,
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from None
+    response = await _to_response(service, row)
+    await service.db.commit()
+    return response
+
+
+@router.get("/changes", response_model=PendingChangeListResponse)
+async def list_changes(
+    status_filter: str | None = Query("pending", alias="status"),
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> PendingChangeListResponse:
+    rows = await service.list_pending_changes(
+        owner_user_id=owner_user_id, status=status_filter
+    )
+    items = [await _to_response(service, row) for row in rows]
+    return PendingChangeListResponse(items=items, total=len(items))
+
+
+@router.get("/changes/{change_id}", response_model=PendingChangeResponse)
+async def get_change(
+    change_id: int,
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> PendingChangeResponse:
+    row = await service.get_pending_change(change_id, owner_user_id=owner_user_id)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Change not found"
+        )
+    return await _to_response(service, row)
+
+
+@router.post("/changes/{change_id}/approve", response_model=PendingChangeResponse)
+async def approve_change(
+    change_id: int,
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> PendingChangeResponse:
+    """Execute the stored mutation - the one door into the ledger."""
+    try:
+        row = await service.approve_change(change_id, owner_user_id=owner_user_id)
+    except ValueError as e:
+        await service.db.commit()  # a recorded execution error is audit
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from None
+    response = await _to_response(service, row)
+    await service.db.commit()
+    return response
+
+
+@router.post("/changes/{change_id}/reject", response_model=PendingChangeResponse)
+async def reject_change(
+    change_id: int,
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> PendingChangeResponse:
+    try:
+        row = await service.reject_change(change_id, owner_user_id=owner_user_id)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from None
+    response = await _to_response(service, row)
+    await service.db.commit()
+    return response
+
+
+@router.get("/changes/batch/{batch_id}", response_model=PendingChangeListResponse)
+async def get_batch(
+    batch_id: str,
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> PendingChangeListResponse:
+    """Every row of one batch, whatever its status - the batch card's
+    refresh source."""
+    rows = await writes.batch_rows(service.db, batch_id, owner_user_id=owner_user_id)
+    items = [await _to_response(service, row) for row in rows]
+    return PendingChangeListResponse(items=items, total=len(items))
+
+
+@router.post("/changes/batch/{batch_id}/approve", response_model=BatchResolveResponse)
+async def approve_batch(
+    batch_id: str,
+    body: BatchResolveRequest,
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> BatchResolveResponse:
+    """Approve the batch's pending rows, rejecting any vetoed ids."""
+    summary = await service.approve_batch(
+        batch_id, owner_user_id=owner_user_id, exclude_ids=body.exclude_ids
+    )
+    await service.db.commit()
+    return BatchResolveResponse(**summary)
+
+
+@router.post("/changes/batch/{batch_id}/reject", response_model=BatchResolveResponse)
+async def reject_batch(
+    batch_id: str,
+    service: FinanceService = Depends(get_finance_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> BatchResolveResponse:
+    summary = await service.reject_batch(batch_id, owner_user_id=owner_user_id)
+    await service.db.commit()
+    return BatchResolveResponse(**summary)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/finance/changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/finance/changes.py
@@ -7,6 +7,7 @@ pending with its error in the payload the card renders.
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 
+from app.core.log import logger
 from app.services.finance.deps import (
     get_finance_service,
     get_owner_user_id,
@@ -97,6 +98,16 @@ async def approve_change(
         await service.db.commit()  # a recorded execution error is audit
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(e)
+        ) from None
+    except Exception:
+        # Same audit rule for a NON-domain crash - the row's recorded
+        # error must survive, or the card shows a pending change with
+        # no explanation - but internals never reach the client.
+        await service.db.commit()
+        logger.exception(f"Executing pending change {change_id} failed")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="The change could not be executed.",
         ) from None
     response = await _to_response(service, row)
     await service.db.commit()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/finance/router.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/finance/router.py.jinja
@@ -22,6 +22,7 @@ from app.components.backend.api.finance import (
     accounts,
     budgets,
     categories,
+    changes,
     declare,
     goals,
     imports,
@@ -29,7 +30,6 @@ from app.components.backend.api.finance import (
     investments,
     overview,
     payees,
-    goals,
     planning,
     recurring,
     register,
@@ -47,6 +47,7 @@ router.include_router(planning.router, tags=["finance: envelopes"])
 router.include_router(goals.router, tags=["finance: goals"])
 router.include_router(payees.router, tags=["finance: payees"])
 router.include_router(categories.router, tags=["finance: categories"])
+router.include_router(changes.router, tags=["finance: changes"])
 router.include_router(transfers.router, tags=["finance: transfers"])
 router.include_router(recurring.router, tags=["finance: recurring"])
 router.include_router(declare.router, tags=["finance: recurring"])

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py
@@ -37,6 +37,12 @@ SERVICE_MIGRATION_SIGNATURES: dict[str, tuple[str, ...]] = {
     "finance_budget_payee": ("column", "finance.finance_budget_category", "payee_key"),
     "finance_auth_link": ("foreign_key", "finance.finance_account", "owner_user_id"),
     "finance_icon": ("table", "finance.finance_icon"),
+    "pending_changes": ("table", "finance.finance_pending_change"),
+    "pending_change_batch": (
+        "column",
+        "finance.finance_pending_change",
+        "batch_id",
+    ),
     "secured_debt": (
         "column",
         "finance.finance_liability_detail",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/components.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/components.py
@@ -1,0 +1,461 @@
+"""In-conversation components: typed data in, system-rendered control out.
+
+The generative-UI foundation. A tool result (or any structured payload)
+carries DATA; presentation is system code selected by ``kind`` from the
+registry below. The model never authors layout, and a kind the frontend
+does not know degrades to absence - never a crash, never a raw dict on
+screen.
+
+The pending-change card (FW-05) is the first kind. It renders the
+STORED queue row - the same row approval executes - so what the user
+sees and what runs cannot diverge. New kinds (previews, dry-run diffs)
+register here; nothing else changes.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+import json
+import re
+from typing import Any
+
+import flet as ft
+
+from app.components.frontend.controls.buttons import PulseButton
+from app.components.frontend.controls.text import LabelText, SecondaryText
+from app.components.frontend.theme import AegisTheme as Theme
+
+# on_action(change_id, "approve" | "reject") -> the updated change dict
+# (the API response), or None when the call failed and the card should
+# stay actionable.
+ChangeAction = Callable[[int, str], Awaitable[dict[str, Any] | None]]
+
+# A confirmation is a focused decision, not a banner: the card keeps a
+# fixed narrow width and centers in whatever column hosts it.
+CARD_WIDTH = 420
+
+_STATUS_COPY = {
+    "pending": ("Awaiting your approval", Theme.Colors.WARNING),
+    "approved": ("Approved", Theme.Colors.SUCCESS),
+    "rejected": ("Rejected", Theme.Colors.ERROR),
+    "expired": ("Expired", ft.Colors.OUTLINE),
+}
+
+
+BatchAction = Callable[[str, str, list[int]], Awaitable[dict[str, Any] | None]]
+
+_ARROW = " \u2192 "
+
+
+def _value_text(value: str, *, color: str, **kwargs: Any) -> SecondaryText:
+    """A display value; a "before \u2192 after" line gets its target in
+    accent teal so the eye lands on what will change."""
+    if _ARROW not in value:
+        return SecondaryText(value, color=color, **kwargs)
+    before, _, target = value.rpartition(_ARROW)
+    return SecondaryText(
+        "",
+        color=color,
+        spans=[
+            ft.TextSpan(before + _ARROW),
+            ft.TextSpan(target, style=ft.TextStyle(color=Theme.Colors.ACCENT)),
+        ],
+        **kwargs,
+    )
+
+
+class PendingChangeBatchCard(ft.Container):
+    """One decision over many rows: every proposal in the batch as a
+    compact line with a per-row veto, and bulk actions whose copy says
+    exactly how many will land. Resolved batches read as an outcome
+    summary - the audit lives on the individual rows.
+    """
+
+    def __init__(
+        self,
+        data: dict[str, Any],
+        on_batch_action: BatchAction,
+        fetch_items: Callable[[str], Awaitable[list[dict[str, Any]] | None]]
+        | None = None,
+    ) -> None:
+        super().__init__(
+            border=ft.border.all(1, ft.Colors.OUTLINE),
+            border_radius=Theme.Components.CARD_RADIUS,
+            padding=ft.padding.symmetric(
+                vertical=Theme.Spacing.SM, horizontal=Theme.Spacing.MD
+            ),
+            bgcolor=ft.Colors.SURFACE_CONTAINER_HIGHEST,
+            width=CARD_WIDTH,
+            margin=ft.margin.symmetric(
+                vertical=Theme.Spacing.XS, horizontal=Theme.Spacing.SM
+            ),
+        )
+        self._on_batch_action = on_batch_action
+        self._fetch_items = fetch_items
+        self._batch_id = str(data.get("batch_id") or "")
+        self._title = str(data.get("title") or data.get("change_type") or "Changes")
+        self._excluded: set[int] = set()
+        self._expanded = False
+        self.render(data.get("items") or [])
+
+    def toggle_expanded(self) -> None:
+        self._expanded = not self._expanded
+        self.render(self._items)
+        if self.page:
+            self.update()
+
+    def toggle_veto(self, change_id: int) -> None:
+        if change_id in self._excluded:
+            self._excluded.discard(change_id)
+        else:
+            self._excluded.add(change_id)
+        self.render(self._items)
+        if self.page:
+            self.update()
+
+    async def refresh_from(
+        self, fetch: Callable[[str], Awaitable[list[dict[str, Any]] | None]]
+    ) -> None:
+        items = await fetch(self._batch_id)
+        if items is not None:
+            self.render(items)
+            if self.page:
+                self.update()
+
+    @staticmethod
+    def _outcome_summary(items: list[dict[str, Any]]) -> str:
+        """ "1 approved, 1 rejected" - the resolved batch's one-line story."""
+        counts: dict[str, int] = {}
+        for item in items:
+            counts[str(item.get("status"))] = counts.get(str(item.get("status")), 0) + 1
+        return ", ".join(f"{n} {status}" for status, n in sorted(counts.items()))
+
+    def _row_line(self, item: dict[str, Any]) -> str:
+        return "  \u00b7  ".join(
+            str(line.get("value", "")) for line in item.get("display") or []
+        )
+
+    def render(self, items: list[dict[str, Any]]) -> None:
+        self._items = items
+        pending = [i for i in items if i.get("status") == "pending"]
+        header: list[ft.Control] = [
+            LabelText(f"{self._title} ({len(items)})"),
+            ft.Container(expand=True),
+            SecondaryText(
+                (_STATUS_COPY["pending"][0] if pending else "Resolved"),
+                color=(_STATUS_COPY["pending"][1] if pending else ft.Colors.OUTLINE),
+            ),
+        ]
+        if not pending:
+            header.append(
+                ft.IconButton(
+                    icon=(
+                        ft.Icons.EXPAND_LESS if self._expanded else ft.Icons.EXPAND_MORE
+                    ),
+                    icon_size=16,
+                    width=28,
+                    height=28,
+                    padding=0,
+                    on_click=lambda _e: self.toggle_expanded(),
+                )
+            )
+        rows: list[ft.Control] = [
+            ft.Row(header, vertical_alignment=ft.CrossAxisAlignment.CENTER)
+        ]
+        if not pending and not self._expanded:
+            rows.append(SecondaryText(self._outcome_summary(items)))
+            self.content = ft.Column(rows, spacing=Theme.Spacing.SM, tight=True)
+            return
+        for item in items:
+            item_id = int(item.get("id") or 0)
+            status = str(item.get("status", "pending"))
+            vetoed = item_id in self._excluded
+            dimmed = vetoed or status == "rejected"
+            line = (
+                SecondaryText(self._row_line(item), color=ft.Colors.OUTLINE)
+                if dimmed
+                else _value_text(self._row_line(item), color=ft.Colors.ON_SURFACE)
+            )
+            trailing: ft.Control
+            if status == "pending":
+                trailing = ft.TextButton(
+                    "veto" if not vetoed else "keep",
+                    on_click=lambda _e, cid=item_id: self.toggle_veto(cid),
+                )
+            else:
+                copy, color = _STATUS_COPY.get(
+                    status, (status.title(), ft.Colors.OUTLINE)
+                )
+                trailing = SecondaryText(copy, color=color)
+            rows.append(
+                ft.Row(
+                    [ft.Container(content=line, expand=True), trailing],
+                    spacing=Theme.Spacing.SM,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                )
+            )
+        if pending:
+            landing = len(pending) - len(
+                self._excluded & {int(i.get("id") or 0) for i in pending}
+            )
+
+            async def _act(action: str) -> None:
+                summary = await self._on_batch_action(
+                    self._batch_id, action, sorted(self._excluded)
+                )
+                if summary is None:
+                    return
+                if self._fetch_items is not None:
+                    await self.refresh_from(self._fetch_items)
+
+            rows.append(
+                ft.Row(
+                    [
+                        ft.Container(expand=True),
+                        PulseButton(
+                            on_click_callable=lambda: _act("reject"),
+                            text="Reject all",
+                            variant="muted",
+                            compact=True,
+                        ),
+                        PulseButton(
+                            on_click_callable=lambda: _act("approve"),
+                            text=f"Approve all ({landing})",
+                            variant="teal",
+                            compact=True,
+                        ),
+                    ],
+                    spacing=Theme.Spacing.SM,
+                )
+            )
+        else:
+            rows.append(SecondaryText(self._outcome_summary(items)))
+        self.content = ft.Column(rows, spacing=Theme.Spacing.SM, tight=True)
+
+
+class PendingChangeCard(ft.Container):
+    """One proposed mutation, from pending through resolution.
+
+    ``render(data)`` rebuilds the card from a change dict (the API's
+    ``PendingChangeResponse`` shape); the action buttons call
+    ``on_action`` and re-render from whatever it returns, so the card
+    always shows the queue's truth, never an optimistic guess.
+    """
+
+    def __init__(self, data: dict[str, Any], on_action: ChangeAction) -> None:
+        super().__init__(
+            border=ft.border.all(1, ft.Colors.OUTLINE),
+            border_radius=Theme.Components.CARD_RADIUS,
+            padding=ft.padding.symmetric(
+                vertical=Theme.Spacing.SM, horizontal=Theme.Spacing.MD
+            ),
+            bgcolor=ft.Colors.SURFACE_CONTAINER_HIGHEST,
+            width=CARD_WIDTH,
+            margin=ft.margin.symmetric(
+                vertical=Theme.Spacing.XS, horizontal=Theme.Spacing.SM
+            ),
+        )
+        self._on_action = on_action
+        self._change_id = int(data.get("id") or data.get("pending_change_id") or 0)
+        self._expanded = False
+        self.render(data)
+
+    def toggle_expanded(self) -> None:
+        self._expanded = not self._expanded
+        self.render(self._data)
+        if self.page:
+            self.update()
+
+    async def refresh_from(
+        self, fetch: Callable[[int], Awaitable[dict[str, Any] | None]]
+    ) -> None:
+        """Re-render from the queue's current truth.
+
+        A card rebuilt from a history snapshot shows propose-time state;
+        a resolution made on another surface (the Overview tab) has to
+        reach it. A failed fetch changes nothing - the snapshot stays.
+        """
+        data = await fetch(self._change_id)
+        if data is not None:
+            self.render(data)
+            if self.page:
+                self.update()
+
+    def render(self, data: dict[str, Any]) -> None:
+        self._data = data
+        status = str(data.get("status", "pending"))
+        copy, color = _STATUS_COPY.get(status, (status.title(), ft.Colors.OUTLINE))
+        resolved = status != "pending"
+        header: list[ft.Control] = [
+            LabelText(str(data.get("title") or data.get("change_type", ""))),
+            ft.Container(expand=True),
+            SecondaryText(copy, color=color),
+        ]
+        if resolved:
+            # A decided card is history, not homework: it folds to this
+            # line automatically, expandable on demand.
+            header.append(
+                ft.IconButton(
+                    icon=(
+                        ft.Icons.EXPAND_LESS if self._expanded else ft.Icons.EXPAND_MORE
+                    ),
+                    icon_size=16,
+                    width=28,
+                    height=28,
+                    padding=0,
+                    on_click=lambda _e: self.toggle_expanded(),
+                )
+            )
+        rows: list[ft.Control] = [
+            ft.Row(header, vertical_alignment=ft.CrossAxisAlignment.CENTER)
+        ]
+        if resolved and not self._expanded:
+            self.content = ft.Column(rows, spacing=Theme.Spacing.SM, tight=True)
+            return
+        for line in data.get("display") or []:
+            # The value gets the row's remaining width and WRAPS: a long
+            # before -> after line clipped at the card edge is exactly
+            # the half-truth a confirmation cannot afford.
+            rows.append(
+                ft.Row(
+                    [
+                        SecondaryText(str(line.get("label", ""))),
+                        ft.Container(
+                            content=_value_text(
+                                str(line.get("value", "")),
+                                color=ft.Colors.ON_SURFACE,
+                                text_align=ft.TextAlign.RIGHT,
+                            ),
+                            expand=True,
+                        ),
+                    ],
+                    spacing=Theme.Spacing.SM,
+                    vertical_alignment=ft.CrossAxisAlignment.START,
+                )
+            )
+        error = data.get("error")
+        if error:
+            rows.append(SecondaryText(str(error), color=Theme.Colors.ERROR))
+        if status == "pending":
+            change_id = int(data.get("id") or data.get("pending_change_id") or 0)
+
+            async def _act(action: str) -> None:
+                updated = await self._on_action(change_id, action)
+                if updated is not None:
+                    self.render(updated)
+                    if self.page:
+                        self.update()
+
+            rows.append(
+                ft.Row(
+                    [
+                        ft.Container(expand=True),
+                        PulseButton(
+                            on_click_callable=lambda: _act("reject"),
+                            text="Reject",
+                            variant="muted",
+                            compact=True,
+                        ),
+                        PulseButton(
+                            on_click_callable=lambda: _act("approve"),
+                            text="Approve",
+                            variant="teal",
+                            compact=True,
+                        ),
+                    ],
+                    spacing=Theme.Spacing.SM,
+                )
+            )
+        self.content = ft.Column(rows, spacing=Theme.Spacing.SM, tight=True)
+
+
+def render_component(
+    kind: str,
+    data: dict[str, Any],
+    *,
+    on_action: ChangeAction,
+    on_batch_action: BatchAction | None = None,
+    fetch_items: Callable[[str], Awaitable[list[dict[str, Any]] | None]] | None = None,
+) -> ft.Control | None:
+    """The registry's one door: a control for a known kind, None for an
+    unknown one."""
+    if kind == "pending_change":
+        return PendingChangeCard(data, on_action)
+    if kind == "pending_change_batch" and on_batch_action is not None:
+        return PendingChangeBatchCard(data, on_batch_action, fetch_items=fetch_items)
+    return None
+
+
+def _salvage_identity(clipped: str) -> dict[str, Any] | None:
+    """Identity fields from a truncated proposal result, or None."""
+    fields: dict[str, Any] = {}
+    for key in ("batch_id", "change_type", "title", "status"):
+        m = re.search(rf'"{key}":\s*"([^"]*)"', clipped)
+        if m:
+            fields[key] = m.group(1)
+    m = re.search(r'"pending_change_id":\s*(\d+)', clipped)
+    if m:
+        fields["pending_change_id"] = int(m.group(1))
+    if fields.get("batch_id"):
+        return {**fields, "items": []}
+    if fields.get("pending_change_id"):
+        return {"status": "pending", "display": [], **fields}
+    return None
+
+
+def components_from_trace(
+    trace: list[dict[str, Any]],
+    *,
+    on_action: ChangeAction,
+    on_batch_action: BatchAction | None = None,
+    fetch_items: Callable[[str], Awaitable[list[dict[str, Any]] | None]] | None = None,
+) -> list[ft.Control]:
+    """Cards for the trace's propose results.
+
+    The tool trail is the transport: a ``propose`` (or ``propose_many``)
+    call's result IS the pending-change data. Anything that does not
+    parse as one is left to the trail's ordinary rendering.
+    """
+    cards: list[ft.Control] = []
+    for entry in trace:
+        if entry.get("tool") not in ("propose", "propose_many"):
+            continue
+        # The compact marker is the contract: the result blob is
+        # display-clipped and a big batch truncates to invalid JSON.
+        # Cards built from the marker refresh their rows from the
+        # queue; parsing the result is the legacy fallback for traces
+        # recorded before the marker existed.
+        data: dict[str, Any] | None = None
+        marker = entry.get("component")
+        if isinstance(marker, dict) and marker.get("kind"):
+            data = {**marker, "items": []}
+        else:
+            result = entry.get("result")
+            if not isinstance(result, str):
+                continue
+            try:
+                parsed = json.loads(result)
+            except (TypeError, ValueError):
+                # Pre-marker traces clipped big results to invalid
+                # JSON. The identity fields lead the blob, so they
+                # survive the clip - salvage them; the card fetches
+                # its rows from the queue like any marker card.
+                parsed = _salvage_identity(result)
+            if isinstance(parsed, dict):
+                data = parsed
+        if data is None:
+            continue
+        card: ft.Control | None = None
+        if "batch_id" in data and isinstance(data.get("items"), list):
+            card = render_component(
+                "pending_change_batch",
+                data,
+                on_action=on_action,
+                on_batch_action=on_batch_action,
+                fetch_items=fetch_items,
+            )
+        elif "pending_change_id" in data:
+            card = render_component("pending_change", data, on_action=on_action)
+        if card is not None:
+            cards.append(card)
+    return cards

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/message.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/message.py
@@ -41,6 +41,15 @@ class ChatMessageBubble(ft.Container):
             "", size=Theme.Typography.BODY_SMALL, visible=False
         )
         self._trail = ft.Column([], spacing=2, tight=True, visible=False)
+        # In-conversation components (approval cards, future previews):
+        # system-rendered from typed tool-result data, never model layout.
+        self._components = ft.Column(
+            [],
+            spacing=Theme.Spacing.SM,
+            tight=True,
+            visible=False,
+            horizontal_alignment=ft.CrossAxisAlignment.CENTER,
+        )
         self._waiting = ft.Container(
             content=busy_bar(width=160),
             padding=ft.padding.symmetric(vertical=Theme.Spacing.XS),
@@ -54,6 +63,7 @@ class ChatMessageBubble(ft.Container):
                 LabelText("You" if is_user else agent_name),
                 self._trail,
                 self._body,
+                self._components,
                 self._waiting,
                 self._footer,
             ],
@@ -74,9 +84,7 @@ class ChatMessageBubble(ft.Container):
                 alignment=ft.alignment.center_right,
                 padding=ft.padding.only(left=_ALIGN_INSET),
             )
-        return ft.Container(
-            content=self, padding=ft.padding.only(right=_ALIGN_INSET)
-        )
+        return ft.Container(content=self, padding=ft.padding.only(right=_ALIGN_INSET))
 
     # -- waiting indicator -------------------------------------------------
 
@@ -194,6 +202,13 @@ class ChatMessageBubble(ft.Container):
         self._body.value = text
         if self.page:
             self._body.update()
+
+    def set_components(self, controls: list[ft.Control]) -> None:
+        """Attach in-conversation components below the message body."""
+        self._components.controls = list(controls)
+        self._components.visible = bool(controls)
+        if self.page:
+            self._components.update()
 
     def finalize(
         self,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/model_picker.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/model_picker.py
@@ -22,7 +22,7 @@ from app.components.frontend.controls.text import (
 )
 from app.components.frontend.theme import AegisTheme as Theme
 
-from .models import group_models, newest_first
+from .models import group_models, model_label, newest_first
 
 _GROUP_MODES = (("vendor", "Vendors"), ("family", "Families"), ("all", "All"))
 
@@ -209,3 +209,54 @@ class ModelPickerDialog(StyledAlertDialog):
                 self._on_pick, mid
             ),
         )
+
+
+class ModelChipMixin:
+    """The panel's model chip + picker verbs.
+
+    State contract with ``ChatPanel``: ``_api()``, ``_model_chip_label``,
+    ``_model_dialog``, ``page``. Split from the panel purely so each
+    module stays inside the size budget - one surface, two files.
+    """
+
+    async def _refresh_model_chip(self) -> None:
+        current = await self._api().get("/api/v1/llm/current")
+        self._model_chip_label.value = model_label(current)
+        if self.page:
+            self._model_chip_label.update()
+
+    async def _pick_model(self, model_id: str) -> None:
+        result = await self._api().post("/api/v1/llm/current", {"model_id": model_id})
+        if not result or not result.get("success"):
+            from app.components.frontend.controls.snack_bar import ErrorSnackBar
+
+            detail = (result or {}).get("message") or "Model switch failed."
+            self.page.open(ErrorSnackBar(detail))
+            return
+        if self._model_dialog is not None:
+            self._model_dialog.open = False
+        await self._refresh_model_chip()
+        self.page.update()
+
+    async def _close_model_picker(self) -> None:
+        if self._model_dialog is not None:
+            self._model_dialog.open = False
+            self.page.update()
+
+    async def _open_model_picker(self) -> None:
+        models = await self._api().get(
+            "/api/v1/llm/models", {"limit": 200, "usable": True}
+        )
+        vendors = await self._api().get("/api/v1/llm/vendors", {"usable": True})
+        current = await self._api().get("/api/v1/llm/current")
+        vendor_icons = {
+            v["name"]: v["icon_b64"] for v in (vendors or []) if v.get("icon_b64")
+        }
+        self._model_dialog = ModelPickerDialog(
+            models=models or [],
+            vendor_icons=vendor_icons,
+            active_id=str((current or {}).get("model") or ""),
+            on_pick=self._pick_model,
+            on_close=self._close_model_picker,
+        )
+        self.page.open(self._model_dialog)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/panel.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/controls/chat/panel.py
@@ -15,14 +15,16 @@ import flet as ft
 from app.components.frontend.controls.buttons import BaseIconButton
 from app.components.frontend.controls.dialog import StyledAlertDialog
 from app.components.frontend.controls.form_fields import input_field_kwargs
+from app.components.frontend.controls.snack_bar import ErrorSnackBar
 from app.components.frontend.controls.text import PrimaryText, SecondaryText
 from app.components.frontend.theme import AegisTheme as Theme
 from app.core.formatting import format_relative_time
 from app.core.log import logger
 from app.core.sse import stream_sse_post
 
+from .components import PendingChangeBatchCard, components_from_trace
 from .message import ChatMessageBubble
-from .model_picker import ModelPickerDialog
+from .model_picker import ModelChipMixin
 from .models import model_label
 from .stream import StreamAccumulator, narration_note, tool_label
 
@@ -30,7 +32,7 @@ from .stream import StreamAccumulator, narration_note, tool_label
 _RENDER_INTERVAL_SECONDS = 0.1
 
 
-class ChatPanel(ft.Container):
+class ChatPanel(ModelChipMixin, ft.Container):
     """A self-contained chat surface bound to one agent row.
 
     Args:
@@ -143,9 +145,7 @@ class ChatPanel(ft.Container):
                 ft.Stack(
                     [
                         self._body,
-                        ft.Container(
-                            content=self._jump_button, right=10, bottom=10
-                        ),
+                        ft.Container(content=self._jump_button, right=10, bottom=10),
                     ],
                     expand=True,
                 ),
@@ -155,8 +155,43 @@ class ChatPanel(ft.Container):
             spacing=Theme.Spacing.SM,
         )
         self.expand = True
+        # Every pending-change card the transcript currently shows, so a
+        # return to this tab can re-read them - a resolution made on the
+        # Overview tab must reach a card chat already rendered.
+        self._pending_cards: list[ft.Control] = []
 
     # -- lifecycle ---------------------------------------------------------
+
+    def _clear_transcript(self) -> None:
+        self._transcript.controls.clear()
+        self._pending_cards.clear()
+
+    def refresh_on_revisit(self) -> None:
+        if self.page and self._pending_cards:
+            self.page.run_task(self._refresh_pending_cards)
+
+    def _track_cards(self, cards: list[ft.Control]) -> None:
+        """Register rendered cards and immediately re-read each from the
+        queue: a card built from the trace's compact marker carries
+        identity only - the server supplies the rows."""
+        self._pending_cards.extend(cards)
+        for card in cards:
+            fetch = (
+                self._batch_fetch
+                if isinstance(card, PendingChangeBatchCard)
+                else self._change_fetch
+            )
+            if self.page:
+                self.page.run_task(card.refresh_from, fetch)
+
+    async def _refresh_pending_cards(self) -> None:
+        for card in list(self._pending_cards):
+            fetch = (
+                self._batch_fetch
+                if isinstance(card, PendingChangeBatchCard)
+                else self._change_fetch
+            )
+            await card.refresh_from(fetch)
 
     def did_mount(self) -> None:
         self.page.run_task(self._resume_latest)
@@ -186,15 +221,27 @@ class ChatPanel(ft.Container):
         if detail is None:
             return
         self.conversation_id = conversation_id
-        self._transcript.controls.clear()
+        self._clear_transcript()
         for message in detail.get("messages", []):
             role = message.get("role", "assistant")
+            trace = (message.get("metadata") or {}).get("tool_trace")
             bubble = ChatMessageBubble(
                 role=role,
                 text=message.get("content", ""),
                 agent_name=self.agent_name,
-                tool_trace=(message.get("metadata") or {}).get("tool_trace"),
+                tool_trace=trace,
             )
+            if trace:
+                cards = components_from_trace(
+                    trace,
+                    on_action=self._change_action,
+                    on_batch_action=self._batch_action,
+                    fetch_items=self._batch_fetch,
+                )
+                bubble.set_components(cards)
+                # Snapshot state is propose-time state: a resolution made
+                # on the Overview tab has to reach a reloaded chat card.
+                self._track_cards(cards)
             self._transcript.controls.append(bubble.in_row())
         self._show_transcript()
 
@@ -238,6 +285,7 @@ class ChatPanel(ft.Container):
         ]
         if not rows:
             rows = [SecondaryText("No conversations yet.")]
+
         async def _close_history() -> None:
             if self._history_dialog is not None:
                 self._history_dialog.open = False
@@ -255,58 +303,10 @@ class ChatPanel(ft.Container):
 
     async def _start_new_conversation(self) -> None:
         self.conversation_id = None
-        self._transcript.controls.clear()
+        self._clear_transcript()
         self._body.content = self._empty_state
         if self.page:
             self.update()
-
-    # -- model selection ---------------------------------------------------
-
-    async def _refresh_model_chip(self) -> None:
-        current = await self._api().get("/api/v1/llm/current")
-        self._model_chip_label.value = model_label(current)
-        if self.page:
-            self._model_chip_label.update()
-
-    async def _pick_model(self, model_id: str) -> None:
-        result = await self._api().post(
-            "/api/v1/llm/current", {"model_id": model_id}
-        )
-        if not result or not result.get("success"):
-            from app.components.frontend.controls.snack_bar import ErrorSnackBar
-
-            detail = (result or {}).get("message") or "Model switch failed."
-            self.page.open(ErrorSnackBar(detail))
-            return
-        if self._model_dialog is not None:
-            self._model_dialog.open = False
-        await self._refresh_model_chip()
-        self.page.update()
-
-    async def _close_model_picker(self) -> None:
-        if self._model_dialog is not None:
-            self._model_dialog.open = False
-            self.page.update()
-
-    async def _open_model_picker(self) -> None:
-        models = await self._api().get(
-            "/api/v1/llm/models", {"limit": 200, "usable": True}
-        )
-        vendors = await self._api().get("/api/v1/llm/vendors", {"usable": True})
-        current = await self._api().get("/api/v1/llm/current")
-        vendor_icons = {
-            v["name"]: v["icon_b64"]
-            for v in (vendors or [])
-            if v.get("icon_b64")
-        }
-        self._model_dialog = ModelPickerDialog(
-            models=models or [],
-            vendor_icons=vendor_icons,
-            active_id=str((current or {}).get("model") or ""),
-            on_pick=self._pick_model,
-            on_close=self._close_model_picker,
-        )
-        self.page.open(self._model_dialog)
 
     # -- streaming turn ----------------------------------------------------
 
@@ -388,11 +388,69 @@ class ChatPanel(ft.Container):
                 accumulator.final_meta,
                 accumulator.tool_trace,
             )
+            if accumulator.tool_trace:
+                cards = components_from_trace(
+                    accumulator.tool_trace,
+                    on_action=self._change_action,
+                    on_batch_action=self._batch_action,
+                    fetch_items=self._batch_fetch,
+                )
+                reply.set_components(cards)
+                self._track_cards(cards)
         self._scroll_to_latest()
         self._streaming = False
         self._send_button.update_state(disabled=False)
         if self.page:
             self._input.focus()
+
+    async def _batch_fetch(self, batch_id: str) -> list[dict[str, Any]] | None:
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        response = await api.get(f"/api/v1/finance/changes/batch/{batch_id}")
+        return response.get("items") if isinstance(response, dict) else None
+
+    async def _batch_action(
+        self, batch_id: str, action: str, exclude_ids: list[int]
+    ) -> dict[str, Any] | None:
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        response = await api.post(
+            f"/api/v1/finance/changes/batch/{batch_id}/{action}",
+            json={"exclude_ids": exclude_ids} if action == "approve" else None,
+        )
+        if not isinstance(response, dict):
+            ErrorSnackBar(api.last_error or "Could not resolve the batch.").launch(
+                self.page
+            )
+            return None
+        return response
+
+    async def _change_fetch(self, change_id: int) -> dict[str, Any] | None:
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        response = await api.get(f"/api/v1/finance/changes/{change_id}")
+        return response if isinstance(response, dict) else None
+
+    async def _change_action(
+        self, change_id: int, action: str
+    ) -> dict[str, Any] | None:
+        """Resolve one pending change and hand the card the queue's new
+        truth. The endpoint is the finance write queue's - the only
+        surface that currently proposes - and a stack without it simply
+        never renders a card that could call this."""
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        response = await api.post(f"/api/v1/finance/changes/{change_id}/{action}")
+        if not isinstance(response, dict):
+            ErrorSnackBar(api.last_error or "Could not resolve the change.").launch(
+                self.page
+            )
+            return None
+        return response
 
     # -- scroll behavior ---------------------------------------------------
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/__init__.py
@@ -78,11 +78,12 @@ from app.components.frontend.dashboard.modals.finance_modal.import_preview impor
     import_preview_body,
 )
 from app.components.frontend.dashboard.modals.finance_modal.import_summary import (
-    import_identical_body,
     import_summary_body,
+    import_up_to_date_body,
     investment_import_preview_body,
     investment_import_summary_body,
     investment_target_options,
+    nothing_to_import,
 )
 from app.components.frontend.dashboard.modals.finance_modal.no_payee_panel import (
     NoPayeePanel,
@@ -178,7 +179,8 @@ __all__ = [
     "goal_amounts_line",
     "goal_eta_caption",
     "goal_suggestion_message",
-    "import_identical_body",
+    "import_up_to_date_body",
+    "nothing_to_import",
     "import_preview_body",
     "import_summary_body",
     "investment_import_preview_body",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/import_summary.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/import_summary.py
@@ -57,8 +57,25 @@ from app.components.frontend.theme import AegisTheme as Theme
 from app.core.formatting import format_date
 
 
-def import_identical_body(preview: dict[str, Any], file_name: str) -> ft.Column:
-    """The body for a file that was already imported, byte for byte.
+def nothing_to_import(preview: dict[str, Any]) -> bool:
+    """True when the review has nothing to offer an Import button.
+
+    Two shapes of the same dead end: the byte-identical re-upload, and a
+    fresh export whose every row is already stored (yesterday's import,
+    or a sync, got there first). Parse errors disqualify - a file that
+    partly failed deserves the full review, not a shrug.
+    """
+    if preview.get("identical_batch_id") is not None:
+        return True
+    return (
+        preview.get("rows_inserted", 0) == 0
+        and preview.get("rows_updated", 0) == 0
+        and preview.get("rows_error", 0) == 0
+    )
+
+
+def import_up_to_date_body(preview: dict[str, Any], file_name: str) -> ft.Column:
+    """The body for a file with nothing to import, byte-identical or not.
 
     The third state of the same dialog, so it keeps the family's shape:
     the same subtitle line, the same dot vocabulary, the same closing
@@ -71,6 +88,7 @@ def import_identical_body(preview: dict[str, Any], file_name: str) -> ft.Column:
     reads as a failed import; what the reader needs is that this exact
     file already went in.
     """
+    identical = preview.get("identical_batch_id") is not None
     return ft.Column(
         [
             SecondaryText(
@@ -85,20 +103,33 @@ def import_identical_body(preview: dict[str, Any], file_name: str) -> ft.Column:
                         Theme.Colors.TEXT_SECONDARY,
                         "Every row in this file is already in your ledger.",
                     ),
-                    _preview_dot(
-                        "identical file",
-                        False,
-                        Theme.Colors.TEXT_SECONDARY,
-                        "Matched by content hash, so a rename would not fool it.",
+                    (
+                        _preview_dot(
+                            "identical file",
+                            False,
+                            Theme.Colors.TEXT_SECONDARY,
+                            "Matched by content hash, so a rename would not fool it.",
+                        )
+                        if identical
+                        else _preview_dot(
+                            "up to date",
+                            False,
+                            Theme.Colors.TEXT_SECONDARY,
+                            "Every row this file carries is already stored - an "
+                            "earlier import or sync brought them in.",
+                        )
                     ),
                 ],
                 spacing=Theme.Spacing.MD,
                 wrap=True,
             ),
-            # Short: the dots above already carry "identical" and "no
-            # changes", so this only has to say WHY, once.
+            # Short: the dots above already carry the outcome, so this
+            # only has to say WHY, once.
             _import_footnote(
                 "Nothing has been written. You already imported this exact file."
+                if identical
+                else "Nothing has been written. Your ledger already has "
+                "everything this file carries."
             ),
         ],
         spacing=Theme.Spacing.MD,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/overview_tab.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/overview_tab.py
@@ -64,6 +64,9 @@ from app.components.frontend.dashboard.modals.finance_modal.formatting import (
     _month_label,
     _usd,
 )
+from app.components.frontend.dashboard.modals.finance_modal.pending_changes import (
+    PendingChangesSection,
+)
 from app.components.frontend.dashboard.modals.finance_modal.transactions_view import (
     _transaction_expanded_content,
 )
@@ -139,6 +142,7 @@ class OverviewTab(FinancePanel):
         # Header matches the Projected tab: title + subtitle on the left,
         # the headline figures bare against the right edge. Cards below
         # would cost the chart a card's height and box it twice.
+        self._pending_changes = PendingChangesSection(page)
         self._stats = ft.Row(
             [],
             spacing=Theme.Spacing.LG,
@@ -146,6 +150,7 @@ class OverviewTab(FinancePanel):
         )
         self.content = ft.Column(
             [
+                self._pending_changes,
                 ft.Row(
                     [
                         ft.Column(
@@ -276,6 +281,7 @@ class OverviewTab(FinancePanel):
         self.page.open(dialog)
 
     async def _load(self) -> None:
+        await self._pending_changes.refresh()
         from app.components.frontend.state.session_state import get_session_state
 
         api = get_session_state(self.page).api_client

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/pending_changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/pending_changes.py
@@ -1,0 +1,131 @@
+"""Pending changes on the finance modal: proposals must outlive the chat.
+
+The card is the SAME control the conversation renders
+(``controls/chat/components``) - one renderer, one truth, two surfaces.
+A proposal made in a chat that was closed still gets decided here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import flet as ft
+
+from app.components.frontend.controls import SecondaryText
+from app.components.frontend.controls.chat.components import render_component
+from app.components.frontend.controls.snack_bar import ErrorSnackBar
+from app.components.frontend.controls.text import H3Text
+from app.components.frontend.theme import AegisTheme as Theme
+
+
+class PendingChangesSection(ft.Container):
+    """The modal's queue view: every pending proposal, newest first.
+
+    Invisible when the queue is empty - an empty approvals box would
+    nag about a kind of event most sessions don't have.
+    """
+
+    def __init__(self, page: ft.Page) -> None:
+        super().__init__(visible=False)
+        self.page = page
+        # A horizontal rail, not a column: approvals sit side by side
+        # above the page and scroll sideways on overflow, instead of
+        # pushing the charts down.
+        self._cards = ft.Row(
+            [],
+            spacing=Theme.Spacing.SM,
+            scroll=ft.ScrollMode.AUTO,
+            vertical_alignment=ft.CrossAxisAlignment.START,
+        )
+        self.content = ft.Column(
+            [
+                ft.Row(
+                    [
+                        H3Text("Pending changes"),
+                        SecondaryText(
+                            "Proposed by your assistant - nothing runs until you approve"
+                        ),
+                    ],
+                    spacing=Theme.Spacing.SM,
+                    vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                ),
+                self._cards,
+            ],
+            spacing=Theme.Spacing.SM,
+            tight=True,
+        )
+
+    async def refresh(self) -> None:
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        listing = await api.get("/api/v1/finance/changes")
+        items = listing.get("items", []) if isinstance(listing, dict) else []
+        # A 30-row batch proposed in chat is ONE card here too: group by
+        # batch, singles stay singles - same renderers as the chat.
+        batches: dict[str, list[dict[str, Any]]] = {}
+        singles: list[dict[str, Any]] = []
+        for item in items:
+            if item.get("batch_id"):
+                batches.setdefault(item["batch_id"], []).append(item)
+            else:
+                singles.append(item)
+        controls: list[ft.Control] = []
+        for batch_id, batch_items in batches.items():
+            card = render_component(
+                "pending_change_batch",
+                {
+                    "batch_id": batch_id,
+                    "title": batch_items[0].get("title"),
+                    "items": batch_items,
+                },
+                on_action=self._resolve,
+                on_batch_action=self._resolve_batch,
+                fetch_items=self._fetch_batch,
+            )
+            if card is not None:
+                controls.append(card)
+        for item in singles:
+            card = render_component("pending_change", item, on_action=self._resolve)
+            if card is not None:
+                controls.append(card)
+        self._cards.controls = controls
+        self.visible = bool(self._cards.controls)
+        if self.page:
+            self.update()
+
+    async def _resolve(self, change_id: int, action: str) -> dict[str, Any] | None:
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        response = await api.post(f"/api/v1/finance/changes/{change_id}/{action}")
+        if not isinstance(response, dict):
+            ErrorSnackBar(api.last_error or "Could not resolve the change.").launch(
+                self.page
+            )
+            return None
+        return response
+
+    async def _fetch_batch(self, batch_id: str) -> list[dict[str, Any]] | None:
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        response = await api.get(f"/api/v1/finance/changes/batch/{batch_id}")
+        return response.get("items") if isinstance(response, dict) else None
+
+    async def _resolve_batch(
+        self, batch_id: str, action: str, exclude_ids: list[int]
+    ) -> dict[str, Any] | None:
+        from app.components.frontend.state.session_state import get_session_state
+
+        api = get_session_state(self.page).api_client
+        response = await api.post(
+            f"/api/v1/finance/changes/batch/{batch_id}/{action}",
+            json={"exclude_ids": exclude_ids} if action == "approve" else None,
+        )
+        if not isinstance(response, dict):
+            ErrorSnackBar(api.last_error or "Could not resolve the batch.").launch(
+                self.page
+            )
+            return None
+        return response

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/transactions_panel/imports_flow.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/finance_modal/transactions_panel/imports_flow.py
@@ -25,11 +25,12 @@ from app.components.frontend.dashboard.modals.finance_modal.import_preview impor
 )
 from app.components.frontend.dashboard.modals.finance_modal.import_summary import (
     _suggested_account_name,
-    import_identical_body,
     import_summary_body,
+    import_up_to_date_body,
     investment_import_preview_body,
     investment_import_summary_body,
     investment_target_options,
+    nothing_to_import,
 )
 from app.components.frontend.dashboard.modals.finance_modal.transactions_panel.base import (
     TransactionsPanelState,
@@ -38,12 +39,12 @@ from app.components.frontend.theme import AegisTheme as Theme
 from app.core.config import settings
 from app.core.constants import dashboard_upload_dir
 
-
 # Import uploads parse the file and run the reconciliation plan inside
 # the request, so they legitimately outlive the client-wide 10s UI
 # budget. The commit path is exempt: it returns a job id immediately
 # and streams progress over SSE.
 _IMPORT_TIMEOUT_SECONDS = 120.0
+
 
 class ImportsFlowMixin(TransactionsPanelState):
     """The file-import flow: picker, upload, preview, run, summary dialogs."""
@@ -415,10 +416,14 @@ class ImportsFlowMixin(TransactionsPanelState):
                 dialog.open = False
             self.page.update()
 
-        if preview.get("identical_batch_id") is not None:
+        if nothing_to_import(preview):
             dialog = StyledAlertDialog(
-                title="Nothing to import",
-                body=import_identical_body(preview, original_name),
+                title=(
+                    "Nothing to import"
+                    if preview.get("identical_batch_id") is not None
+                    else "Import up to date"
+                ),
+                body=import_up_to_date_body(preview, original_name),
                 actions=[
                     PulseButton(
                         on_click_callable=_close,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/agent_loader.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/agent_loader.py.jinja
@@ -14,8 +14,7 @@ CRUD paths that edit agent rows must call ``invalidate_agent_cache`` so
 the next request sees the change.
 """
 
-{% if ai_backend != "memory" and ai_framework == "pydantic-ai" %}
-from collections.abc import Callable, Sequence
+{% if ai_backend != "memory" and ai_framework == "pydantic-ai" %}from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -28,10 +27,10 @@ from app.core.config import settings
 from app.core.db import get_async_session
 from app.core.log import logger
 from app.services.ai.domains.chat.chat_kit import ContextProvider, ToolChatAgent
-from app.services.ai.models.agents import Agent
 from app.services.ai.domains.chat.module_context import MemoryModuleContextProvider
 from app.services.ai.domains.chat.prompts import get_default_system_prompt
 from app.services.ai.domains.chat.tools import resolve_tools
+from app.services.ai.models.agents import Agent
 from app.services.ai.usage_recording import record_usage
 {% elif ai_backend != "memory" %}
 from dataclasses import dataclass
@@ -52,7 +51,6 @@ from app.core.config import settings
 from app.core.log import logger
 from app.services.ai.domains.chat.prompts import get_default_system_prompt
 {% endif %}
-
 DEFAULT_AGENT_SLUG = "assistant"
 
 
@@ -93,7 +91,6 @@ def default_agent_config() -> AgentConfig:
     )
 {% if ai_backend != "memory" %}
 
-
 _cache: dict[str, AgentConfig] = {}
 
 
@@ -122,9 +119,7 @@ def _to_config(row: Agent) -> AgentConfig:
 
 async def _fetch_agent(session: AsyncSession, slug: str) -> Agent | None:
     stmt = (
-        select(Agent)
-        .where(Agent.slug == slug)
-        .options(selectinload(Agent.tools))  # type: ignore[arg-type]
+        select(Agent).where(Agent.slug == slug).options(selectinload(Agent.tools))  # type: ignore[arg-type]
     )
     result = await session.exec(stmt)
     return result.first()
@@ -185,8 +180,6 @@ async def resolve_agent(
     return default_agent_config()
 {% endif %}
 {% if ai_backend != "memory" and ai_framework == "pydantic-ai" %}
-
-
 # Per-turn tool-call budgets. Chat stays briefing-first and snappy; code
 # mode's loop is script -> observe -> script, so its budget must cover a
 # real investigation without letting a runaway loop stack latency forever.
@@ -213,20 +206,16 @@ def agent_capabilities(config: AgentConfig) -> list[Any]:
     if config.code_mode:
         from pydantic_ai_harness import CodeMode
 
-        from app.services.ai.domains.chat.user_memory import (
-            MEMORY_WRITE_TOOL_NAMES,
-        )
+        from app.services.ai.domains.chat.tools import native_write_tool_names
 
         # Reads go in the sandbox (slicing a payload in code is the point);
-        # writes stay native so they surface as their own tool call.
+        # writes stay native so they surface as their own tool call. A
+        # tool declares its own nature at registration (native_write) -
+        # memory saves and queue proposals both ride this, and the next
+        # write tool just declares itself.
+        native = native_write_tool_names()
         capabilities.append(
-            CodeMode(
-                tools=[
-                    name
-                    for name in config.tool_names
-                    if name not in MEMORY_WRITE_TOOL_NAMES
-                ]
-            )
+            CodeMode(tools=[name for name in config.tool_names if name not in native])
         )
     if config.code_mode or config.tool_names:
         capabilities.append(_tool_output_limits(code_mode=config.code_mode))
@@ -336,4 +325,4 @@ def build_chat_agent(
         capabilities=effective_capabilities,
         name=config.slug,
     )
-{% endif %}
+{%- endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/chat_kit/agent.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/chat_kit/agent.py
@@ -159,7 +159,11 @@ class ToolChatAgent(Generic[DepsT]):
             result: Any = None
             # Bind the turn's user so a save_memory call mid-stream knows
             # whose fact it is; the scope is the only identity a turn has.
-            with memory_user(scope.user_id):
+            with memory_user(
+                scope.user_id,
+                agent_slug=getattr(self._agent, "name", None),
+                conversation_id=getattr(scope, "conversation_id", None),
+            ):
                 async with self._agent.run_stream_events(
                     message,
                     instructions=run_instructions,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/tools.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/tools.py
@@ -32,11 +32,19 @@ ToolFunc = Callable[..., Any]
 
 @dataclass(frozen=True)
 class RegisteredTool:
-    """A named tool entry: the callable plus registry metadata."""
+    """A named tool entry: the callable plus registry metadata.
+
+    ``native_write`` marks a tool that must stay a visible native call
+    even in code mode - a write the user has to see in the tool trail
+    (memory saves, queue proposals) is never dispatched from inside the
+    sandbox. The tool declares this about itself at registration; the
+    agent loader asks the registry rather than keeping its own list.
+    """
 
     name: str
     func: ToolFunc
     description: str | None = None
+    native_write: bool = False
 
 
 _registry: dict[str, RegisteredTool] = {}
@@ -47,6 +55,7 @@ def register_tool(
     func: ToolFunc,
     *,
     description: str | None = None,
+    native_write: bool = False,
     replace: bool = False,
 ) -> None:
     """Register a callable under a tool name.
@@ -58,7 +67,9 @@ def register_tool(
         raise ValueError(
             f"Tool '{name}' is already registered; pass replace=True to rebind it"
         )
-    _registry[name] = RegisteredTool(name=name, func=func, description=description)
+    _registry[name] = RegisteredTool(
+        name=name, func=func, description=description, native_write=native_write
+    )
 
 
 def unregister_tool(name: str) -> None:
@@ -72,6 +83,11 @@ def unregister_tool(name: str) -> None:
 def get_tool(name: str) -> RegisteredTool | None:
     """Return the registry entry for a name, or None if unregistered."""
     return _registry.get(name)
+
+
+def native_write_tool_names() -> frozenset[str]:
+    """Every registered tool that must stay native in code mode."""
+    return frozenset(t.name for t in _registry.values() if t.native_write)
 
 
 def registered_tool_names() -> list[str]:
@@ -90,9 +106,7 @@ def resolve_tools(names: Iterable[str]) -> list[ToolFunc]:
     for name in names:
         entry = _registry.get(name)
         if entry is None:
-            logger.warning(
-                "Tool has no registered callable; skipping", tool_name=name
-            )
+            logger.warning("Tool has no registered callable; skipping", tool_name=name)
             continue
         resolved.append(entry.func)
     return resolved

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/user_memory.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/user_memory.py
@@ -45,26 +45,45 @@ MEMORY_CATEGORIES = (
 MEMORY_WRITE_TOOL_NAMES: tuple[str, ...] = ("save_memory", "replace_memory")
 
 current_user_id: ContextVar[str | None] = ContextVar("current_user_id", default=None)
+# Attribution for writes made mid-turn (queue proposals): which agent
+# asked, in which conversation. Set by the same runtimes that bind the
+# user - a write with no author cannot be audited.
+current_agent_slug: ContextVar[str | None] = ContextVar(
+    "current_agent_slug", default=None
+)
+current_conversation_id: ContextVar[str | None] = ContextVar(
+    "current_conversation_id", default=None
+)
 
 # The user a single-tenant install writes memory for. Chat turns without an
 # authenticated user (the dashboard's own surfaces) resolve to this, so the
 # facts the assistant saves and the facts the dashboard lists are one store.
 DEFAULT_MEMORY_USER_ID = "0"
 
-@contextmanager
-def memory_user(user_id: str) -> Iterator[None]:
-    """Bind the turn's user so ``save_memory`` knows who it is saving for.
 
-    Every chat runtime wraps its model call in this. Without it the tool
-    has no identity, declines the write, and returns a plain string the
-    model reads as success - the user is told a fact was stored while
-    nothing reached the database.
+@contextmanager
+def memory_user(
+    user_id: str,
+    *,
+    agent_slug: str | None = None,
+    conversation_id: str | None = None,
+) -> Iterator[None]:
+    """Bind the turn's identity: whose turn, which agent, which chat.
+
+    Every chat runtime wraps its model call in this. Without it a
+    memory write has no owner (the tool declines and the model reads
+    the refusal as success), and a queue proposal has no author for
+    the audit trail.
     """
     token = current_user_id.set(user_id)
+    agent_token = current_agent_slug.set(agent_slug)
+    conversation_token = current_conversation_id.set(conversation_id)
     try:
         yield
     finally:
         current_user_id.reset(token)
+        current_agent_slug.reset(agent_token)
+        current_conversation_id.reset(conversation_token)
 
 
 SAVE_MEMORY_GUIDANCE = (
@@ -302,11 +321,13 @@ register_tool(
     "save_memory",
     save_memory,
     description="Persist one durable fact about the current user",
+    native_write=True,
     replace=True,
 )
 register_tool(
     "replace_memory",
     replace_memory,
     description="Replace all saved facts about the current user",
+    native_write=True,
     replace=True,
 )

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
@@ -5,45 +5,41 @@ conversation, gather contexts (from the mixin chain below), run the
 model, record usage, persist. Streaming lives in ``streaming.py``.
 """
 
-import uuid
 from datetime import UTC, datetime
-
+import uuid
 {% if ai_framework == "pydantic-ai" %}
 from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
 {% endif %}
 from app.core.log import logger
-from app.services.ai.domains.chat.titles import conversation_title
 from app.services.ai.config import AIServiceConfig
 from app.services.ai.domains.chat.agent_loader import (
     DEFAULT_AGENT_SLUG,
     resolve_agent,
 )
-from app.services.ai.models import Conversation, ConversationMessage, MessageRole
-from app.services.ai.service.base import (
-    AIServiceError,
-    ConversationError,
-{% if ai_framework == "pydantic-ai" %}
-    ProviderError,
-{% endif %}
-)
-from app.services.ai.service.prompt import PromptMixin
-{%- if ai_backend != "memory" %}
 from app.services.ai.domains.chat.module_context import render_memory_modules
+from app.services.ai.domains.chat.titles import conversation_title
 from app.services.ai.domains.chat.user_memory import (
     build_user_memory_context,
     memory_user,
 )
+from app.services.ai.models import Conversation, ConversationMessage, MessageRole
+from app.services.ai.service.base import (
+    AIServiceError,
+    ConversationError,
+{% if ai_framework == "pydantic-ai" %}    ProviderError,
+{% endif %})
+from app.services.ai.service.prompt import PromptMixin{%- if ai_backend != "memory" %}
+
 {%- endif %}
 {%- if include_finance and ai_backend != "memory" %}
+
 # Importing registers the finance host tools (ledger, accounts, quote)
 # so DB-granted names resolve in every process that serves chat - the
 # API, the CLI, and code-mode agents alike.
-import app.services.finance.ai_tools  # noqa: F401
-{%- endif %}
+import app.services.finance.ai_tools  # noqa: F401{%- endif %}
 {% if ai_rag %}
 from app.services.ai.domains.chat.rag_context import RAGContext
 {% endif %}
-
 
 class ChatMixin(PromptMixin):
     """Non-streaming chat turn plus conversation setup/teardown."""
@@ -59,8 +55,7 @@ class ChatMixin(PromptMixin):
         use_rag: bool = False,
         rag_collection: str | None = None,
         rag_top_k: int | None = None,
-{% endif %}
-    ) -> ConversationMessage:
+{% endif %}    ) -> ConversationMessage:
         """
         Send a chat message and get AI response.
 
@@ -77,7 +72,6 @@ class ChatMixin(PromptMixin):
             rag_collection: Collection to search (uses config default if None)
             rag_top_k: Number of results to retrieve (uses config default if None)
 {% endif %}
-
         Returns:
             ConversationMessage: The AI's response message
 
@@ -115,8 +109,7 @@ class ChatMixin(PromptMixin):
                     allowed_collections=agent_config.knowledge_base_ids,
                 )
 
-{% endif %}
-            # Build health context (always included, refreshed per message)
+{% endif %}            # Build health context (always included, refreshed per message)
             health_context, health_warning = await self._build_health_context()
 
             # Usage and model-catalog self-awareness belong to the
@@ -131,44 +124,42 @@ class ChatMixin(PromptMixin):
                 self._build_catalog_context() if is_default_agent else None
             )
 
-{% if ai_backend != "memory" %}
-            # Guarded per-user memory block (saved via the save_memory tool)
+{% if ai_backend != "memory" %}            # Guarded per-user memory block (saved via the save_memory tool)
             memory_context = await build_user_memory_context(user_id)
 
             # The agent row's memory modules (e.g. the finance snapshot)
             agent_modules_context = await render_memory_modules(
                 agent_config.memory_modules, user_id=user_id
             )
-
 {% endif %}
-{% if ai_rag %}
+{%- if ai_rag %}
             # Build RAG stats context (always included when RAG enabled)
             rag_stats_context = await self._build_rag_stats_context()
-
 {% endif %}
-{% if ai_framework == "pydantic-ai" %}
+{%- if ai_framework == "pydantic-ai" %}
             # Prepare agent and conversation context
             agent, conversation_context = self._prepare_agent_and_context(
                 conversation,
 {% if ai_rag %}
                 rag_context=rag_context,
                 rag_stats_context=rag_stats_context,
-{% endif %}
-                health_context=health_context,
+{% endif %}                health_context=health_context,
                 health_warning=health_warning,
                 usage_context=usage_context,
                 catalog_context=catalog_context,
                 agent_config=agent_config,
-{% if ai_backend != "memory" %}
-                memory_context=memory_context,
+{% if ai_backend != "memory" %}                memory_context=memory_context,
                 agent_modules_context=agent_modules_context,
-{% endif %}
-            )
+{% endif %}            )
 
             # Get AI response. The turn's user rides a ContextVar so a
             # memory write from inside the model call knows whose it is.
             start_time = datetime.now(UTC)
-            with memory_user(user_id):
+            with memory_user(
+                user_id,
+                agent_slug=agent_slug,
+                conversation_id=conversation.id,
+            ):
                 result = await agent.run(conversation_context)
             end_time = datetime.now(UTC)
             response_time_ms = (end_time - start_time).total_seconds() * 1000
@@ -198,11 +189,9 @@ class ChatMixin(PromptMixin):
                 MessageRole.ASSISTANT, result.content, message_id=str(uuid.uuid4())
             )
 {% endif %}
-
             # Store conversation ID in message metadata for easy lookup
             ai_message.metadata["conversation_id"] = conversation.id
             ai_message.metadata["response_time_ms"] = response_time_ms
-
 {% if ai_rag %}
             # Add RAG sources to response metadata if RAG was used
             if rag_context and rag_context.results:
@@ -210,7 +199,7 @@ class ChatMixin(PromptMixin):
                 ai_message.metadata["rag_collection"] = rag_context.collection
 
 {% endif %}
-{% if ai_backend != "memory" %}
+{%- if ai_backend != "memory" %}
             # Record usage tracking, attributed to the resolved agent
             usage = self._extract_usage(result)
             self._record_usage(f"chat:{agent_config.slug}", usage, user_id)
@@ -224,12 +213,10 @@ class ChatMixin(PromptMixin):
             ai_message.metadata["input_tokens"] = usage.get("input_tokens", 0)
             ai_message.metadata["output_tokens"] = output_tokens
 {% endif %}
-
             # Finalize conversation (update metadata and save)
             self._finalize_conversation(conversation, response_time_ms)
 
             return ai_message
-
 {% if ai_framework == "pydantic-ai" %}
         except (ModelRetry, UnexpectedModelBehavior) as e:
             error_msg = f"AI provider error: {e}"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/streaming.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/streaming.py.jinja
@@ -69,7 +69,6 @@ from app.services.ai.service.trace import (
 class StreamingMixin(ChatMixin):
     """Streaming variant of the chat turn."""
 {% if ai_framework == "pydantic-ai" %}
-
     @staticmethod
     def _tool_notice(
         tool_name: str,
@@ -89,7 +88,6 @@ class StreamingMixin(ChatMixin):
             metadata={"event": "tool", "tool": tool_name, "args": args},
         )
 {% endif %}
-
     async def stream_chat(
         self,
         message: str,
@@ -102,8 +100,7 @@ class StreamingMixin(ChatMixin):
         use_rag: bool = False,
         rag_collection: str | None = None,
         rag_top_k: int | None = None,
-{% endif %}
-    ) -> AsyncIterator[StreamingMessage]:
+{% endif %}    ) -> AsyncIterator[StreamingMessage]:
         """
         Stream a chat message with real-time response generation.
 
@@ -121,7 +118,6 @@ class StreamingMixin(ChatMixin):
             rag_collection: Collection to search (uses config default if None)
             rag_top_k: Number of results to retrieve (uses config default if None)
 {% endif %}
-
         Yields:
             StreamingMessage: Real-time message chunks
 
@@ -163,8 +159,7 @@ class StreamingMixin(ChatMixin):
                     allowed_collections=agent_config.knowledge_base_ids,
                 )
 
-{% endif %}
-            # Build health context (always included, refreshed per message)
+{% endif %}            # Build health context (always included, refreshed per message)
             health_context, health_warning = await self._build_health_context()
 
             # Usage and model-catalog self-awareness belong to the
@@ -178,13 +173,12 @@ class StreamingMixin(ChatMixin):
             catalog_context = (
                 self._build_catalog_context() if is_default_agent else None
             )
-
 {% if ai_rag %}
             # Build RAG stats context (always included when RAG enabled)
             rag_stats_context = await self._build_rag_stats_context()
 
 {% endif %}
-{% if ai_backend != "memory" %}
+{%- if ai_backend != "memory" %}
             # Guarded per-user memory block (saved via the save_memory tool)
             memory_context = await build_user_memory_context(user_id)
 
@@ -192,26 +186,22 @@ class StreamingMixin(ChatMixin):
             agent_modules_context = await render_memory_modules(
                 agent_config.memory_modules, user_id=user_id
             )
-
 {% endif %}
-{% if ai_framework == "pydantic-ai" %}
+{%- if ai_framework == "pydantic-ai" %}
             # Prepare agent and conversation context
             agent, conversation_context = self._prepare_agent_and_context(
                 conversation,
 {% if ai_rag %}
                 rag_context=rag_context,
                 rag_stats_context=rag_stats_context,
-{% endif %}
-                health_context=health_context,
+{% endif %}                health_context=health_context,
                 health_warning=health_warning,
                 usage_context=usage_context,
                 catalog_context=catalog_context,
                 agent_config=agent_config,
-{% if ai_backend != "memory" %}
-                memory_context=memory_context,
+{% if ai_backend != "memory" %}                memory_context=memory_context,
                 agent_modules_context=agent_modules_context,
-{% endif %}
-            )
+{% endif %}            )
 {% else %}
             # Prepare LLM and messages with full context
             llm, messages = self._prepare_llm_and_messages(
@@ -221,14 +211,12 @@ class StreamingMixin(ChatMixin):
                 conversation, None, None, health_context, health_warning, usage_context, catalog_context, agent_config=agent_config{% if ai_backend != "memory" %}, memory_context=memory_context{% endif %}
 {% endif %}
             )
-{% endif %}
-
+{%- endif %}
             # Start streaming
             start_time = datetime.now(UTC)
 
             # Generate a message ID for the streaming response
             message_id = str(uuid.uuid4())
-
 {% if ai_framework == "pydantic-ai" %}
             # Event-based streaming: unlike ``run_stream`` (which treats the
             # first text output as THE answer and stops), the event stream
@@ -242,7 +230,11 @@ class StreamingMixin(ChatMixin):
             # The turn's user rides a ContextVar for the whole stream:
             # a memory write lands mid-stream, inside a tool call, and
             # has no other way to know whose fact it is.
-            with memory_user(user_id):
+            with memory_user(
+                user_id,
+                agent_slug=agent_slug,
+                conversation_id=conversation.id,
+            ):
                 async with agent.run_stream_events(conversation_context) as events:
                     async for event in events:
                         text_chunk = ""
@@ -285,7 +277,7 @@ class StreamingMixin(ChatMixin):
                                 )
                             continue
                         elif isinstance(event, AgentRunResultEvent):
-    {% if ai_backend != "memory" %}
+{%- if ai_backend != "memory" %}
                             usage_obj = (
                                 event.result.usage()
                                 if callable(getattr(event.result, "usage", None))
@@ -293,14 +285,19 @@ class StreamingMixin(ChatMixin):
                             )
                             if usage_obj:
                                 stream_usage = {
-                                    "input_tokens": getattr(usage_obj, "input_tokens", 0)
+                                    "input_tokens": getattr(
+                                        usage_obj, "input_tokens", 0
+                                    )
                                     or 0,
-                                    "output_tokens": getattr(usage_obj, "output_tokens", 0)
+                                    "output_tokens": getattr(
+                                        usage_obj, "output_tokens", 0
+                                    )
                                     or 0,
                                 }
-    {% else %}
+{%- else %}
                             pass
-    {% endif %}
+{%- endif %}
+
                         if not text_chunk:
                             continue
 
@@ -322,7 +319,7 @@ class StreamingMixin(ChatMixin):
                                 "stream_delta": stream_delta,
                             },
                         )
-    {% else %}
+{%- else %}
             # Use LangChain's astream method for streaming
             async for chunk in llm.astream(messages):
                 # Get content from chunk
@@ -378,17 +375,17 @@ class StreamingMixin(ChatMixin):
                 }
 
 {% endif %}
-{% if ai_backend != "memory" %}
-{% if ai_framework == "pydantic-ai" %}
-            # Record usage tracking (PydanticAI provides streaming usage)
-            self._record_usage(f"stream_chat:{agent_config.slug}", stream_usage, user_id)
+{%- if ai_backend != "memory" %}
+{%- if ai_framework == "pydantic-ai" %}            # Record usage tracking (PydanticAI provides streaming usage)
+            self._record_usage(
+                f"stream_chat:{agent_config.slug}", stream_usage, user_id
+            )
 {% else %}
             # LangChain streaming doesn't provide token counts
             # Record with zero tokens - actual usage tracking requires non-streaming
             self._record_usage(f"stream_chat:{agent_config.slug}", {"input_tokens": 0, "output_tokens": 0}, user_id)
 {% endif %}
-{% endif %}
-
+{%- endif %}
             # Finalize conversation (update metadata and save)
             self._finalize_conversation(
                 conversation, response_time_ms, is_streaming=True
@@ -407,21 +404,18 @@ class StreamingMixin(ChatMixin):
             if output_tokens > 0 and response_time_ms > 0:
                 gen_tps = round(output_tokens * 1000 / response_time_ms, 1)
 {% endif %}
-
             final_metadata: dict[str, Any] = {
                 "provider": current.provider,
                 "model": current.model,
                 "response_time_ms": response_time_ms,
                 "stream_complete": True,
-{% if ai_backend != "memory" %}
-                # Token usage and cost for CLI status line
+{% if ai_backend != "memory" %}                # Token usage and cost for CLI status line
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 "cost": cost,
                 # TPS for performance monitoring (especially useful for Ollama)
                 "gen_tps": gen_tps,
-{% endif %}
-            }
+{% endif %}            }
 {% if ai_rag %}
             final_metadata.update(rag_metadata)
 {% endif %}
@@ -436,8 +430,7 @@ class StreamingMixin(ChatMixin):
                 metadata=final_metadata,
             )
 
-{% if ai_framework == "pydantic-ai" %}
-        except (ModelRetry, UnexpectedModelBehavior) as e:
+{% if ai_framework == "pydantic-ai" %}        except (ModelRetry, UnexpectedModelBehavior) as e:
             error_msg = f"AI provider streaming error: {e}"
             logger.error(error_msg)
             raise ProviderError(error_msg) from e

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/trace.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/trace.py.jinja
@@ -79,9 +79,49 @@ def record_tool_result(
     content = event.part.content
     text = content if isinstance(content, str) else json.dumps(content, default=str)
     entry["result"] = text[:_TRACE_RESULT_CAP]
+    marker = _component_marker(name, content, text)
+    if marker is not None:
+        entry["component"] = marker
     nested = nested_tool_calls(event)
     if nested:
         entry["nested"] = [{"tool": n, "args": a} for n, a in nested]
+
+
+def _component_marker(name: str, content: Any, text: str) -> dict[str, Any] | None:
+    """A compact, parse-safe payload for results the UI must RENDER.
+
+    The result field above is clipped for display; a large proposal
+    batch truncates to invalid JSON, and a card built by parsing it
+    silently vanished. The card needs only identity - the queue is
+    fetched for the rows - so identity rides here, under any cap.
+    """
+    if name not in ("propose", "propose_many"):
+        return None
+    data: Any = content
+    if isinstance(content, str):
+        try:
+            data = json.loads(text if len(text) < _TRACE_RESULT_CAP else content)
+        except (TypeError, ValueError):
+            return None
+    if not isinstance(data, dict) or data.get("error"):
+        return None
+    if data.get("batch_id"):
+        return {
+            "kind": "pending_change_batch",
+            "batch_id": data["batch_id"],
+            "change_type": data.get("change_type"),
+            "title": data.get("title"),
+            "count": data.get("count"),
+        }
+    if data.get("pending_change_id"):
+        return {
+            "kind": "pending_change",
+            "pending_change_id": data["pending_change_id"],
+            "change_type": data.get("change_type"),
+            "title": data.get("title"),
+            "status": data.get("status", "pending"),
+        }
+    return None
 
 
 def nested_tool_calls(event: FunctionToolResultEvent) -> list[tuple[str, str]]:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_tools.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_tools.py.jinja
@@ -406,8 +406,6 @@ async def quote(ticker: str) -> dict[str, Any]:
 
 # Built-in registration: importing this module makes the tools grantable
 # via the agent registry. replace=True keeps re-imports idempotent.
-# Built-in registration: importing this module makes the tools grantable
-# via the agent registry. replace=True keeps re-imports idempotent.
 
 
 register_tool(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_tools.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_tools.py.jinja
@@ -22,6 +22,7 @@ from typing import Any
 
 from app.core.db import get_async_session
 from app.services.ai.domains.chat.tools import register_tool
+from app.services.finance.constants import UNCATEGORIZED_CATEGORY_NAMES
 from app.services.finance.domains.investments import queries as investment_queries
 from app.services.finance.domains.investments.securities import (
     list_current_holdings,
@@ -37,14 +38,17 @@ from app.services.finance.domains.ledger.properties import (
     secured_position,
 )
 from app.services.finance.domains.ledger.queries.accounts import accounts_page
-from app.services.finance.domains.ledger.valuations import preferred_valuation_row
 from app.services.finance.domains.ledger.queries.categories import (
     category_names_by_id,
 )
 from app.services.finance.domains.ledger.queries.transactions import (
     transactions_window_with_payees,
 )
-from app.services.finance.domains.ledger.transactions import monthly_cashflow
+from app.services.finance.domains.ledger.transactions import (
+    monthly_cashflow,
+    transaction_tags,
+)
+from app.services.finance.domains.ledger.valuations import preferred_valuation_row
 from app.services.finance.domains.planning.envelopes import envelope_metadata
 from app.services.finance.domains.planning.goals import goal_metadata
 from app.services.finance.domains.planning.recurring import (
@@ -120,12 +124,18 @@ async def ledger(months: int = 12, detail: str = "monthly") -> dict[str, Any]:
             page=1,
             page_size=500,
         )
+        tags_by_txn = await transaction_tags(
+            session, [t.id for t, _name in rows if t.id is not None]
+        )
     account_names = {account.id: account.name for account in account_rows}
     return {
         "total": total,
         "returned": len(rows),
         "transactions": [
             {
+                # The id is what a transaction.categorize proposal's
+                # 'transaction_id' takes - names alone cannot propose.
+                "id": txn.id,
                 "date": txn.date_.isoformat(),
                 # Curated merchant name first - what the register shows -
                 # then the provider's merchant string, then the raw
@@ -134,7 +144,18 @@ async def ledger(months: int = 12, detail: str = "monthly") -> dict[str, Any]:
                 "payee": curated_name or txn.merchant_name or txn.name,
                 "amount_cents": txn.amount,
                 "category": category_names.get(txn.category_id),
+                "category_id": txn.category_id,
+                # True for BOTH shapes of uncategorized: no category at
+                # all, or the import catch-all bucket ("Uncategorized",
+                # "Misc", ...). Filtering category is None alone misses
+                # the second shape - a model burned four runs on that.
+                "uncategorized": txn.category_id is None
+                or (category_names.get(txn.category_id) or "").lower()
+                in UNCATEGORIZED_CATEGORY_NAMES,
                 "account": account_names.get(txn.account_id),
+                # The label axis, orthogonal to category ("Business" on
+                # a Software row) - what tag rollups compute over.
+                "tags": sorted(t.name for t in tags_by_txn.get(txn.id, [])),
                 "pending": txn.pending,
             }
             for txn, curated_name in rows
@@ -293,7 +314,6 @@ async def accounts() -> dict[str, Any]:
                 "is_estimate": (
                     valuation.is_estimate if valuation is not None else None
                 ),
-
                 "purchase_price_cents": property_meta.purchase_price,
                 "purchase_date": (
                     property_meta.purchase_date.isoformat()
@@ -364,9 +384,7 @@ async def quote(ticker: str) -> dict[str, Any]:
         security = await investment_queries.security_by_ticker(session, symbol)
         if security is None or security.id is None:
             return {"found": False, "ticker": symbol}
-        price = await investment_queries.latest_price_for_security(
-            session, security.id
-        )
+        price = await investment_queries.latest_price_for_security(session, security.id)
     if price is None:
         return {"found": False, "ticker": symbol}
     # Normalize to cents in integer arithmetic regardless of the row's
@@ -388,6 +406,10 @@ async def quote(ticker: str) -> dict[str, Any]:
 
 # Built-in registration: importing this module makes the tools grantable
 # via the agent registry. replace=True keeps re-imports idempotent.
+# Built-in registration: importing this module makes the tools grantable
+# via the agent registry. replace=True keeps re-imports idempotent.
+
+
 register_tool(
     "ledger",
     ledger,
@@ -405,6 +427,18 @@ register_tool(
     quote,
     description="Latest stored closing price for a ticker",
     replace=True,
+)
+
+# The write-side tools (and the id lookup they need) live in their own
+# module; importing it here keeps "import ai_tools" the one line that
+# registers the whole finance tool surface.
+from app.services.finance.ai_write_tools import (  # noqa: E402,F401
+    bill_candidates,
+    bills,
+    categories,
+    propose,
+    propose_many,
+    tags,
 )
 {% else %}"""Finance host tools ship only with the AI service on a persistent backend."""
 {% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_write_tools.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/ai_write_tools.py.jinja
@@ -1,0 +1,244 @@
+{% if include_ai and ai_backend != "memory" %}"""The finance write surface for agents: propose, never mutate.
+
+Split from ``ai_tools`` (the read surface): the tools that file pending
+changes for the user's approval, plus ``categories``, the id lookup a
+categorize payload needs. The write tools register ``native_write``, so
+code mode dispatches them as visible calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.core.db import get_async_session
+from app.services.ai.domains.chat.tools import register_tool
+
+
+async def propose_many(
+    change_type: str, payloads: list[dict[str, Any]]
+) -> dict[str, Any]:
+    """Propose MANY changes of one type as a single batch the user
+    resolves together ("approve them all"), with a per-row veto. Use
+    this whenever more than one change of the same type is wanted - a
+    batch renders as one card, not a pile. Max 100 per batch; every
+    payload follows the change type's contract. Never claim the changes
+    happened - they are pending until the user acts.
+    """
+    from app.services.ai.domains.chat.user_memory import (
+        current_agent_slug,
+        current_conversation_id,
+    )
+    from app.services.finance.domains import writes
+
+    async with get_async_session() as session:
+        try:
+            rows = await writes.propose_many(
+                session,
+                change_type,
+                payloads,
+                owner_user_id=None,
+                proposed_by_agent=current_agent_slug.get(),
+                conversation_id=current_conversation_id.get(),
+            )
+            items = [
+                {
+                    "id": row.id,
+                    "pending_change_id": row.id,
+                    "status": row.status,
+                    "display": await writes.describe_change(session, row),
+                }
+                for row in rows
+            ]
+            await session.commit()
+        except ValueError as e:
+            return {
+                "error": str(e),
+                "registered_change_types": list(writes.registered_change_types()),
+            }
+    return {
+        "batch_id": rows[0].batch_id,
+        "change_type": change_type,
+        "title": writes.executor_for(change_type).title,
+        "count": len(items),
+        "items": items,
+    }
+
+
+async def categories() -> dict[str, Any]:
+    """Every assignable category: 'id', 'name' and 'classification'
+    ('expense' | 'income' | 'transfer'). The id is what a
+    transaction.categorize proposal's 'category_id' takes.
+    """
+    from sqlmodel import select
+
+    from app.services.finance.models import FinanceCategory
+
+    async with get_async_session() as session:
+        rows = (
+            await session.exec(
+                select(FinanceCategory)
+                .where(FinanceCategory.is_archived == False)  # noqa: E712
+                .order_by(FinanceCategory.name)
+            )
+        ).all()
+    return {
+        "categories": [
+            {"id": row.id, "name": row.name, "classification": row.classification}
+            for row in rows
+        ]
+    }
+
+
+async def bills() -> dict[str, Any]:
+    """Every live bill and income stream: 'id', 'name', 'direction'
+    ('outflow' | 'inflow'), 'frequency', 'expected_amount' (cents),
+    'next_expected_date' and 'last_date' (ISO or null). The id is what
+    a recurring.match proposal's 'stream_id' takes."""
+    from app.services.finance.domains.planning.recurring import queries
+
+    async with get_async_session() as session:
+        rows = await queries.active_streams(session, owner_user_id=None)
+    return {
+        "bills": [
+            {
+                "id": s.id,
+                "name": s.name,
+                "direction": s.direction,
+                "frequency": s.frequency,
+                "expected_amount": s.expected_amount,
+                "average_amount": s.average_amount,
+                "next_expected_date": (
+                    s.next_expected_date.isoformat() if s.next_expected_date else None
+                ),
+                "last_date": s.last_date.isoformat() if s.last_date else None,
+            }
+            for s in rows
+        ]
+    }
+
+
+async def bill_candidates(stream_id: int) -> dict[str, Any]:
+    """The ranked shortlist of unclaimed transactions that could be this
+    bill's payment - the same heuristic the app's manual match picker
+    uses (direction, amount band, due-date window, name affinity).
+    Each candidate's 'id' is what a recurring.match proposal's
+    'transaction_id' takes. Propose matches ONLY from this list."""
+    from app.services.finance.domains.planning.recurring.matching import (
+        recurring_match_candidates,
+    )
+
+    async with get_async_session() as session:
+        rows = await recurring_match_candidates(session, stream_id, owner_user_id=None)
+    return {
+        "stream_id": stream_id,
+        "candidates": [
+            {
+                "id": t.id,
+                "date": t.date_.isoformat(),
+                "payee": t.merchant_name or t.name,
+                "amount": t.amount,
+                "account_id": t.account_id,
+            }
+            for t in rows
+        ],
+    }
+
+
+async def tags() -> dict[str, Any]:
+    """Every live tag with how many transactions wear it: 'id', 'name',
+    'count'. Tags are the label axis ORTHOGONAL to categories (a
+    "Business" tag on a Software-categorized row). A transaction.tag
+    payload takes the NAME - reuse an existing spelling from here before
+    coining a new one."""
+    from app.services.finance.domains.ledger.transactions import list_tags
+
+    async with get_async_session() as session:
+        rows = await list_tags(session, owner_user_id=None)
+    return {"tags": [{"id": t.id, "name": t.name, "count": count} for t, count in rows]}
+
+
+async def propose(change_type: str, payload: dict[str, Any]) -> dict[str, Any]:
+    """Propose a finance mutation for the user's approval. The ONLY
+    write tool: nothing moves until the user approves the pending
+    change in the app, and execution happens exclusively there.
+
+    ``change_type`` must be a registered type (see the error message
+    for the current vocabulary); ``payload`` is that type's exact
+    mutation contract. Returns the pending change's id, status and the
+    human-readable description the approval card will show. Propose
+    ONE change per call; never claim a change happened - it is pending
+    until the user acts.
+    """
+    from app.services.ai.domains.chat.user_memory import (
+        current_agent_slug,
+        current_conversation_id,
+    )
+    from app.services.finance.domains import writes
+
+    async with get_async_session() as session:
+        try:
+            row = await writes.propose(
+                session,
+                change_type,
+                payload,
+                owner_user_id=None,
+                proposed_by_agent=current_agent_slug.get(),
+                conversation_id=current_conversation_id.get(),
+            )
+            display = await writes.describe_change(session, row)
+            await session.commit()
+        except ValueError as e:
+            return {
+                "error": str(e),
+                "registered_change_types": list(writes.registered_change_types()),
+            }
+    return {
+        "pending_change_id": row.id,
+        "change_type": row.change_type,
+        "title": writes.executor_for(row.change_type).title,
+        "status": row.status,
+        "display": display,
+    }
+
+
+# Built-in registration: importing this module makes the tools grantable
+# via the agent registry. replace=True keeps re-imports idempotent.
+register_tool(
+    "categories",
+    categories,
+    description="Assignable categories with the ids proposals need",
+    replace=True,
+)
+register_tool(
+    "bills",
+    bills,
+    description="Live bills and income streams with the ids matches need",
+    replace=True,
+)
+register_tool(
+    "bill_candidates",
+    bill_candidates,
+    description="Ranked unclaimed transactions that could be a bill's payment",
+    replace=True,
+)
+register_tool(
+    "tags",
+    tags,
+    description="The tag directory: names, ids and usage counts",
+    replace=True,
+)
+register_tool(
+    "propose",
+    propose,
+    description="Propose a finance change for the user's approval (the only write)",
+    native_write=True,
+    replace=True,
+)
+register_tool(
+    "propose_many",
+    propose_many,
+    description="Propose a batch of same-type changes for one bulk approval",
+    native_write=True,
+    replace=True,
+)
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/__init__.py
@@ -5,6 +5,9 @@ merchants). ``planning`` is what that past implies about the future
 (budgets, goals, envelopes, recurring streams). ``detection`` is the
 passes that infer facts nobody typed (transfers, rhythms, insights).
 ``investments`` is securities and the positions held in them.
+``writes`` is the propose/approve queue - the ONE door through which an
+assistant's mutation can reach any of the others, and only with the
+user's approval.
 
 Each is function-style (``async def foo(db, ...)``) and owns its own
 ``queries`` module. They speak the shared vocabulary in

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/detection/analyst/prompts.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/detection/analyst/prompts.py.jinja
@@ -5,9 +5,6 @@ SEED CONTENT ONLY: the agent rows in the database are the runtime source
 first populates those rows, and the fallback when a row is missing.
 """
 
-
-
-
 # Sampling: low temperature because the job is faithful restatement, not
 # invention. The token ceiling covers a full sectioned report (~300 words is
 # ~400 tokens) with headroom for a reasoning model that spends output tokens
@@ -27,7 +24,6 @@ DEEP_DIVE_TEMPERATURE = 0.3
 DEEP_DIVE_MAX_TOKENS = 6_000
 
 
-
 # The invariants, in one place because BOTH prompts must obey them and a
 # copy in each is a copy that drifts. Embedded, not appended, so each
 # prompt keeps its own section order.
@@ -41,8 +37,6 @@ markdown, no emoji, no sign-off - the application owns the layout.
 upcoming payments; mention one only when it explains a finding or a risk.
 - Prefer saying what a figure MEANS over repeating it. The report already \
 prints the numbers beside your words."""
-
-
 
 
 ANALYST_SYSTEM_PROMPT = f"""\
@@ -83,8 +77,6 @@ has changed about it, or lead with the next most important thing.
 Never describe a partial month as if it were a whole one.
 - Keep each field under 60 words.
 """
-
-
 
 
 DEEP_DIVE_SYSTEM_PROMPT = f"""\
@@ -180,6 +172,42 @@ ONE script, compute, and print only the final figures - state persists, \
 so never re-fetch data you already hold. Aim for one script per answer, \
 two when the first run genuinely surprises you.
 
+## PROPOSING CHANGES
+
+You cannot mutate the ledger directly, and you never claim you can't \
+help with a change - you PROPOSE it. propose(change_type, payload) files \
+a pending change the user approves or rejects in the app; nothing \
+happens until they act, so propose confidently whenever the user asks \
+for a change you have a change_type for.
+
+- `transaction.categorize` - payload {"transaction_id": int, \
+"category_id": int}. Get the transaction id from \
+ledger(detail="transactions") rows; get the category id from \
+categories().
+- `recurring.match` - payload {"transaction_id": int, "stream_id": int}: \
+records which payment paid which bill. Get the bill's stream_id from \
+bills(); get the transaction_id ONLY from bill_candidates(stream_id) - \
+it ranks unclaimed payments with the same heuristic the app's match \
+picker uses. Never match from your own similarity guess: if the payment \
+is not in the shortlist, say so instead of proposing.
+- `transaction.tag` / `transaction.untag` - payload {"transaction_id": \
+int, "tag": str}. Tags are the label axis ORTHOGONAL to categories: a \
+row keeps its natural category (Software, Meals) and wears tags like \
+"Business" on top, so one lens rolls up without a pile of \
+business-flavored categories. The payload takes the tag NAME - check \
+tags() first and reuse an existing spelling; a new name is created on \
+first approval. Ledger rows carry their current 'tags', so tag rollups \
+(e.g. total business spend) are computed from the data, never guessed.
+- One change per propose call. For SEVERAL changes of the same type \
+(e.g. "categorize all the uncategorized ones"), call \
+propose_many(change_type, payloads) instead - the user gets one card \
+with a per-row veto and an approve-all, not a pile of cards.
+- After proposing, do NOT announce the card - the user sees it under \
+your message. One short sentence on what you matched or chose is \
+enough; never say the change happened.
+- If no registered change_type fits, say the app cannot do that yet - \
+the propose error lists what is registered.
+
 ## MEMORY
 
 The snapshot and your tools cover everything the ledger knows. Anything \
@@ -200,13 +228,30 @@ appraisal, statement. A saved number is not an appraisal.
 
 ## SANDBOX RULES
 
+run_code is NOT a REPL. Every call carries a COMPLETE script - fetch,
+compute, print - and a typical answer is exactly ONE run_code call
+(state persists, so a second run is only for when the first result
+genuinely surprises you). Six one-line calls is a defect, not caution.
+
+One complete script looks like:
+
+    data = await ledger(months=2, detail="transactions")
+    unc = [r for r in data["transactions"] if r["uncategorized"]]
+    for r in unc:
+        print(r["id"], r["date"], r["payee"], r["amount_cents"])
+
 run_code executes Monty, a strict Python subset. Scripts that break these \
 rules fail:
 
+- If a run fails, FIX the script and resubmit it WHOLE - never fall back \
+to line-at-a-time execution.
+
 - Tools are async: call them with plain top-level `await`. Do not define a \
 `main()` wrapper or call `asyncio.run` - top-level await already works.
-- `asyncio.gather` takes positional awaitables only; keyword arguments \
-like `return_exceptions` are unsupported.
+- Everything is already async - just `await` each tool directly, one \
+after another. You never need the `asyncio` MODULE (`gather`, `run`): \
+the tools are millisecond reads, so concurrency saves nothing, and \
+`asyncio.gather` without its import is this sandbox's most common crash.
 - Show results ONLY by print()-ing plain data (strings, numbers, lists, \
 dicts). Never end a script on a bare non-data expression such as \
 `type(x)` - the tool report cannot carry it. `json.dumps` extras like \

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/detection/analyst/seeds.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/detection/analyst/seeds.py.jinja
@@ -1,30 +1,43 @@
-{% if include_ai and ai_backend != "memory" %}"""The database handoff: agent + memory-module seed rows and their loader.
-"""
+{% if include_ai and ai_backend != "memory" %}"""The database handoff: agent + memory-module seed rows and their loader."""
 
 from typing import Any
+
 from sqlmodel import (
     Session,
     select,
 )
-from app.core.log import logger
 
-# Registers the finance host tools (ledger/accounts/quote) by import, so a
-# bare seeding process gets their ``tool`` rows and the grants below
-# resolve. Same reason the ai fixtures import their built-ins.
-import app.services.finance.ai_tools  # noqa: F401
+from app.core.log import logger
 from app.services.ai.models.agents import (
     Agent,
     AgentTool,
     MemoryModule,
     Tool,
 )
-from app.services.finance.domains.detection.analyst.prompts import ANALYST_MAX_TOKENS, ANALYST_SYSTEM_PROMPT, ANALYST_TEMPERATURE, DEEP_DIVE_MAX_TOKENS, DEEP_DIVE_SYSTEM_PROMPT, DEEP_DIVE_TEMPERATURE, FINANCE_CHAT_MAX_TOKENS, FINANCE_CHAT_SYSTEM_PROMPT, FINANCE_CHAT_TEMPERATURE
-from app.services.finance.domains.detection.analyst.shared import ANALYST_AGENT_SLUG, DEEP_DIVE_AGENT_SLUG, FINANCE_CHAT_AGENT_SLUG, SNAPSHOT_MODULE_SLUG
 
+# Registers the finance host tools (ledger/accounts/quote) by import, so a
+# bare seeding process gets their ``tool`` rows and the grants below
+# resolve. Same reason the ai fixtures import their built-ins.
+import app.services.finance.ai_tools  # noqa: F401
+from app.services.finance.domains.detection.analyst.prompts import (
+    ANALYST_MAX_TOKENS,
+    ANALYST_SYSTEM_PROMPT,
+    ANALYST_TEMPERATURE,
+    DEEP_DIVE_MAX_TOKENS,
+    DEEP_DIVE_SYSTEM_PROMPT,
+    DEEP_DIVE_TEMPERATURE,
+    FINANCE_CHAT_MAX_TOKENS,
+    FINANCE_CHAT_SYSTEM_PROMPT,
+    FINANCE_CHAT_TEMPERATURE,
+)
+from app.services.finance.domains.detection.analyst.shared import (
+    ANALYST_AGENT_SLUG,
+    DEEP_DIVE_AGENT_SLUG,
+    FINANCE_CHAT_AGENT_SLUG,
+    SNAPSHOT_MODULE_SLUG,
+)
 
 SNAPSHOT_TOKEN_ESTIMATE = 1_200
-
-
 
 
 def snapshot_module_definition() -> dict[str, Any]:
@@ -48,8 +61,6 @@ def snapshot_module_definition() -> dict[str, Any]:
     }
 
 
-
-
 def analyst_agent_definition() -> dict[str, Any]:
     """The seed row for the finance analyst agent.
 
@@ -69,8 +80,6 @@ def analyst_agent_definition() -> dict[str, Any]:
         "knowledge_base_ids": [],
         "is_active": True,
     }
-
-
 
 
 def deep_dive_agent_definition() -> dict[str, Any]:
@@ -95,8 +104,6 @@ def deep_dive_agent_definition() -> dict[str, Any]:
     }
 
 
-
-
 # The chat agent's data surface: the finance host tools registered by
 # ``app.services.finance.ai_tools``. Attachment is by name against the
 # tool rows the fixture sync seeds; a missing row is skipped, never an
@@ -105,10 +112,26 @@ FINANCE_CHAT_TOOL_NAMES = (
     "ledger",
     "accounts",
     "quote",
-    # The one write: durable facts the user states about their money
-    # (a property value, a bill no connection reports) outlive the
-    # conversation. Not a ledger write - that rides the approval queue.
+    # The ids a proposal's payload takes - names alone cannot propose.
+    "categories",
+    # The bill surface: live streams, and the ranked shortlist of
+    # unclaimed payments the app's own match picker uses - matches are
+    # proposed FROM the shortlist, never from lookalike guessing.
+    "bills",
+    "bill_candidates",
+    # The tag directory: the label axis a transaction.tag payload
+    # names; listed so spellings are reused, not coined per turn.
+    "tags",
+    # The one memory write: durable facts the user states about their
+    # money (a property value, a bill no connection reports) outlive
+    # the conversation.
     "save_memory",
+    # The one LEDGER write, and it does not write: it files a pending
+    # change the user approves in the app (FW-05). Registered
+    # native_write, so it surfaces as its own visible call.
+    "propose",
+    # Same contract, many rows, one approval card with per-row veto.
+    "propose_many",
 )
 
 
@@ -142,9 +165,12 @@ def _attach_chat_tools(session: Session) -> int:
     ).first()
     if agent is None or agent.id is None:
         return 0
-    linked = {link.tool_id for link in session.exec(
-        select(AgentTool).where(AgentTool.agent_id == agent.id)
-    ).all()}
+    linked = {
+        link.tool_id
+        for link in session.exec(
+            select(AgentTool).where(AgentTool.agent_id == agent.id)
+        ).all()
+    }
     attached = 0
     for name in FINANCE_CHAT_TOOL_NAMES:
         tool = session.exec(select(Tool).where(Tool.name == name)).first()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/streams.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/streams.py
@@ -172,7 +172,9 @@ async def attach_transaction_to_stream(
     charge for the record must not re-arm July's nag.
     """
     stream = await get_recurring(db, stream_id, owner_user_id)
-    if stream is None:
+    if stream is None or stream.deleted_at is not None:
+        # A queued match proposal can outlive its bill; attaching to a
+        # deleted stream would resurrect it as a phantom claim.
         return None
     txn = await ledger_queries.transaction_by_id(
         db, transaction_id, owner_user_id=owner_user_id

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/__init__.py
@@ -1,0 +1,43 @@
+"""The propose/approve write queue (FW-05).
+
+Importing this package registers the built-in change types - an
+executor that is never imported does not exist to the queue, the same
+rule the tool registry lives by.
+"""
+
+from app.services.finance.domains.writes import executors as executors
+from app.services.finance.domains.writes.queue import (
+    approve,
+    approve_batch,
+    batch_rows,
+    describe_change,
+    get_change,
+    list_changes,
+    propose,
+    propose_many,
+    reject,
+    reject_batch,
+)
+from app.services.finance.domains.writes.registry import (
+    ChangeExecutor,
+    executor_for,
+    register,
+    registered_change_types,
+)
+
+__all__ = [
+    "ChangeExecutor",
+    "approve",
+    "reject_batch",
+    "propose_many",
+    "batch_rows",
+    "approve_batch",
+    "describe_change",
+    "executor_for",
+    "get_change",
+    "list_changes",
+    "propose",
+    "register",
+    "registered_change_types",
+    "reject",
+]

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/executors.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/executors.py
@@ -1,0 +1,259 @@
+"""The registered change types. FW-05 ships one - categorize - to prove
+the loop end to end; FW-06..09 add theirs HERE, one entry each."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.finance.domains.detection.insights.formatting import format_usd
+from app.services.finance.domains.ledger import categories, transactions
+from app.services.finance.domains.writes.registry import ChangeExecutor, register
+
+
+class CategorizePayload(BaseModel):
+    """The exact mutation: which transaction, which category. ``extra``
+    is forbidden so a proposal cannot smuggle fields no executor reads
+    but a card might display."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transaction_id: int
+    category_id: int
+
+
+async def _categorize_execute(
+    db: AsyncSession, payload: CategorizePayload, owner_user_id: int | None
+) -> dict[str, Any]:
+    txn = await categories.categorize_transaction(
+        db,
+        payload.transaction_id,
+        payload.category_id,
+        owner_user_id=owner_user_id,
+        source="user",
+    )
+    if txn is None:
+        raise ValueError(f"Transaction {payload.transaction_id} not found.")
+    return {"transaction_id": txn.id, "category_id": payload.category_id}
+
+
+async def _txn_subject(
+    db: AsyncSession, transaction_id: int, owner_user_id: int | None
+) -> tuple[Any, str]:
+    """The row and its card-ready one-liner: the register's curated
+    payee (never the raw bank descriptor), amount, date. Every
+    describe renders the same subject the same way."""
+    txn = await transactions.get_transaction(
+        db, transaction_id, owner_user_id=owner_user_id
+    )
+    subject = (
+        f"{txn.merchant_name or txn.name} "
+        f"({format_usd(abs(txn.amount))} on {txn.date_})"
+        if txn is not None
+        else f"transaction {transaction_id} (missing)"
+    )
+    return txn, subject
+
+
+async def _categorize_describe(
+    db: AsyncSession, payload: CategorizePayload, owner_user_id: int | None
+) -> list[dict[str, str]]:
+    txn, subject = await _txn_subject(db, payload.transaction_id, owner_user_id)
+    wanted = [payload.category_id]
+    if txn is not None and txn.category_id is not None:
+        wanted.append(txn.category_id)
+    names = await categories.category_names(db, wanted)
+    # A recategorization is a MOVE: show what it moves FROM, resolved
+    # from the row at read time - if the category changed since the
+    # proposal, the card shows the current truth.
+    before = (
+        names.get(txn.category_id, "Uncategorized")
+        if txn is not None and txn.category_id is not None
+        else "Uncategorized"
+    )
+    after = names.get(payload.category_id, f"category {payload.category_id}")
+    return [
+        {"label": "Transaction", "value": subject},
+        {"label": "Category", "value": f"{before} \u2192 {after}"},
+    ]
+
+
+class MatchPayload(BaseModel):
+    """Which payment paid which bill."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transaction_id: int
+    stream_id: int
+
+
+async def _match_execute(
+    db: AsyncSession, payload: MatchPayload, owner_user_id: int | None
+) -> dict[str, Any]:
+    from app.services.finance.domains.planning.recurring import streams
+
+    stream = await streams.attach_transaction_to_stream(
+        db,
+        payload.transaction_id,
+        payload.stream_id,
+        owner_user_id=owner_user_id,
+    )
+    if stream is None:
+        raise ValueError(
+            f"Transaction {payload.transaction_id} or bill "
+            f"{payload.stream_id} not found."
+        )
+    return {
+        "transaction_id": payload.transaction_id,
+        "stream_id": stream.id,
+        "next_expected_date": (
+            stream.next_expected_date.isoformat() if stream.next_expected_date else None
+        ),
+    }
+
+
+async def _match_describe(
+    db: AsyncSession, payload: MatchPayload, owner_user_id: int | None
+) -> list[dict[str, str]]:
+    from app.services.finance.domains.planning.recurring import streams
+
+    txn, subject = await _txn_subject(db, payload.transaction_id, owner_user_id)
+    stream = await streams.get_recurring(db, payload.stream_id, owner_user_id)
+    # A match is a MOVE too: from whichever live bill holds the row now
+    # (usually none) to the proposed one, read from the row so the card
+    # shows the current truth.
+    before = "Unmatched"
+    if txn is not None and txn.recurring_stream_id is not None:
+        holder = await streams.get_recurring(db, txn.recurring_stream_id, owner_user_id)
+        if holder is not None:
+            before = holder.name
+    after = stream.name if stream is not None else f"bill {payload.stream_id} (missing)"
+    return [
+        {"label": "Payment", "value": subject},
+        {"label": "Bill", "value": f"{before} \u2192 {after}"},
+    ]
+
+
+class TagPayload(BaseModel):
+    """Which transaction, which label. The tag is a NAME - created on
+    first use, resolved by normalized spelling after that - because the
+    label vocabulary belongs to the user, not to an id table the model
+    would have to pre-populate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    transaction_id: int
+    tag: str
+
+
+async def _tag_names(db: AsyncSession, transaction_id: int) -> list[str]:
+    current = await transactions.transaction_tags(db, [transaction_id])
+    return sorted(t.name for t in current.get(transaction_id, []))
+
+
+def _tag_rows(
+    subject: str, before: list[str], after: list[str]
+) -> list[dict[str, str]]:
+    return [
+        {"label": "Transaction", "value": subject},
+        {
+            "label": "Tags",
+            "value": f"{', '.join(before) or 'none'} \u2192 "
+            f"{', '.join(after) or 'none'}",
+        },
+    ]
+
+
+async def _tag_execute(
+    db: AsyncSession, payload: TagPayload, owner_user_id: int | None
+) -> dict[str, Any]:
+    txn = await transactions.get_transaction(
+        db, payload.transaction_id, owner_user_id=owner_user_id
+    )
+    if txn is None:
+        raise ValueError(f"Transaction {payload.transaction_id} not found.")
+    tag = await transactions.tag_transactions(
+        db, [payload.transaction_id], payload.tag, owner_user_id=owner_user_id
+    )
+    return {"transaction_id": payload.transaction_id, "tag_id": tag.id}
+
+
+async def _tag_describe(
+    db: AsyncSession, payload: TagPayload, owner_user_id: int | None
+) -> list[dict[str, str]]:
+    _txn, subject = await _txn_subject(db, payload.transaction_id, owner_user_id)
+    before = await _tag_names(db, payload.transaction_id)
+    after = sorted(set(before) | {payload.tag.strip()})
+    return _tag_rows(subject, before, after)
+
+
+async def _untag_execute(
+    db: AsyncSession, payload: TagPayload, owner_user_id: int | None
+) -> dict[str, Any]:
+    from app.services.finance.domains.ledger.queries import transactions as queries
+    from app.services.finance.utils import normalize_payee
+
+    store_owner = 0 if owner_user_id is None else owner_user_id
+    tag = await queries.tag_by_normalized_name(
+        db, store_owner=store_owner, normalized=normalize_payee(payload.tag)
+    )
+    if tag is None or tag.id is None:
+        raise ValueError(f'No tag named "{payload.tag}" exists.')
+    removed = await transactions.untag_transactions(
+        db, [payload.transaction_id], tag.id, owner_user_id=owner_user_id
+    )
+    return {
+        "transaction_id": payload.transaction_id,
+        "tag_id": tag.id,
+        "removed": removed,
+    }
+
+
+async def _untag_describe(
+    db: AsyncSession, payload: TagPayload, owner_user_id: int | None
+) -> list[dict[str, str]]:
+    _txn, subject = await _txn_subject(db, payload.transaction_id, owner_user_id)
+    before = await _tag_names(db, payload.transaction_id)
+    wanted = payload.tag.strip().casefold()
+    after = [n for n in before if n.casefold() != wanted]
+    return _tag_rows(subject, before, after)
+
+
+register(
+    ChangeExecutor(
+        change_type="transaction.categorize",
+        title="Categorize a transaction",
+        payload_model=CategorizePayload,
+        execute=_categorize_execute,
+        describe=_categorize_describe,
+    )
+)
+register(
+    ChangeExecutor(
+        change_type="recurring.match",
+        title="Match a payment to a bill",
+        payload_model=MatchPayload,
+        execute=_match_execute,
+        describe=_match_describe,
+    )
+)
+register(
+    ChangeExecutor(
+        change_type="transaction.tag",
+        title="Tag a transaction",
+        payload_model=TagPayload,
+        execute=_tag_execute,
+        describe=_tag_describe,
+    )
+)
+register(
+    ChangeExecutor(
+        change_type="transaction.untag",
+        title="Remove a tag from a transaction",
+        payload_model=TagPayload,
+        execute=_untag_execute,
+        describe=_untag_describe,
+    )
+)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/executors.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/executors.py
@@ -183,9 +183,18 @@ async def _tag_execute(
 async def _tag_describe(
     db: AsyncSession, payload: TagPayload, owner_user_id: int | None
 ) -> list[dict[str, str]]:
+    from app.services.finance.utils import normalize_payee
+
     _txn, subject = await _txn_subject(db, payload.transaction_id, owner_user_id)
     before = await _tag_names(db, payload.transaction_id)
-    after = sorted(set(before) | {payload.tag.strip()})
+    # Predict with the executor's own rule: attach dedupes by normalized
+    # name, so "business" against an existing "Business" changes nothing
+    # - the card must not promise a duplicate that will never exist.
+    wanted = normalize_payee(payload.tag)
+    if any(normalize_payee(name) == wanted for name in before):
+        after = before
+    else:
+        after = sorted([*before, payload.tag.strip()])
     return _tag_rows(subject, before, after)
 
 
@@ -214,10 +223,13 @@ async def _untag_execute(
 async def _untag_describe(
     db: AsyncSession, payload: TagPayload, owner_user_id: int | None
 ) -> list[dict[str, str]]:
+    from app.services.finance.utils import normalize_payee
+
     _txn, subject = await _txn_subject(db, payload.transaction_id, owner_user_id)
     before = await _tag_names(db, payload.transaction_id)
-    wanted = payload.tag.strip().casefold()
-    after = [n for n in before if n.casefold() != wanted]
+    # Same normalization the executor resolves the tag with.
+    wanted = normalize_payee(payload.tag)
+    after = [n for n in before if normalize_payee(n) != wanted]
     return _tag_rows(subject, before, after)
 
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/queue.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/queue.py
@@ -1,0 +1,268 @@
+"""The queue itself: propose, approve, reject, and the reads over them.
+
+Approval is the ONLY execution path. ``approve`` re-validates the
+payload and runs the registered executor in the caller's transaction, so
+the status flip and the mutation land or fail together; a failing
+execution leaves the row PENDING with the error in ``result`` - the user
+rejects it with full information, nothing half-lands.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from pydantic import ValidationError
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.finance.domains.writes.registry import executor_for
+from app.services.finance.models import FinancePendingChange
+from app.services.finance.utils import utcnow
+
+
+async def propose(
+    db: AsyncSession,
+    change_type: str,
+    payload: dict[str, Any],
+    *,
+    owner_user_id: int | None = None,
+    proposed_by_agent: str | None = None,
+    conversation_id: str | None = None,
+) -> FinancePendingChange:
+    """Record a proposed mutation. Nothing in the ledger moves here.
+
+    The payload is validated against the change type's contract NOW: a
+    malformed proposal dies at the door instead of becoming a card the
+    user cannot safely approve.
+    """
+    executor = executor_for(change_type)
+    try:
+        model = executor.payload_model(**payload)
+    except ValidationError as e:
+        raise ValueError(f"invalid {change_type} payload: {e}") from None
+    row = FinancePendingChange(
+        owner_user_id=owner_user_id,
+        change_type=change_type,
+        payload=model.model_dump(mode="json"),
+        proposed_by_agent=proposed_by_agent,
+        conversation_id=conversation_id,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+MAX_BATCH_SIZE = 100
+
+
+async def propose_many(
+    db: AsyncSession,
+    change_type: str,
+    payloads: list[dict[str, Any]],
+    *,
+    owner_user_id: int | None = None,
+    proposed_by_agent: str | None = None,
+    conversation_id: str | None = None,
+) -> list[FinancePendingChange]:
+    """One decision over many rows: N ordinary proposals sharing a
+    batch id. Every row still resolves individually and keeps its own
+    audit trail - a batch is a grouping, not a different kind of thing.
+
+    All payloads validate BEFORE any row is written: a batch with one
+    malformed member dies whole at the door rather than filing a card
+    the user can only partially trust.
+    """
+    if not payloads:
+        raise ValueError("a batch needs at least one change")
+    if len(payloads) > MAX_BATCH_SIZE:
+        raise ValueError(
+            f"batch of {len(payloads)} exceeds the {MAX_BATCH_SIZE}-change cap"
+        )
+    executor = executor_for(change_type)
+    models = []
+    for index, payload in enumerate(payloads):
+        try:
+            models.append(executor.payload_model(**payload))
+        except ValidationError as e:
+            raise ValueError(
+                f"invalid {change_type} payload at index {index}: {e}"
+            ) from None
+    batch_id = str(uuid4())
+    rows = [
+        FinancePendingChange(
+            owner_user_id=owner_user_id,
+            change_type=change_type,
+            payload=model.model_dump(mode="json"),
+            proposed_by_agent=proposed_by_agent,
+            conversation_id=conversation_id,
+            batch_id=batch_id,
+        )
+        for model in models
+    ]
+    for row in rows:
+        db.add(row)
+    await db.flush()
+    return rows
+
+
+async def batch_rows(
+    db: AsyncSession, batch_id: str, *, owner_user_id: int | None = None
+) -> list[FinancePendingChange]:
+    query = select(FinancePendingChange).where(
+        FinancePendingChange.batch_id == batch_id
+    )
+    if owner_user_id is not None:
+        query = query.where(FinancePendingChange.owner_user_id == owner_user_id)
+    return list((await db.exec(query.order_by(FinancePendingChange.id))).all())  # type: ignore[arg-type]
+
+
+async def approve_batch(
+    db: AsyncSession,
+    batch_id: str,
+    *,
+    owner_user_id: int | None = None,
+    exclude_ids: list[int] | None = None,
+) -> dict[str, Any]:
+    """Approve every pending row in the batch except the vetoed ones
+    (which are rejected - a veto is a decision, not a deferral). One
+    failing row stays pending with its error; the rest land.
+    """
+    excluded = set(exclude_ids or [])
+    approved = rejected = failed = 0
+    for row in await batch_rows(db, batch_id, owner_user_id=owner_user_id):
+        if row.status != "pending" or row.id is None:
+            continue
+        if row.id in excluded:
+            await reject(db, row.id, owner_user_id=owner_user_id, note="vetoed")
+            rejected += 1
+            continue
+        try:
+            await approve(db, row.id, owner_user_id=owner_user_id)
+            approved += 1
+        except Exception:
+            failed += 1
+    return {"approved": approved, "rejected": rejected, "failed": failed}
+
+
+async def reject_batch(
+    db: AsyncSession,
+    batch_id: str,
+    *,
+    owner_user_id: int | None = None,
+) -> dict[str, Any]:
+    rejected = 0
+    for row in await batch_rows(db, batch_id, owner_user_id=owner_user_id):
+        if row.status != "pending" or row.id is None:
+            continue
+        await reject(db, row.id, owner_user_id=owner_user_id)
+        rejected += 1
+    return {"approved": 0, "rejected": rejected, "failed": 0}
+
+
+async def get_change(
+    db: AsyncSession, change_id: int, *, owner_user_id: int | None = None
+) -> FinancePendingChange | None:
+    row = (
+        await db.exec(
+            select(FinancePendingChange).where(FinancePendingChange.id == change_id)
+        )
+    ).first()
+    if row is None:
+        return None
+    if owner_user_id is not None and row.owner_user_id != owner_user_id:
+        return None
+    return row
+
+
+async def list_changes(
+    db: AsyncSession,
+    *,
+    owner_user_id: int | None = None,
+    status: str | None = "pending",
+) -> list[FinancePendingChange]:
+    """Newest first. ``status=None`` returns the full audit trail."""
+    query = select(FinancePendingChange).order_by(
+        FinancePendingChange.id.desc()  # type: ignore[attr-defined]
+    )
+    if status is not None:
+        query = query.where(FinancePendingChange.status == status)
+    if owner_user_id is not None:
+        query = query.where(FinancePendingChange.owner_user_id == owner_user_id)
+    return list((await db.exec(query)).all())
+
+
+def _require_pending(row: FinancePendingChange | None) -> FinancePendingChange:
+    if row is None:
+        raise ValueError("pending change not found")
+    if row.status != "pending":
+        raise ValueError(f"change already {row.status}")
+    return row
+
+
+async def approve(
+    db: AsyncSession, change_id: int, *, owner_user_id: int | None = None
+) -> FinancePendingChange:
+    """Execute the stored mutation. The one door into the ledger."""
+    row = _require_pending(await get_change(db, change_id, owner_user_id=owner_user_id))
+    executor = executor_for(row.change_type)
+    model = executor.payload_model(**row.payload)
+    # Snapshot the display BEFORE executing: after the mutation the
+    # world reflects it, and re-resolving read "Groceries -> Groceries".
+    # Resolution freezes the record; only pending cards track the world.
+    display = await executor.describe(db, model, row.owner_user_id)
+    try:
+        result = await executor.execute(db, model, row.owner_user_id)
+    except Exception as e:
+        # The row stays PENDING: the error is audit, the decision is
+        # still the user's (reject it, or fix the world and re-approve).
+        row.result = {"error": str(e)}
+        row.updated_at = utcnow()
+        db.add(row)
+        await db.flush()
+        raise
+    row.status = "approved"
+    row.result = {**result, "display": display}
+    row.resolved_at = utcnow()
+    row.updated_at = row.resolved_at
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def reject(
+    db: AsyncSession,
+    change_id: int,
+    *,
+    owner_user_id: int | None = None,
+    note: str | None = None,
+) -> FinancePendingChange:
+    row = _require_pending(await get_change(db, change_id, owner_user_id=owner_user_id))
+    executor = executor_for(row.change_type)
+    display = await executor.describe(
+        db, executor.payload_model(**row.payload), row.owner_user_id
+    )
+    row.status = "rejected"
+    row.result = {"display": display, **({"note": note} if note else {})}
+    row.resolved_at = utcnow()
+    row.updated_at = row.resolved_at
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def describe_change(
+    db: AsyncSession, row: FinancePendingChange
+) -> list[dict[str, str]]:
+    """The card's body lines: system truth, never model copy.
+
+    Pending rows resolve from the database at read time (the world may
+    have moved since the proposal); resolved rows read the snapshot
+    frozen at resolution - history does not re-resolve.
+    """
+    frozen = (row.result or {}).get("display")
+    if row.status != "pending" and isinstance(frozen, list):
+        return frozen
+    executor = executor_for(row.change_type)
+    model = executor.payload_model(**row.payload)
+    return await executor.describe(db, model, row.owner_user_id)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/registry.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/writes/registry.py
@@ -1,0 +1,58 @@
+"""The change-type registry: what the queue knows how to execute.
+
+One entry per mutation kind. FW-06..09 grow by REGISTERING here - a
+payload contract, an executor, a describer - never by adding queue
+machinery. The payload model validates at propose time (a card the user
+cannot safely approve should never exist) and again at approve time
+(the world may have moved between the two).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import Any
+
+from pydantic import BaseModel
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+
+@dataclass(frozen=True)
+class ChangeExecutor:
+    """One kind of proposable mutation.
+
+    ``execute`` runs the REAL service mutation and returns an audit
+    summary; ``describe`` resolves the payload's ids into the
+    human-readable lines the confirmation card renders - system truth
+    from the database, never model-authored copy.
+    """
+
+    change_type: str
+    title: str
+    payload_model: type[BaseModel]
+    execute: Callable[[AsyncSession, Any, int | None], Awaitable[dict[str, Any]]]
+    describe: Callable[[AsyncSession, Any, int | None], Awaitable[list[dict[str, str]]]]
+
+
+_EXECUTORS: dict[str, ChangeExecutor] = {}
+
+
+def register(executor: ChangeExecutor) -> ChangeExecutor:
+    """Add one change type. Double registration is a wiring bug, not a
+    merge - two executors silently fighting over one type is exactly
+    the ambiguity a confirmation queue cannot carry."""
+    if executor.change_type in _EXECUTORS:
+        raise ValueError(f"change type {executor.change_type!r} already registered")
+    _EXECUTORS[executor.change_type] = executor
+    return executor
+
+
+def executor_for(change_type: str) -> ChangeExecutor:
+    try:
+        return _EXECUTORS[change_type]
+    except KeyError:
+        raise ValueError(f"unknown change type: {change_type!r}") from None
+
+
+def registered_change_types() -> tuple[str, ...]:
+    return tuple(sorted(_EXECUTORS))

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/__init__.py
@@ -35,6 +35,9 @@ from app.services.finance.models.categorization import (
     FinanceTag,
     FinanceTransactionTag,
 )
+from app.services.finance.models.changes import (
+    FinancePendingChange,
+)
 from app.services.finance.models.connections import (
     FinanceConnection,
     FinanceInstitution,
@@ -92,6 +95,7 @@ __all__ = [
     "FinanceLiabilityDetail",
     "FinanceMerchant",
     "FinanceNetWorthSnapshot",
+    "FinancePendingChange",
     "FinanceRecurringStream",
     "FinanceRule",
     "FinanceSecurity",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/changes.py
@@ -1,0 +1,61 @@
+"""The propose/approve queue: AI writes as pending changes (FW-05).
+
+Confirmation is structural: the sandbox's only write tool is ``propose``,
+and execution happens exclusively when the app user approves - no
+direct-write tool exists, so the model cannot skip it. Every resolution
+keeps its row: the queue IS the audit trail.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, CheckConstraint, Column, Index
+from sqlmodel import Field, SQLModel
+
+from app.services.finance.models.base import _SCHEMA, _utcnow
+
+PENDING_CHANGE_STATUSES = ("pending", "approved", "rejected", "expired")
+
+
+class FinancePendingChange(SQLModel, table=True):
+    """One proposed mutation, from proposal through resolution.
+
+    ``payload`` is the exact mutation the executor will run on approval -
+    the confirmation card renders THIS row, so what the user sees is what
+    executes, by construction. ``result`` records the execution outcome
+    (or refusal reason) for the audit trail.
+    """
+
+    __tablename__ = "finance_pending_change"
+    __table_args__ = (
+        Index("ix_finance_pending_owner", "owner_user_id"),
+        Index("ix_finance_pending_status", "status"),
+        CheckConstraint(
+            "status IN ('pending', 'approved', 'rejected', 'expired')",
+            name="ck_finance_pending_status",
+        ),
+        {"schema": _SCHEMA},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    change_type: str = Field(max_length=64)
+    payload: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("payload", JSON, nullable=False)
+    )
+    # Who asked: agent slug + the conversation the proposal was made in,
+    # so the card can live inline and the audit names its author.
+    proposed_by_agent: str | None = Field(default=None, max_length=64)
+    conversation_id: str | None = Field(default=None, max_length=64)
+    # Rows proposed together share a batch id ("approve them all" is
+    # one decision over many auditable rows); NULL = a lone proposal.
+    batch_id: str | None = Field(default=None, max_length=36, index=True)
+    status: str = Field(default="pending", max_length=16)
+    result: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("result", JSON, nullable=False)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime = Field(default_factory=_utcnow)
+    resolved_at: datetime | None = Field(default=None)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/schemas/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/schemas/__init__.py
@@ -85,6 +85,14 @@ from app.services.finance.schemas.categorization import (
     TagRemoveResult,
     TagResponse,
 )
+from app.services.finance.schemas.changes import (
+    BatchResolveRequest,
+    BatchResolveResponse,
+    ChangeDisplayRow,
+    ChangeProposal,
+    PendingChangeListResponse,
+    PendingChangeResponse,
+)
 from app.services.finance.schemas.goals import (
     GoalContribute,
     GoalCreate,
@@ -182,7 +190,13 @@ __all__ = [
     "BudgetSummaryResponse",
     "BudgetTrimPlan",
     "BudgetTrimResponse",
+    "BatchResolveRequest",
+    "BatchResolveResponse",
     "CashflowMonth",
+    "PendingChangeResponse",
+    "PendingChangeListResponse",
+    "ChangeProposal",
+    "ChangeDisplayRow",
     "CashflowResponse",
     "CategoryCreate",
     "CategoryListResponse",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/schemas/changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/schemas/changes.py
@@ -55,8 +55,10 @@ class PendingChangeResponse(BaseModel):
         title: str,
         display: list[dict[str, str]],
     ) -> PendingChangeResponse:
+        if row.id is None:
+            raise ValueError("pending change row has no id - flush before responding")
         return cls(
-            id=row.id or 0,
+            id=row.id,
             change_type=row.change_type,
             title=title,
             status=row.status,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/schemas/changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/schemas/changes.py
@@ -1,0 +1,88 @@
+"""Pending-change shapes: the confirmation card's data contract.
+
+A topic module of the ``schemas`` package; every name here is
+re-exported from its root. The card renders THIS response - which is
+built from the stored queue row, which is what approval executes - so
+what the user sees and what runs are the same thing by construction.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel
+
+if TYPE_CHECKING:
+    from app.services.finance.models import FinancePendingChange
+
+
+class ChangeProposal(BaseModel):
+    """POST body for /finance/changes: one proposed mutation."""
+
+    change_type: str
+    payload: dict[str, Any]
+    proposed_by_agent: str | None = None
+    conversation_id: str | None = None
+
+
+class ChangeDisplayRow(BaseModel):
+    """One label/value line of the card body - resolved from the
+    database at read time, never authored by a model."""
+
+    label: str
+    value: str
+
+
+class PendingChangeResponse(BaseModel):
+    id: int
+    change_type: str
+    title: str
+    status: str
+    display: list[ChangeDisplayRow]
+    proposed_by_agent: str | None
+    conversation_id: str | None
+    batch_id: str | None
+    error: str | None
+    created_at: datetime
+    resolved_at: datetime | None
+
+    @classmethod
+    def from_row(
+        cls,
+        row: FinancePendingChange,
+        *,
+        title: str,
+        display: list[dict[str, str]],
+    ) -> PendingChangeResponse:
+        return cls(
+            id=row.id or 0,
+            change_type=row.change_type,
+            title=title,
+            status=row.status,
+            display=[ChangeDisplayRow(**line) for line in display],
+            proposed_by_agent=row.proposed_by_agent,
+            conversation_id=row.conversation_id,
+            batch_id=row.batch_id,
+            error=(row.result or {}).get("error"),
+            created_at=row.created_at,
+            resolved_at=row.resolved_at,
+        )
+
+
+class PendingChangeListResponse(BaseModel):
+    items: list[PendingChangeResponse]
+    total: int
+
+
+class BatchResolveRequest(BaseModel):
+    """POST body for batch approval: the vetoed row ids (rejected, not
+    deferred - a veto is a decision)."""
+
+    exclude_ids: list[int] = []
+
+
+class BatchResolveResponse(BaseModel):
+    approved: int
+    rejected: int
+    failed: int

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/__init__.py
@@ -28,6 +28,7 @@ from app.services.finance.service.accounts import AccountsMixin
 from app.services.finance.service.base import FinanceServiceBase
 from app.services.finance.service.budgets import BudgetsMixin
 from app.services.finance.service.categories import CategoriesMixin
+from app.services.finance.service.changes import ChangesMixin
 from app.services.finance.service.goals import GoalsMixin
 from app.services.finance.service.imports import ImportsMixin
 from app.services.finance.service.insights import InsightsMixin
@@ -42,6 +43,7 @@ class FinanceService(
     AccountsMixin,
     TransactionsMixin,
     CategoriesMixin,
+    ChangesMixin,
     MerchantsMixin,
     NetWorthMixin,
     BudgetsMixin,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/changes.py
@@ -1,0 +1,99 @@
+"""Facade methods for the propose/approve queue."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.finance.domains import writes
+from app.services.finance.models import FinancePendingChange
+from app.services.finance.service.base import FinanceServiceBase
+
+
+class ChangesMixin(FinanceServiceBase):
+    async def propose_change(
+        self,
+        change_type: str,
+        payload: dict[str, Any],
+        *,
+        owner_user_id: int | None = None,
+        proposed_by_agent: str | None = None,
+        conversation_id: str | None = None,
+    ) -> FinancePendingChange:
+        return await writes.propose(
+            self.db,
+            change_type,
+            payload,
+            owner_user_id=owner_user_id,
+            proposed_by_agent=proposed_by_agent,
+            conversation_id=conversation_id,
+        )
+
+    async def approve_change(
+        self, change_id: int, *, owner_user_id: int | None = None
+    ) -> FinancePendingChange:
+        return await writes.approve(self.db, change_id, owner_user_id=owner_user_id)
+
+    async def reject_change(
+        self,
+        change_id: int,
+        *,
+        owner_user_id: int | None = None,
+        note: str | None = None,
+    ) -> FinancePendingChange:
+        return await writes.reject(
+            self.db, change_id, owner_user_id=owner_user_id, note=note
+        )
+
+    async def list_pending_changes(
+        self, *, owner_user_id: int | None = None, status: str | None = "pending"
+    ) -> list[FinancePendingChange]:
+        return await writes.list_changes(
+            self.db, owner_user_id=owner_user_id, status=status
+        )
+
+    async def get_pending_change(
+        self, change_id: int, *, owner_user_id: int | None = None
+    ) -> FinancePendingChange | None:
+        return await writes.get_change(self.db, change_id, owner_user_id=owner_user_id)
+
+    async def describe_pending_change(
+        self, row: FinancePendingChange
+    ) -> list[dict[str, str]]:
+        return await writes.describe_change(self.db, row)
+
+    async def propose_many_changes(
+        self,
+        change_type: str,
+        payloads: list[dict[str, Any]],
+        *,
+        owner_user_id: int | None = None,
+        proposed_by_agent: str | None = None,
+        conversation_id: str | None = None,
+    ) -> list[FinancePendingChange]:
+        return await writes.propose_many(
+            self.db,
+            change_type,
+            payloads,
+            owner_user_id=owner_user_id,
+            proposed_by_agent=proposed_by_agent,
+            conversation_id=conversation_id,
+        )
+
+    async def approve_batch(
+        self,
+        batch_id: str,
+        *,
+        owner_user_id: int | None = None,
+        exclude_ids: list[int] | None = None,
+    ) -> dict[str, Any]:
+        return await writes.approve_batch(
+            self.db,
+            batch_id,
+            owner_user_id=owner_user_id,
+            exclude_ids=exclude_ids,
+        )
+
+    async def reject_batch(
+        self, batch_id: str, *, owner_user_id: int | None = None
+    ) -> dict[str, Any]:
+        return await writes.reject_batch(self.db, batch_id, owner_user_id=owner_user_id)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_finance_endpoints.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_finance_endpoints.py
@@ -3369,3 +3369,54 @@ async def test_batch_approve_with_a_veto(
     await async_db_session.refresh(txns[1])
     assert txns[0].category_id == category.id
     assert txns[1].category_id is None
+
+
+@pytest.mark.asyncio
+async def test_an_executor_crash_keeps_the_recorded_error(
+    authenticated_client: TestClient,
+    async_db_session: AsyncSession,
+    acting_owner_user_id: int | None,
+) -> None:
+    """A non-domain executor failure (not ValueError) must still land the
+    row's recorded error - losing it to a rollback erases exactly the
+    audit detail the card shows - and must not leak internals."""
+    from pydantic import BaseModel, ConfigDict
+
+    from app.services.finance.domains.writes import registry
+
+    class _BoomPayload(BaseModel):
+        model_config = ConfigDict(extra="forbid")
+        anything: int
+
+    async def _boom(db, payload, owner_user_id):
+        raise RuntimeError("secret internal detail")
+
+    async def _describe(db, payload, owner_user_id):
+        return [{"label": "Anything", "value": str(payload.anything)}]
+
+    registry.register(
+        registry.ChangeExecutor(
+            change_type="test.boom",
+            title="Boom",
+            payload_model=_BoomPayload,
+            execute=_boom,
+            describe=_describe,
+        )
+    )
+    try:
+        change = authenticated_client.post(
+            "/api/v1/finance/changes",
+            json={"change_type": "test.boom", "payload": {"anything": 1}},
+        ).json()
+
+        crashed = authenticated_client.post(
+            f"/api/v1/finance/changes/{change['id']}/approve"
+        )
+
+        assert crashed.status_code == 500
+        assert "secret internal detail" not in crashed.text
+        row = authenticated_client.get(f"/api/v1/finance/changes/{change['id']}").json()
+        assert row["status"] == "pending"
+        assert "secret internal detail" in (row["error"] or "")
+    finally:
+        registry._EXECUTORS.pop("test.boom", None)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_finance_endpoints.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_finance_endpoints.py
@@ -3221,3 +3221,151 @@ async def test_a_lien_on_a_non_property_is_refused(
     )
     assert refused.status_code == 400
     assert "not a property" in refused.json()["detail"]
+
+
+async def _seed_change_fixture(service, owner_user_id):
+    account = await service.create_manual_account(
+        owner_user_id=owner_user_id,
+        name="Checking",
+        account_type="checking",
+        classification="asset",
+    )
+    category = await service.get_or_create_category_from_hint(
+        "Food & Dining:Eating Out"
+    )
+    txn = await service.create_transaction(
+        owner_user_id=owner_user_id,
+        account_id=account.id,
+        amount=-897,
+        txn_date=date(2026, 6, 10),
+        name="Shelly's Deli",
+    )
+    return txn, category
+
+
+@pytest.mark.asyncio
+async def test_pending_change_approve_round_trip(
+    authenticated_client: TestClient,
+    async_db_session: AsyncSession,
+    acting_owner_user_id: int | None,
+) -> None:
+    """FW-05 acceptance: a proposal lists as pending with its
+    human-readable display, approval executes the mutation, and the
+    resolved state reads back."""
+    txn, category = await _seed_change_fixture(
+        FinanceService(async_db_session), acting_owner_user_id
+    )
+    await async_db_session.commit()
+
+    proposed = authenticated_client.post(
+        "/api/v1/finance/changes",
+        json={
+            "change_type": "transaction.categorize",
+            "payload": {"transaction_id": txn.id, "category_id": category.id},
+        },
+    )
+    assert proposed.status_code == 200, proposed.text
+    change = proposed.json()
+    assert change["status"] == "pending"
+    assert change["title"] == "Categorize a transaction"
+    assert any("Shelly" in row["value"] for row in change["display"])
+
+    listed = authenticated_client.get("/api/v1/finance/changes").json()
+    assert [c["id"] for c in listed["items"]] == [change["id"]]
+
+    approved = authenticated_client.post(
+        f"/api/v1/finance/changes/{change['id']}/approve"
+    )
+    assert approved.status_code == 200
+    assert approved.json()["status"] == "approved"
+
+    await async_db_session.refresh(txn)
+    assert txn.category_id == category.id
+
+
+@pytest.mark.asyncio
+async def test_pending_change_reject_keeps_the_audit_row(
+    authenticated_client: TestClient,
+    async_db_session: AsyncSession,
+    acting_owner_user_id: int | None,
+) -> None:
+    txn, category = await _seed_change_fixture(
+        FinanceService(async_db_session), acting_owner_user_id
+    )
+    await async_db_session.commit()
+
+    change = authenticated_client.post(
+        "/api/v1/finance/changes",
+        json={
+            "change_type": "transaction.categorize",
+            "payload": {"transaction_id": txn.id, "category_id": category.id},
+        },
+    ).json()
+
+    rejected = authenticated_client.post(
+        f"/api/v1/finance/changes/{change['id']}/reject"
+    )
+    assert rejected.status_code == 200
+    assert rejected.json()["status"] == "rejected"
+
+    assert authenticated_client.get("/api/v1/finance/changes").json()["items"] == []
+    trail = authenticated_client.get(
+        "/api/v1/finance/changes", params={"status": "rejected"}
+    ).json()["items"]
+    assert [c["id"] for c in trail] == [change["id"]]
+
+    await async_db_session.refresh(txn)
+    assert txn.category_id is None
+    resolved_again = authenticated_client.post(
+        f"/api/v1/finance/changes/{change['id']}/approve"
+    )
+    assert resolved_again.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_batch_approve_with_a_veto(
+    authenticated_client: TestClient,
+    async_db_session: AsyncSession,
+    acting_owner_user_id: int | None,
+) -> None:
+    service = FinanceService(async_db_session)
+    account = await service.create_manual_account(
+        owner_user_id=acting_owner_user_id,
+        name="Checking",
+        account_type="checking",
+        classification="asset",
+    )
+    category = await service.get_or_create_category_from_hint("Food & Dining:Groceries")
+    txns = [
+        await service.create_transaction(
+            owner_user_id=acting_owner_user_id,
+            account_id=account.id,
+            amount=-1_000 - i,
+            txn_date=date(2026, 8, 1 + i),
+            name=f"Store {i}",
+        )
+        for i in range(3)
+    ]
+    rows = await service.propose_many_changes(
+        "transaction.categorize",
+        [{"transaction_id": t.id, "category_id": category.id} for t in txns],
+        owner_user_id=acting_owner_user_id,
+    )
+    batch_id = rows[0].batch_id
+    await async_db_session.commit()
+
+    listed = authenticated_client.get("/api/v1/finance/changes").json()["items"]
+    assert {c["batch_id"] for c in listed} == {batch_id}
+
+    resolved = authenticated_client.post(
+        f"/api/v1/finance/changes/batch/{batch_id}/approve",
+        json={"exclude_ids": [rows[1].id]},
+    )
+    assert resolved.status_code == 200
+    assert resolved.json()["approved"] == 2
+    assert resolved.json()["rejected"] == 1
+
+    await async_db_session.refresh(txns[0])
+    await async_db_session.refresh(txns[1])
+    assert txns[0].category_id == category.id
+    assert txns[1].category_id is None

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/_tree.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/_tree.py
@@ -26,12 +26,20 @@ def walk(node: Any) -> Iterator[Any]:
 
 
 def texts(node: Any) -> list[str]:
-    """Every non-empty rendered string in the tree, in walk order."""
-    return [
-        n.value
-        for n in walk(node)
-        if isinstance(getattr(n, "value", None), str) and n.value
-    ]
+    """Every non-empty rendered string in the tree, in walk order.
+
+    Includes ``TextSpan`` text: a value split into styled spans still
+    reads as one rendered line."""
+    out: list[str] = []
+    for n in walk(node):
+        value = getattr(n, "value", None)
+        if isinstance(value, str) and value:
+            out.append(value)
+        for span in getattr(n, "spans", None) or []:
+            text = getattr(span, "text", None)
+            if isinstance(text, str) and text:
+                out.append(text)
+    return out
 
 
 def rendered(node: Any) -> str:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_chat_components.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_chat_components.py
@@ -1,0 +1,486 @@
+"""In-conversation components: typed data in, system-rendered control out.
+
+The generative-UI foundation (FW-05): the model contributes DATA (via
+tool results); presentation is system code keyed by ``kind``. The
+pending-change card is the first kind - it renders the stored queue
+row, which is exactly what approval executes, so what the user sees and
+what runs cannot diverge.
+"""
+
+from typing import Any
+
+from tests.components.frontend._tree import rendered
+
+_CHANGE = {
+    "id": 7,
+    "change_type": "transaction.categorize",
+    "title": "Categorize a transaction",
+    "status": "pending",
+    "display": [
+        {"label": "Transaction", "value": "Shelly's Deli ($8.97 on 2026-06-10)"},
+        {"label": "Category", "value": "Food & Dining:Eating Out"},
+    ],
+}
+
+
+async def _noop_action(change_id: int, action: str) -> dict[str, Any] | None:
+    return None
+
+
+class TestComponentRegistry:
+    def test_a_known_kind_renders(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component("pending_change", _CHANGE, on_action=_noop_action)
+        assert card is not None
+        assert "Categorize a transaction" in rendered(card)
+
+    def test_an_unknown_kind_renders_nothing(self) -> None:
+        """A payload the frontend does not understand degrades to
+        absence, never to a crash or a raw dict on screen."""
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        assert render_component("hologram", {"x": 1}, on_action=_noop_action) is None
+
+
+class TestPendingChangeCard:
+    def test_a_pending_card_shows_the_stored_row_and_both_actions(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component("pending_change", _CHANGE, on_action=_noop_action)
+        text = rendered(card)
+        assert "Shelly's Deli ($8.97 on 2026-06-10)" in text
+        assert "Food & Dining:Eating Out" in text
+        assert "Approve" in text
+        assert "Reject" in text
+
+    def test_a_resolved_card_drops_the_actions(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        resolved = {**_CHANGE, "status": "approved"}
+        card = render_component("pending_change", resolved, on_action=_noop_action)
+        text = rendered(card)
+        assert "Approved" in text
+        assert "Approve" != text  # chip, not button: no actionable copy
+        assert "Reject" not in text
+
+    def test_an_execution_error_is_shown_on_the_card(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        errored = {**_CHANGE, "error": "Transaction 999 not found."}
+        card = render_component("pending_change", errored, on_action=_noop_action)
+        assert "Transaction 999 not found." in rendered(card)
+
+
+class TestTraceExtraction:
+    def test_propose_calls_become_cards_and_other_tools_do_not(self) -> None:
+        """The trail is the transport: a propose result carries the
+        pending-change data, and the renderer turns exactly those
+        entries into cards."""
+        import json
+
+        from app.components.frontend.controls.chat.components import (
+            components_from_trace,
+        )
+
+        trace = [
+            {"tool": "ledger", "args": "months=3", "result": "{...}"},
+            {
+                "tool": "propose",
+                "args": "",
+                "result": json.dumps(
+                    {
+                        "pending_change_id": 7,
+                        "change_type": "transaction.categorize",
+                        "title": "Categorize a transaction",
+                        "status": "pending",
+                        "display": _CHANGE["display"],
+                    }
+                ),
+            },
+            {"tool": "propose", "args": "", "result": "not json at all"},
+        ]
+
+        cards = components_from_trace(trace, on_action=_noop_action)
+
+        assert len(cards) == 1
+        assert "Categorize a transaction" in rendered(cards[0])
+
+
+class TestCardGeometry:
+    def test_the_card_is_narrow_and_never_message_width(self) -> None:
+        """A confirmation is a focused decision, not a banner: the card
+        holds a fixed narrow width instead of stretching across the
+        transcript."""
+        from app.components.frontend.controls.chat.components import (
+            CARD_WIDTH,
+            render_component,
+        )
+
+        card = render_component("pending_change", _CHANGE, on_action=_noop_action)
+        assert card.width == CARD_WIDTH
+        assert CARD_WIDTH <= 440
+
+
+class TestCardStateSync:
+    def test_a_history_card_refreshes_to_the_queues_truth(self) -> None:
+        """A card rendered from a history snapshot says whatever was
+        true at propose time; acting on another surface must reach it.
+        ``refresh_from`` re-renders from a queue fetch."""
+        import asyncio
+
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component("pending_change", _CHANGE, on_action=_noop_action)
+        assert "Approve" in rendered(card)
+
+        async def fetch(change_id: int):
+            assert change_id == 7
+            return {**_CHANGE, "status": "approved"}
+
+        asyncio.run(card.refresh_from(fetch))
+
+        text = rendered(card)
+        assert "Approved" in text
+        assert "Reject" not in text
+
+    def test_a_failed_fetch_leaves_the_card_alone(self) -> None:
+        import asyncio
+
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component("pending_change", _CHANGE, on_action=_noop_action)
+
+        async def fetch(change_id: int):
+            return None
+
+        asyncio.run(card.refresh_from(fetch))
+        assert "Approve" in rendered(card)
+
+
+_BATCH = {
+    "batch_id": "b-1",
+    "change_type": "transaction.categorize",
+    "title": "Categorize a transaction",
+    "items": [
+        {
+            "id": 11,
+            "status": "pending",
+            "display": [
+                {"label": "Transaction", "value": "Store 0 ($10.00 on 2026-08-01)"},
+                {"label": "Category", "value": "Uncategorized \u2192 Groceries"},
+            ],
+        },
+        {
+            "id": 12,
+            "status": "pending",
+            "display": [
+                {"label": "Transaction", "value": "Store 1 ($11.00 on 2026-08-02)"},
+                {"label": "Category", "value": "Uncategorized \u2192 Groceries"},
+            ],
+        },
+    ],
+}
+
+
+async def _noop_batch_action(batch_id, action, exclude_ids):
+    return None
+
+
+class TestBatchCard:
+    def _card(self):
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        return render_component(
+            "pending_change_batch",
+            _BATCH,
+            on_action=_noop_action,
+            on_batch_action=_noop_batch_action,
+        )
+
+    def test_a_batch_renders_every_row_and_both_bulk_actions(self) -> None:
+        card = self._card()
+        text = rendered(card)
+        assert "Store 0" in text and "Store 1" in text
+        assert "Approve all (2)" in text
+        assert "Reject all" in text
+
+    def test_a_veto_shrinks_the_approve_count(self) -> None:
+        """Vetoing a row is a per-row decision inside the one bulk
+        decision: the approve button says exactly how many will land."""
+        card = self._card()
+        card.toggle_veto(11)
+        assert "Approve all (1)" in rendered(card)
+        card.toggle_veto(11)
+        assert "Approve all (2)" in rendered(card)
+
+    def test_a_resolved_batch_shows_the_outcome_summary(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        resolved = {
+            **_BATCH,
+            "items": [
+                {**_BATCH["items"][0], "status": "approved"},
+                {**_BATCH["items"][1], "status": "rejected"},
+            ],
+        }
+        card = render_component(
+            "pending_change_batch",
+            resolved,
+            on_action=_noop_action,
+            on_batch_action=_noop_batch_action,
+        )
+        text = rendered(card)
+        assert "1 approved" in text
+        assert "1 rejected" in text
+        assert "Approve all" not in text
+
+
+class TestBatchTraceExtraction:
+    def test_a_propose_many_result_becomes_one_batch_card(self) -> None:
+        import json
+
+        from app.components.frontend.controls.chat.components import (
+            components_from_trace,
+        )
+
+        trace = [
+            {"tool": "propose_many", "args": "", "result": json.dumps(_BATCH)},
+        ]
+        cards = components_from_trace(
+            trace, on_action=_noop_action, on_batch_action=_noop_batch_action
+        )
+        assert len(cards) == 1
+        assert "Approve all (2)" in rendered(cards[0])
+
+
+class TestResolvedCardsCollapse:
+    def test_a_resolved_card_collapses_to_one_line(self) -> None:
+        """A decided card is history, not homework: it folds to its
+        title and outcome, expandable on demand."""
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component(
+            "pending_change",
+            {**_CHANGE, "status": "approved"},
+            on_action=_noop_action,
+        )
+        text = rendered(card)
+        assert "Categorize a transaction" in text
+        assert "Approved" in text
+        assert "Shelly's Deli" not in text  # detail folded away
+
+    def test_the_fold_opens_on_demand(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component(
+            "pending_change",
+            {**_CHANGE, "status": "approved"},
+            on_action=_noop_action,
+        )
+        card.toggle_expanded()
+        assert "Shelly's Deli" in rendered(card)
+        card.toggle_expanded()
+        assert "Shelly's Deli" not in rendered(card)
+
+    def test_a_pending_card_never_collapses(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component("pending_change", _CHANGE, on_action=_noop_action)
+        assert "Shelly's Deli" in rendered(card)
+
+    def test_a_resolved_batch_collapses_to_its_summary(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        resolved = {
+            **_BATCH,
+            "items": [
+                {**_BATCH["items"][0], "status": "approved"},
+                {**_BATCH["items"][1], "status": "rejected"},
+            ],
+        }
+        card = render_component(
+            "pending_change_batch",
+            resolved,
+            on_action=_noop_action,
+            on_batch_action=_noop_batch_action,
+        )
+        text = rendered(card)
+        assert "1 approved" in text
+        assert "Store 0" not in text  # rows folded away
+        card.toggle_expanded()
+        assert "Store 0" in rendered(card)
+
+
+class TestTargetCategoryHighlight:
+    """A "before → after" value renders its target in accent teal: the
+    eye lands on what will change, not on the prose around it."""
+
+    @staticmethod
+    def _accent_texts(card: Any) -> list[str]:
+        from app.components.frontend.theme import AegisTheme as Theme
+        from tests.components.frontend._tree import walk
+
+        return [
+            span.text
+            for n in walk(card)
+            for span in getattr(n, "spans", None) or []
+            if getattr(getattr(span, "style", None), "color", None)
+            == Theme.Colors.ACCENT
+        ]
+
+    def test_the_single_card_target_is_teal(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        change = {
+            **_CHANGE,
+            "display": [
+                {"label": "Transaction", "value": "Shelly's Deli ($8.97)"},
+                {
+                    "label": "Category",
+                    "value": "Uncategorized \u2192 Food & Dining:Eating Out",
+                },
+            ],
+        }
+        card = render_component("pending_change", change, on_action=_noop_action)
+        assert "Food & Dining:Eating Out" in self._accent_texts(card)
+        text = rendered(card)
+        assert "Uncategorized \u2192 " in text
+        assert "Food & Dining:Eating Out" in text
+
+    def test_a_batch_row_target_is_teal(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        card = render_component(
+            "pending_change_batch",
+            _BATCH,
+            on_action=_noop_action,
+            on_batch_action=_noop_batch_action,
+        )
+        accents = self._accent_texts(card)
+        assert any("Groceries" in t for t in accents)
+
+    def test_a_rejected_row_stays_dim(self) -> None:
+        """Teal marks what WILL happen; a rejected row won't."""
+        from app.components.frontend.controls.chat.components import (
+            render_component,
+        )
+
+        rejected = {
+            **_BATCH,
+            "items": [{**i, "status": "rejected"} for i in _BATCH["items"]],
+        }
+        card = render_component(
+            "pending_change_batch",
+            rejected,
+            on_action=_noop_action,
+            on_batch_action=_noop_batch_action,
+        )
+        card.toggle_expanded()
+        assert self._accent_texts(card) == []
+
+
+class TestMarkerTraceExtraction:
+    """The card builds from the trace's compact marker when present -
+    the clipped result blob is display-only and may be truncated JSON."""
+
+    def test_a_marker_builds_the_batch_card_despite_a_mangled_result(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            components_from_trace,
+        )
+
+        trace = [
+            {
+                "tool": "propose_many",
+                "args": "",
+                "result": '{"batch_id": "b-9", "items": [{"trunca',
+                "component": {
+                    "kind": "pending_change_batch",
+                    "batch_id": "b-9",
+                    "change_type": "transaction.tag",
+                    "title": "Tag a transaction",
+                    "count": 9,
+                },
+            },
+        ]
+        cards = components_from_trace(
+            trace, on_action=_noop_action, on_batch_action=_noop_batch_action
+        )
+        assert len(cards) == 1
+        assert cards[0]._batch_id == "b-9"
+
+    def test_a_single_marker_builds_the_single_card(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            components_from_trace,
+        )
+
+        trace = [
+            {
+                "tool": "propose",
+                "args": "",
+                "result": "not json at all",
+                "component": {
+                    "kind": "pending_change",
+                    "pending_change_id": 7,
+                    "change_type": "transaction.categorize",
+                    "title": "Categorize a transaction",
+                    "status": "pending",
+                },
+            },
+        ]
+        cards = components_from_trace(trace, on_action=_noop_action)
+        assert len(cards) == 1
+        assert cards[0]._change_id == 7
+
+
+    def test_a_pre_marker_truncated_result_still_yields_the_card(self) -> None:
+        """Traces recorded before the marker existed clipped big batch
+        results to invalid JSON. The identity fields lead the blob, so
+        they survive the clip - salvage them and let the card fetch its
+        rows from the queue."""
+        from app.components.frontend.controls.chat.components import (
+            components_from_trace,
+        )
+
+        result = (
+            '{"batch_id": "97d8b137-ba64", "change_type": "transaction.tag", '
+            '"title": "Tag a transaction", "count": 9, "items": [{"id": 12, '
+            '"display": [{"label": "Transaction", "value": "trunca'
+        )
+        trace = [{"tool": "propose_many", "args": "", "result": result}]
+        cards = components_from_trace(
+            trace, on_action=_noop_action, on_batch_action=_noop_batch_action
+        )
+        assert len(cards) == 1
+        assert cards[0]._batch_id == "97d8b137-ba64"
+        assert "Tag a transaction" in rendered(cards[0])

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_chat_components.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_chat_components.py
@@ -64,13 +64,14 @@ class TestPendingChangeCard:
         from app.components.frontend.controls.chat.components import (
             render_component,
         )
+        from tests.components.frontend._tree import texts
 
         resolved = {**_CHANGE, "status": "approved"}
         card = render_component("pending_change", resolved, on_action=_noop_action)
-        text = rendered(card)
-        assert "Approved" in text
-        assert "Approve" != text  # chip, not button: no actionable copy
-        assert "Reject" not in text
+        tokens = texts(card)
+        assert "Approved" in tokens  # the status chip
+        assert "Approve" not in tokens  # the button label, gone
+        assert "Reject" not in tokens
 
     def test_an_execution_error_is_shown_on_the_card(self) -> None:
         from app.components.frontend.controls.chat.components import (
@@ -461,7 +462,6 @@ class TestMarkerTraceExtraction:
         cards = components_from_trace(trace, on_action=_noop_action)
         assert len(cards) == 1
         assert cards[0]._change_id == 7
-
 
     def test_a_pre_marker_truncated_result_still_yields_the_card(self) -> None:
         """Traces recorded before the marker existed clipped big batch

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_chat_panel_revisit.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_chat_panel_revisit.py
@@ -1,0 +1,72 @@
+"""Returning to the Chat tab refreshes its pending-change cards.
+
+A resolution made on ANOTHER surface (approving on the Overview tab)
+must reach a card the open chat already rendered - the modal's
+``refresh_on_revisit`` hook fires on tab return, and the panel re-reads
+every card it has shown from the queue's current truth.
+"""
+
+from typing import Any
+
+import pytest
+
+from tests.components.frontend._tree import rendered
+
+_CHANGE = {
+    "id": 7,
+    "change_type": "transaction.categorize",
+    "title": "Categorize a transaction",
+    "status": "pending",
+    "display": [{"label": "Category", "value": "Uncategorized → Groceries"}],
+}
+
+
+async def _noop_action(change_id: int, action: str) -> dict[str, Any] | None:
+    return None
+
+
+def _panel() -> Any:
+    from app.components.frontend.controls.chat.panel import ChatPanel
+
+    return ChatPanel(agent_slug="finance-assistant", surface="finance", user_id="0")
+
+
+class TestRevisitRefreshesCards:
+    def test_the_panel_opts_into_the_revisit_hook(self) -> None:
+        assert callable(getattr(_panel(), "refresh_on_revisit", None))
+
+    @pytest.mark.asyncio
+    async def test_a_revisit_rereads_every_rendered_card(self) -> None:
+        from app.components.frontend.controls.chat.components import (
+            PendingChangeCard,
+        )
+
+        panel = _panel()
+        card = PendingChangeCard(dict(_CHANGE), on_action=_noop_action)
+        panel._pending_cards.append(card)
+
+        async def fetch(change_id: int) -> dict[str, Any] | None:
+            assert change_id == 7
+            return {**_CHANGE, "status": "approved"}
+
+        panel._change_fetch = fetch  # type: ignore[method-assign]
+        await panel._refresh_pending_cards()
+
+        assert "Approved" in rendered(card)
+
+    @pytest.mark.asyncio
+    async def test_a_new_conversation_drops_the_tracked_cards(self) -> None:
+        """Cards from a conversation the transcript no longer shows must
+        not be refetched forever."""
+        from app.components.frontend.controls.chat.components import (
+            PendingChangeCard,
+        )
+
+        panel = _panel()
+        panel._pending_cards.append(
+            PendingChangeCard(dict(_CHANGE), on_action=_noop_action)
+        )
+
+        panel._clear_transcript()
+
+        assert panel._pending_cards == []

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_import_preview_body.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_import_preview_body.py
@@ -27,9 +27,9 @@ from app.components.frontend.controls import (
     Tag,
 )
 from app.components.frontend.dashboard.modals.finance_modal import (
-    import_identical_body,
     import_preview_body,
     import_summary_body,
+    import_up_to_date_body,
     investment_import_preview_body,
     investment_target_options,
 )
@@ -389,7 +389,9 @@ class TestIdenticalFile:
     IDENTICAL: dict[str, Any] = {"rows_total": 18343, "identical_batch_id": 7}
 
     def test_it_names_the_file_and_the_row_count(self) -> None:
-        rendered = " ".join(_texts(import_identical_body(self.IDENTICAL, "export.csv")))
+        rendered = " ".join(
+            _texts(import_up_to_date_body(self.IDENTICAL, "export.csv"))
+        )
         assert "export.csv" in rendered
         assert "18,343" in rendered
 
@@ -397,25 +399,29 @@ class TestIdenticalFile:
         """Nothing lands, so nothing earns a card. A row of zeroes in the
         chrome that means "this reaches your ledger" says the opposite of
         what happened."""
-        body = import_identical_body(self.IDENTICAL, "export.csv")
+        body = import_up_to_date_body(self.IDENTICAL, "export.csv")
         assert not _of_type(body, MetricCard)
         assert "0 changes" in _dots(body)
 
     def test_the_dots_are_muted(self) -> None:
         """A no-op is not a warning. Nothing here should catch the eye."""
         for _label, color in _dots(
-            import_identical_body(self.IDENTICAL, "e.csv")
+            import_up_to_date_body(self.IDENTICAL, "e.csv")
         ).items():
             assert color == Theme.Colors.TEXT_SECONDARY
 
     def test_it_says_nothing_was_written(self) -> None:
-        rendered = " ".join(_texts(import_identical_body(self.IDENTICAL, "export.csv")))
+        rendered = " ".join(
+            _texts(import_up_to_date_body(self.IDENTICAL, "export.csv"))
+        )
         assert "Nothing has been written" in rendered
 
     def test_it_explains_why_there_is_nothing_to_do(self) -> None:
         """ "0 changes" alone reads as a failed import. The reason - you
         already imported this exact file - is the whole message."""
-        rendered = " ".join(_texts(import_identical_body(self.IDENTICAL, "export.csv")))
+        rendered = " ".join(
+            _texts(import_up_to_date_body(self.IDENTICAL, "export.csv"))
+        )
         assert "already imported" in rendered.lower()
 
 
@@ -443,7 +449,7 @@ class TestTheFootnoteWraps:
     def test_every_dialog_constrains_its_footnote(self) -> None:
         for body in (
             import_preview_body(PREVIEW, "export.csv"),
-            import_identical_body(
+            import_up_to_date_body(
                 {"rows_total": 18343, "identical_batch_id": 7}, "export.csv"
             ),
         ):
@@ -457,7 +463,7 @@ class TestTheFootnoteWraps:
     def test_the_icon_sits_with_the_first_line(self) -> None:
         """Centred against a note that wraps to two lines, the icon
         floats into the gap between them."""
-        body = import_identical_body(
+        body = import_up_to_date_body(
             {"rows_total": 18343, "identical_batch_id": 7}, "export.csv"
         )
         for row in self._footnote_rows(body):
@@ -544,3 +550,49 @@ class TestInvestmentPreviewBody:
         assert isinstance(name, PrimaryText)
         assert shares.color == Theme.Colors.TEXT_SECONDARY
         assert not isinstance(value, SecondaryText)
+
+
+class TestUpToDateFile:
+    """A DIFFERENT file whose every row is already stored is the same
+    dead end as a byte-identical one: nothing to decide, so no Import
+    button may be offered. Same family, same one-button shape."""
+
+    UP_TO_DATE: dict[str, Any] = {
+        "rows_total": 207,
+        "rows_inserted": 0,
+        "rows_updated": 0,
+        "rows_error": 0,
+    }
+
+    def test_zero_changes_means_nothing_to_import(self) -> None:
+        from app.components.frontend.dashboard.modals.finance_modal.import_summary import (
+            nothing_to_import,
+        )
+
+        assert nothing_to_import(self.UP_TO_DATE)
+        assert nothing_to_import({"identical_batch_id": 7})
+        assert not nothing_to_import({**self.UP_TO_DATE, "rows_inserted": 3})
+        assert not nothing_to_import({**self.UP_TO_DATE, "rows_updated": 1})
+        # A file with parse errors deserves the full review, not a shrug.
+        assert not nothing_to_import({**self.UP_TO_DATE, "rows_error": 2})
+
+    def test_the_body_says_up_to_date_not_identical(self) -> None:
+        from app.components.frontend.dashboard.modals.finance_modal.import_summary import (
+            import_up_to_date_body,
+        )
+
+        body = import_up_to_date_body(self.UP_TO_DATE, "export.csv")
+        dots = _dots(body)
+        assert "up to date" in dots
+        assert "identical file" not in dots
+        assert not _of_type(body, MetricCard)
+
+    def test_the_identical_case_keeps_its_own_words(self) -> None:
+        from app.components.frontend.dashboard.modals.finance_modal.import_summary import (
+            import_up_to_date_body,
+        )
+
+        body = import_up_to_date_body(
+            {"rows_total": 5, "identical_batch_id": 7}, "export.csv"
+        )
+        assert "identical file" in _dots(body)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_pending_changes_section.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_pending_changes_section.py
@@ -1,0 +1,22 @@
+"""The Overview tab's Pending changes section.
+
+The queue lays out as one horizontal band: fixed-width cards side by
+side, scrolling sideways on overflow - approvals read as a short rail
+above the page, never a column pushing the net worth chart down.
+"""
+
+import flet as ft
+
+
+class TestCardsLayOutHorizontally:
+    def test_the_card_rail_is_a_sideways_scrolling_row(self) -> None:
+        from app.components.frontend.dashboard.modals.finance_modal.pending_changes import (
+            PendingChangesSection,
+        )
+
+        section = PendingChangesSection(page=None)
+
+        rail = section._cards
+        assert isinstance(rail, ft.Row)
+        assert rail.scroll == ft.ScrollMode.AUTO
+        assert rail.vertical_alignment == ft.CrossAxisAlignment.START

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_pending_changes_section.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_pending_changes_section.py
@@ -7,13 +7,13 @@ above the page, never a column pushing the net worth chart down.
 
 import flet as ft
 
+from app.components.frontend.dashboard.modals.finance_modal.pending_changes import (
+    PendingChangesSection,
+)
+
 
 class TestCardsLayOutHorizontally:
     def test_the_card_rail_is_a_sideways_scrolling_row(self) -> None:
-        from app.components.frontend.dashboard.modals.finance_modal.pending_changes import (
-            PendingChangesSection,
-        )
-
         section = PendingChangesSection(page=None)
 
         rail = section._cards

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_tool_trace.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_tool_trace.py
@@ -1,0 +1,86 @@
+"""Trace assembly: the run trail's entries survive their own size caps.
+
+The result field is clipped for display, so anything the UI must PARSE
+(the pending-change card payload) rides a separate compact marker that
+no cap can corrupt - a 9-row batch once rendered no card because its
+JSON was truncated mid-string.
+"""
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+
+def _result_event(tool_name: str, content: Any) -> Any:
+    return SimpleNamespace(
+        part=SimpleNamespace(tool_name=tool_name, content=content, metadata=None)
+    )
+
+
+class TestProposalComponentMarker:
+    def test_an_oversized_batch_result_still_carries_its_marker(self) -> None:
+        from app.services.ai.service.trace import record_tool_result
+
+        items = [
+            {
+                "id": n,
+                "pending_change_id": n,
+                "status": "pending",
+                "display": [{"label": "Transaction", "value": "X" * 300}],
+            }
+            for n in range(9)
+        ]
+        result = {
+            "batch_id": "b-123",
+            "change_type": "transaction.tag",
+            "title": "Tag a transaction",
+            "count": 9,
+            "items": items,
+        }
+        trace: list[dict[str, Any]] = [{"tool": "propose_many", "args": ""}]
+
+        record_tool_result(trace, _result_event("propose_many", json.dumps(result)))
+
+        entry = trace[0]
+        assert len(entry["result"]) <= 2_000  # the display clip stands
+        marker = entry["component"]
+        assert marker["kind"] == "pending_change_batch"
+        assert marker["batch_id"] == "b-123"
+        assert marker["title"] == "Tag a transaction"
+
+    def test_a_single_proposal_gets_its_marker_too(self) -> None:
+        from app.services.ai.service.trace import record_tool_result
+
+        result = {
+            "pending_change_id": 7,
+            "change_type": "transaction.categorize",
+            "title": "Categorize a transaction",
+            "status": "pending",
+            "display": [],
+        }
+        trace: list[dict[str, Any]] = [{"tool": "propose", "args": ""}]
+
+        record_tool_result(trace, _result_event("propose", json.dumps(result)))
+
+        marker = trace[0]["component"]
+        assert marker["kind"] == "pending_change"
+        assert marker["pending_change_id"] == 7
+
+    def test_a_failed_proposal_carries_no_marker(self) -> None:
+        from app.services.ai.service.trace import record_tool_result
+
+        result = {"error": "unknown change type", "registered_change_types": []}
+        trace: list[dict[str, Any]] = [{"tool": "propose", "args": ""}]
+
+        record_tool_result(trace, _result_event("propose", json.dumps(result)))
+
+        assert "component" not in trace[0]
+
+    def test_other_tools_are_untouched(self) -> None:
+        from app.services.ai.service.trace import record_tool_result
+
+        trace: list[dict[str, Any]] = [{"tool": "run_code", "code": "x"}]
+
+        record_tool_result(trace, _result_event("run_code", '{"output": "6"}'))
+
+        assert "component" not in trace[0]

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_ai_tools.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_ai_tools.py.jinja
@@ -53,6 +53,10 @@ def _tools_use_test_session(
         yield session
 
     monkeypatch.setattr(ai_tools, "get_async_session", test_session)
+    # The write tools live in their own module with their own import.
+    from app.services.finance import ai_write_tools
+
+    monkeypatch.setattr(ai_write_tools, "get_async_session", test_session)
 
 
 def test_finance_tools_register_on_import() -> None:
@@ -455,4 +459,296 @@ async def test_an_unlinked_property_shows_no_lending_figures(
     assert "equity_cents" not in entry["property"]
     assert "ltv_bps" not in entry["property"]
     assert "liens" not in entry["property"]
+
+
+@pytest.mark.asyncio
+async def test_propose_is_the_only_write_and_moves_nothing(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    """FW-05: the sandbox's one write tool records a pending change with
+    the turn's attribution and touches nothing in the ledger."""
+    from sqlmodel import select
+
+    from app.services.ai.domains.chat.user_memory import memory_user
+    from app.services.finance.models import FinancePendingChange
+
+    account = await seed_account(svc)
+    from app.services.finance.models import FinanceCategory
+
+    cat = FinanceCategory(
+        owner_user_id=1,
+        name="Food & Dining:Groceries",
+        slug="pc-groceries",
+        classification="expense",
+    )
+    session.add(cat)
+    await session.flush()
+    txn = await svc.create_transaction(
+        account_id=account.id,
+        amount=-897,
+        txn_date=date(2026, 6, 10),
+        owner_user_id=1,
+        name="Shelly's Deli",
+    )
+    await session.commit()
+
+    with memory_user("1", agent_slug="finance-assistant", conversation_id="conv-9"):
+        result = await ai_tools.propose(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": cat.id},
+        )
+
+    assert result["status"] == "pending"
+    assert result["change_type"] == "transaction.categorize"
+    row = (
+        await session.exec(
+            select(FinancePendingChange).where(
+                FinancePendingChange.id == result["pending_change_id"]
+            )
+        )
+    ).one()
+    assert row.proposed_by_agent == "finance-assistant"
+    assert row.conversation_id == "conv-9"
+    await session.refresh(txn)
+    assert txn.category_id is None  # proposing moved nothing
+
+
+@pytest.mark.asyncio
+async def test_propose_registers_as_a_native_write_tool() -> None:
+    """Code mode must dispatch propose as a visible native call - a
+    write from inside the sandbox is invisible in the tool trail."""
+    from app.services.ai.domains.chat.tools import native_write_tool_names
+
+    assert "propose" in native_write_tool_names()
+
+
+@pytest.mark.asyncio
+async def test_transaction_detail_carries_the_ids_a_proposal_needs(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    """A model cannot propose transaction.categorize without the
+    transaction's id and the current category_id - names alone made the
+    write tool ungrantable in practice."""
+    account = await seed_account(svc)
+    txn = await svc.create_transaction(
+        account_id=account.id,
+        amount=-1_296,
+        txn_date=date(2026, 8, 21),
+        owner_user_id=1,
+        name="Target",
+    )
+    await session.commit()
+
+    result = await ai_tools.ledger(months=3, detail="transactions")
+
+    row = next(r for r in result["transactions"] if r["payee"] == "Target")
+    assert row["id"] == txn.id
+    assert row["category_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_categories_lists_the_assignable_targets(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    """The other half of a categorize payload: the target category's id."""
+    from app.services.finance.models import FinanceCategory
+
+    session.add(
+        FinanceCategory(
+            owner_user_id=1,
+            name="Food & Dining:Groceries",
+            slug="cat-tool-groceries",
+            classification="expense",
+        )
+    )
+    await session.commit()
+
+    result = await ai_tools.categories()
+
+    match = next(
+        c for c in result["categories"] if c["name"] == "Food & Dining:Groceries"
+    )
+    assert isinstance(match["id"], int)
+    assert match["classification"] == "expense"
+
+
+@pytest.mark.asyncio
+async def test_ledger_rows_say_uncategorized_outright(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    """ "Uncategorized" in this ledger is usually a REAL category (the
+    import catch-all), not a NULL - a model filtering category is None
+    burned four sandbox runs discovering that. The row states it."""
+    from app.services.finance.models import FinanceCategory
+
+    account = await seed_account(svc)
+    catchall = FinanceCategory(
+        owner_user_id=1,
+        name="Uncategorized",
+        slug="ai-tools-uncat",
+        classification="expense",
+    )
+    groceries = FinanceCategory(
+        owner_user_id=1,
+        name="Food & Dining:Groceries",
+        slug="ai-tools-groc",
+        classification="expense",
+    )
+    session.add(catchall)
+    session.add(groceries)
+    await session.flush()
+    await svc.create_transaction(
+        account_id=account.id,
+        amount=-100,
+        txn_date=date(2026, 8, 1),
+        owner_user_id=1,
+        name="Bare",
+    )
+    bucketed = await svc.create_transaction(
+        account_id=account.id,
+        amount=-200,
+        txn_date=date(2026, 8, 2),
+        owner_user_id=1,
+        name="Bucketed",
+    )
+    await svc.categorize_transaction(bucketed.id, catchall.id, owner_user_id=1)
+    filed = await svc.create_transaction(
+        account_id=account.id,
+        amount=-300,
+        txn_date=date(2026, 8, 3),
+        owner_user_id=1,
+        name="Filed",
+    )
+    await svc.categorize_transaction(filed.id, groceries.id, owner_user_id=1)
+    await session.commit()
+
+    result = await ai_tools.ledger(months=3, detail="transactions")
+
+    by_name = {r["payee"]: r for r in result["transactions"]}
+    assert by_name["Bare"]["uncategorized"] is True
+    assert (
+        by_name["Bucketed"]["uncategorized"] is True
+    )  # the catch-all IS uncategorized
+    assert by_name["Filed"]["uncategorized"] is False
+
+
+@pytest.mark.asyncio
+async def test_bills_lists_the_recurring_surface(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    """The agent cannot discuss (or match) bills it cannot see: every
+    live stream, both directions, with the ids proposals need."""
+    await seed_stream(
+        svc,
+        name="Eleanor Nursing Care",
+        expected_amount=100_000,
+        next_expected_date=date(2026, 7, 31),
+    )
+    await seed_stream(
+        svc,
+        name="Paycheck",
+        expected_amount=250_000,
+        next_expected_date=date(2026, 8, 1),
+        direction="inflow",
+        frequency="biweekly",
+    )
+    await session.commit()
+
+    result = await ai_tools.bills()
+
+    rows = {b["name"]: b for b in result["bills"]}
+    eleanor = rows["Eleanor Nursing Care"]
+    assert eleanor["direction"] == "outflow"
+    assert eleanor["frequency"] == "monthly"
+    assert eleanor["expected_amount"] == 100_000
+    assert eleanor["next_expected_date"] == "2026-07-31"
+    assert isinstance(eleanor["id"], int)
+    assert rows["Paycheck"]["direction"] == "inflow"
+
+
+@pytest.mark.asyncio
+async def test_bill_candidates_returns_the_ranked_shortlist(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    """The same shortlist the Bills tab's picker shows - the agent
+    proposes matches from the real heuristic, never from its own guess
+    about what looks similar."""
+    account = await seed_account(svc)
+    stream = await seed_stream(
+        svc,
+        name="Eleanor Nursing Care",
+        expected_amount=100_000,
+        next_expected_date=date(2026, 7, 31),
+    )
+    # The tools read under the standalone convention (owner NULL) -
+    # the matching heuristic scopes candidate rows to it.
+    payment = await seed_txn(
+        svc,
+        account.id,
+        -100_000,
+        date(2026, 7, 31),
+        name="Recurring Withdrawal CK *Eleanor Nursing Ca",
+        owner_user_id=None,
+    )
+    await seed_txn(  # wrong direction: never a candidate
+        svc,
+        account.id,
+        100_000,
+        date(2026, 7, 30),
+        name="Deposit",
+        owner_user_id=None,
+    )
+    await session.commit()
+
+    result = await ai_tools.bill_candidates(stream.id)
+
+    ids = [c["id"] for c in result["candidates"]]
+    assert payment.id in ids
+    top = result["candidates"][0]
+    assert top["amount"] == -100_000
+    assert top["date"] == "2026-07-31"
+    assert result["stream_id"] == stream.id
+
+
+@pytest.mark.asyncio
+async def test_bill_tools_register_for_granting() -> None:
+    assert {"bills", "bill_candidates"} <= set(registered_tool_names())
+
+
+@pytest.mark.asyncio
+async def test_ledger_rows_carry_their_tags(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    """The label axis must be visible where the agent reads - a tag it
+    cannot see is a rollup it cannot compute."""
+    from app.services.finance.domains.ledger.transactions import tag_transactions
+
+    account = await seed_account(svc)
+    txn = await seed_txn(svc, account.id, -900, date(2026, 8, 24), name="Link.com")
+    await tag_transactions(session, [txn.id], "Business", owner_user_id=None)
+    await session.commit()
+
+    result = await ai_tools.ledger(months=3, detail="transactions")
+
+    row = next(r for r in result["transactions"] if r["id"] == txn.id)
+    assert row["tags"] == ["Business"]
+
+
+@pytest.mark.asyncio
+async def test_tags_tool_lists_the_directory_with_counts(
+    svc: FinanceService, session: AsyncSession
+) -> None:
+    from app.services.finance.domains.ledger.transactions import tag_transactions
+
+    account = await seed_account(svc)
+    a = await seed_txn(svc, account.id, -900, date(2026, 8, 24), name="Link.com")
+    b = await seed_txn(svc, account.id, -800, date(2026, 8, 23), name="X Corp")
+    await tag_transactions(session, [a.id, b.id], "Business", owner_user_id=None)
+    await session.commit()
+
+    result = await ai_tools.tags()
+
+    assert {"name": "Business", "count": 2} in [
+        {"name": t["name"], "count": t["count"]} for t in result["tags"]
+    ]
 {% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
@@ -1,0 +1,647 @@
+"""The propose/approve queue: AI writes land as pending changes.
+
+FW-05. Confirmation is structural, not prompt discipline: the sandbox's
+only write tool is ``propose``, execution happens exclusively through
+``approve``, and the model cannot skip the confirmation because no
+direct-write tool exists.
+"""
+
+from datetime import date
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.finance.models import FinancePendingChange
+from app.services.finance.service import FinanceService
+from tests.services._finance_factories import seed_account as _account
+from tests.services._finance_factories import seed_category as _category
+from tests.services._finance_factories import seed_stream as _stream
+from tests.services._finance_factories import seed_txn as _txn
+
+
+class TestPendingChangeRow:
+    @pytest.mark.asyncio
+    async def test_a_proposal_row_round_trips(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        row = FinancePendingChange(
+            owner_user_id=1,
+            change_type="transaction.categorize",
+            payload={"transaction_id": 7, "category_id": 3},
+            proposed_by_agent="finance-assistant",
+            conversation_id="conv-123",
+        )
+        async_db_session.add(row)
+        await async_db_session.flush()
+
+        assert row.id is not None
+        assert row.status == "pending"
+        assert row.resolved_at is None
+        assert row.payload == {"transaction_id": 7, "category_id": 3}
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_status_is_refused_by_the_table(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        """The status vocabulary is the audit trail's spine; a typo'd
+        status would silently fall out of every pending/resolved read."""
+        from sqlalchemy.exc import IntegrityError
+
+        row = FinancePendingChange(
+            owner_user_id=1,
+            change_type="transaction.categorize",
+            payload={},
+            status="maybe",
+        )
+        async_db_session.add(row)
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+
+class TestProposeApproveReject:
+    """The queue's whole contract: propose moves nothing, approve executes
+    the real mutation transactionally, reject leaves the ledger alone,
+    and every resolution keeps its audit row."""
+
+    @staticmethod
+    async def _fixture(svc: FinanceService, session: AsyncSession):
+        account = await _account(svc)
+        groceries = await _category(session, "Food & Dining:Groceries")
+        txn = await _txn(svc, account.id, -897, date(2026, 6, 10), name="Shelly's Deli")
+        return groceries, txn
+
+    @pytest.mark.asyncio
+    async def test_propose_creates_a_pending_row_and_moves_nothing(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        groceries, txn = await self._fixture(svc, async_db_session)
+
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+            proposed_by_agent="finance-assistant",
+            conversation_id="conv-1",
+        )
+
+        assert row.status == "pending"
+        await async_db_session.refresh(txn)
+        assert txn.category_id is None  # nothing in the ledger moved
+
+    @pytest.mark.asyncio
+    async def test_approve_executes_the_real_mutation(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        groceries, txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+
+        resolved = await svc.approve_change(row.id, owner_user_id=1)
+
+        await async_db_session.refresh(txn)
+        assert txn.category_id == groceries.id
+        assert resolved.status == "approved"
+        assert resolved.resolved_at is not None
+
+    @pytest.mark.asyncio
+    async def test_reject_leaves_the_ledger_and_keeps_the_row(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        groceries, txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+
+        resolved = await svc.reject_change(row.id, owner_user_id=1)
+
+        await async_db_session.refresh(txn)
+        assert txn.category_id is None
+        assert resolved.status == "rejected"
+        assert resolved.resolved_at is not None
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_change_type_is_refused_at_propose(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        with pytest.raises(ValueError):
+            await svc.propose_change("ledger.set_on_fire", {}, owner_user_id=1)
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_payload_is_refused_at_propose(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """Fail at propose, not at approve: a card the user cannot safely
+        approve should never exist."""
+        with pytest.raises(ValueError):
+            await svc.propose_change(
+                "transaction.categorize", {"transaction_id": 1}, owner_user_id=1
+            )
+        with pytest.raises(ValueError):
+            await svc.propose_change(
+                "transaction.categorize",
+                {"transaction_id": 1, "category_id": 2, "amount": -999999},
+                owner_user_id=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_resolved_row_cannot_be_resolved_again(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        groceries, txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+        await svc.reject_change(row.id, owner_user_id=1)
+
+        with pytest.raises(ValueError):
+            await svc.approve_change(row.id, owner_user_id=1)
+
+    @pytest.mark.asyncio
+    async def test_a_failing_execution_stays_pending_with_the_error_recorded(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """Approval of a proposal whose target vanished must not half-land:
+        the row stays pending, the error is in the audit, the user can
+        reject it with full information."""
+        groceries, txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": 999_999, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+
+        with pytest.raises(Exception):
+            await svc.approve_change(row.id, owner_user_id=1)
+
+        await async_db_session.refresh(row)
+        assert row.status == "pending"
+        assert row.result.get("error")
+
+    @pytest.mark.asyncio
+    async def test_pending_changes_list_newest_first(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        groceries, txn = await self._fixture(svc, async_db_session)
+        first = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+        second = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+        await svc.reject_change(first.id, owner_user_id=1)
+
+        pending = await svc.list_pending_changes(owner_user_id=1)
+
+        assert [row.id for row in pending] == [second.id]
+
+
+class TestCategorizeCardCopy:
+    @pytest.mark.asyncio
+    async def test_the_card_shows_before_and_after(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """A recategorization is a MOVE: the card must say what it is
+        moving FROM, or approving is a leap of faith."""
+        account = await _account(svc)
+        shopping = await _category(async_db_session, "Shopping")
+        groceries = await _category(async_db_session, "Food & Dining:Groceries")
+        txn = await _txn(svc, account.id, -1_296, date(2026, 8, 21), name="Target")
+        await svc.categorize_transaction(txn.id, shopping.id, owner_user_id=1)
+
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(row)
+        }
+
+        assert display["Category"] == "Shopping \u2192 Food & Dining:Groceries"
+
+    @pytest.mark.asyncio
+    async def test_an_uncategorized_transaction_says_so(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        account = await _account(svc)
+        groceries = await _category(async_db_session, "Food & Dining:Groceries")
+        txn = await _txn(svc, account.id, -897, date(2026, 6, 10), name="Deli")
+
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(row)
+        }
+
+        assert display["Category"] == "Uncategorized \u2192 Food & Dining:Groceries"
+
+
+class TestResolutionFreezesTheRecord:
+    @pytest.mark.asyncio
+    async def test_an_approved_card_keeps_its_before_state(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """Read-time resolution is honest while pending; after approval
+        the mutation has happened, and re-resolving showed
+        "Groceries -> Groceries". Resolution snapshots the display into
+        the audit row, and the card reads history from there."""
+        account = await _account(svc)
+        shopping = await _category(async_db_session, "Shopping")
+        groceries = await _category(async_db_session, "Food & Dining:Groceries")
+        txn = await _txn(svc, account.id, -1_296, date(2026, 8, 21), name="Target")
+        await svc.categorize_transaction(txn.id, shopping.id, owner_user_id=1)
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+
+        resolved = await svc.approve_change(row.id, owner_user_id=1)
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(resolved)
+        }
+
+        assert display["Category"] == "Shopping \u2192 Food & Dining:Groceries"
+
+    @pytest.mark.asyncio
+    async def test_a_rejected_card_keeps_its_moment_too(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        account = await _account(svc)
+        shopping = await _category(async_db_session, "Shopping")
+        groceries = await _category(async_db_session, "Food & Dining:Groceries")
+        txn = await _txn(svc, account.id, -1_296, date(2026, 8, 21), name="Target")
+        await svc.categorize_transaction(txn.id, shopping.id, owner_user_id=1)
+        row = await svc.propose_change(
+            "transaction.categorize",
+            {"transaction_id": txn.id, "category_id": groceries.id},
+            owner_user_id=1,
+        )
+
+        resolved = await svc.reject_change(row.id, owner_user_id=1)
+        # the world moves after rejection - the card must not follow it
+        await svc.categorize_transaction(txn.id, groceries.id, owner_user_id=1)
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(resolved)
+        }
+
+        assert display["Category"] == "Shopping \u2192 Food & Dining:Groceries"
+
+
+class TestBatches:
+    """ "Approve them all" is one decision over many auditable rows: a
+    batch is a grouping, not a different kind of change - every row
+    still resolves individually and keeps its own audit trail."""
+
+    @staticmethod
+    async def _many(svc: FinanceService, session: AsyncSession, n: int = 3):
+        account = await _account(svc)
+        groceries = await _category(session, "Food & Dining:Groceries")
+        txns = [
+            await _txn(
+                svc, account.id, -1_000 - i, date(2026, 8, 1 + i), name=f"Store {i}"
+            )
+            for i in range(n)
+        ]
+        rows = await svc.propose_many_changes(
+            "transaction.categorize",
+            [{"transaction_id": t.id, "category_id": groceries.id} for t in txns],
+            owner_user_id=1,
+            proposed_by_agent="finance-assistant",
+        )
+        return txns, groceries, rows
+
+    @pytest.mark.asyncio
+    async def test_a_batch_shares_one_id_and_moves_nothing(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        txns, _groceries, rows = await self._many(svc, async_db_session)
+
+        assert len(rows) == 3
+        assert len({r.batch_id for r in rows}) == 1
+        assert rows[0].batch_id is not None
+        for txn in txns:
+            await async_db_session.refresh(txn)
+            assert txn.category_id is None
+
+    @pytest.mark.asyncio
+    async def test_approve_batch_executes_all_but_the_vetoed(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        txns, groceries, rows = await self._many(svc, async_db_session)
+        vetoed = rows[1]
+
+        summary = await svc.approve_batch(
+            rows[0].batch_id, owner_user_id=1, exclude_ids=[vetoed.id]
+        )
+
+        assert summary["approved"] == 2
+        assert summary["rejected"] == 1
+        await async_db_session.refresh(txns[0])
+        await async_db_session.refresh(txns[1])
+        assert txns[0].category_id == groceries.id
+        assert txns[1].category_id is None  # the veto held
+        await async_db_session.refresh(vetoed)
+        assert vetoed.status == "rejected"
+
+    @pytest.mark.asyncio
+    async def test_reject_batch_leaves_the_ledger_untouched(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        txns, _groceries, rows = await self._many(svc, async_db_session)
+
+        summary = await svc.reject_batch(rows[0].batch_id, owner_user_id=1)
+
+        assert summary["rejected"] == 3
+        for txn in txns:
+            await async_db_session.refresh(txn)
+            assert txn.category_id is None
+
+    @pytest.mark.asyncio
+    async def test_a_bad_row_fails_alone_not_the_batch(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """One vanished target must not hold the other eleven hostage:
+        the failed row stays pending with its error, the rest land."""
+        txns, groceries, rows = await self._many(svc, async_db_session)
+        doomed = rows[2]
+        doomed_payload = dict(doomed.payload)
+        doomed_payload["transaction_id"] = 999_999
+        doomed.payload = doomed_payload
+        async_db_session.add(doomed)
+        await async_db_session.flush()
+
+        summary = await svc.approve_batch(rows[0].batch_id, owner_user_id=1)
+
+        assert summary["approved"] == 2
+        assert summary["failed"] == 1
+        await async_db_session.refresh(doomed)
+        assert doomed.status == "pending"
+        assert doomed.result.get("error")
+
+    @pytest.mark.asyncio
+    async def test_an_empty_or_oversized_batch_is_refused(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        with pytest.raises(ValueError):
+            await svc.propose_many_changes(
+                "transaction.categorize", [], owner_user_id=1
+            )
+        with pytest.raises(ValueError):
+            await svc.propose_many_changes(
+                "transaction.categorize",
+                [{"transaction_id": i, "category_id": 1} for i in range(101)],
+                owner_user_id=1,
+            )
+
+
+class TestMatchExecutor:
+    """recurring.match: the manual which-payment-paid-this-bill attach,
+    behind the queue. The executor rides the same domain verb the Bills
+    tab's picker calls - approve here and a click there are one code
+    path."""
+
+    @staticmethod
+    async def _fixture(svc: FinanceService, session: AsyncSession):
+        account = await _account(svc)
+        stream = await _stream(
+            svc,
+            name="Eleanor Nursing Care",
+            expected_amount=100_000,
+            next_expected_date=date(2026, 7, 31),
+        )
+        txn = await _txn(
+            svc,
+            account.id,
+            -100_000,
+            date(2026, 7, 31),
+            name="Recurring Withdrawal CK *Eleanor Nursing Ca",
+        )
+        return stream, txn
+
+    @pytest.mark.asyncio
+    async def test_approve_attaches_the_payment_and_advances_the_bill(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        stream, txn = await self._fixture(svc, async_db_session)
+
+        row = await svc.propose_change(
+            "recurring.match",
+            {"transaction_id": txn.id, "stream_id": stream.id},
+            owner_user_id=1,
+        )
+        await async_db_session.refresh(txn)
+        assert txn.recurring_stream_id is None  # proposing moved nothing
+
+        resolved = await svc.approve_change(row.id, owner_user_id=1)
+
+        assert resolved.status == "approved"
+        await async_db_session.refresh(txn)
+        await async_db_session.refresh(stream)
+        assert txn.recurring_stream_id == stream.id
+        assert stream.next_expected_date == date(2026, 8, 31)
+
+    @pytest.mark.asyncio
+    async def test_the_card_names_both_sides(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """The card must say WHICH payment and WHICH bill, payee-first,
+        with the bill as the arrow's target - approving a match the card
+        only half-describes is a leap of faith."""
+        stream, txn = await self._fixture(svc, async_db_session)
+
+        row = await svc.propose_change(
+            "recurring.match",
+            {"transaction_id": txn.id, "stream_id": stream.id},
+            owner_user_id=1,
+        )
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(row)
+        }
+
+        assert "$1,000.00" in display["Payment"]
+        assert "2026-07-31" in display["Payment"]
+        assert display["Bill"] == "Unmatched \u2192 Eleanor Nursing Care"
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_match_payload_is_refused_at_propose(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        stream, txn = await self._fixture(svc, async_db_session)
+
+        with pytest.raises(ValueError):
+            await svc.propose_change(
+                "recurring.match",
+                {"transaction_id": txn.id, "stream_id": stream.id, "force": True},
+                owner_user_id=1,
+            )
+
+    @pytest.mark.asyncio
+    async def test_a_vanished_stream_fails_the_approval_not_the_queue(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        stream, txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "recurring.match",
+            {"transaction_id": txn.id, "stream_id": stream.id},
+            owner_user_id=1,
+        )
+        await svc.delete_recurring(stream.id, owner_user_id=1)
+
+        with pytest.raises(Exception):
+            await svc.approve_change(row.id, owner_user_id=1)
+
+        await async_db_session.refresh(row)
+        assert row.status == "pending"
+        assert row.result.get("error")
+        await async_db_session.refresh(txn)
+        assert txn.recurring_stream_id is None
+
+
+class TestTagExecutors:
+    """transaction.tag / transaction.untag: the label axis, behind the
+    queue. Rides the register's own verbs (get-or-create by normalized
+    name, idempotent attach) - the bulk toolbar and an approval here are
+    one code path."""
+
+    @staticmethod
+    async def _fixture(svc: FinanceService, session: AsyncSession):
+        account = await _account(svc)
+        txn = await _txn(svc, account.id, -900, date(2026, 8, 24), name="Link.com")
+        return txn
+
+    @pytest.mark.asyncio
+    async def test_approve_tags_the_transaction(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.domains.ledger.transactions import (
+            transaction_tags,
+        )
+
+        txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "transaction.tag",
+            {"transaction_id": txn.id, "tag": "Business"},
+            owner_user_id=1,
+        )
+        assert (await transaction_tags(async_db_session, [txn.id])).get(
+            txn.id, []
+        ) == []
+
+        await svc.approve_change(row.id, owner_user_id=1)
+
+        tags = await transaction_tags(async_db_session, [txn.id])
+        assert [t.name for t in tags[txn.id]] == ["Business"]
+
+    @pytest.mark.asyncio
+    async def test_tags_accumulate_they_do_not_replace(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """The whole point of the axis: labels are a SET, never a slot."""
+        from app.services.finance.domains.ledger.transactions import (
+            transaction_tags,
+        )
+
+        txn = await self._fixture(svc, async_db_session)
+        for name in ("Business", "Travel"):
+            row = await svc.propose_change(
+                "transaction.tag",
+                {"transaction_id": txn.id, "tag": name},
+                owner_user_id=1,
+            )
+            await svc.approve_change(row.id, owner_user_id=1)
+
+        tags = await transaction_tags(async_db_session, [txn.id])
+        assert sorted(t.name for t in tags[txn.id]) == ["Business", "Travel"]
+
+    @pytest.mark.asyncio
+    async def test_the_tag_card_shows_the_set_before_and_after(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.domains.ledger.transactions import (
+            tag_transactions,
+        )
+
+        txn = await self._fixture(svc, async_db_session)
+        await tag_transactions(async_db_session, [txn.id], "Travel", owner_user_id=1)
+
+        row = await svc.propose_change(
+            "transaction.tag",
+            {"transaction_id": txn.id, "tag": "Business"},
+            owner_user_id=1,
+        )
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(row)
+        }
+
+        assert display["Tags"] == "Travel \u2192 Business, Travel"
+
+    @pytest.mark.asyncio
+    async def test_an_untagged_transaction_reads_none(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "transaction.tag",
+            {"transaction_id": txn.id, "tag": "Business"},
+            owner_user_id=1,
+        )
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(row)
+        }
+        assert display["Tags"] == "none \u2192 Business"
+
+    @pytest.mark.asyncio
+    async def test_approve_untag_detaches_only_that_tag(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.domains.ledger.transactions import (
+            tag_transactions,
+            transaction_tags,
+        )
+
+        txn = await self._fixture(svc, async_db_session)
+        await tag_transactions(async_db_session, [txn.id], "Business", owner_user_id=1)
+        await tag_transactions(async_db_session, [txn.id], "Travel", owner_user_id=1)
+
+        row = await svc.propose_change(
+            "transaction.untag",
+            {"transaction_id": txn.id, "tag": "Business"},
+            owner_user_id=1,
+        )
+        await svc.approve_change(row.id, owner_user_id=1)
+
+        tags = await transaction_tags(async_db_session, [txn.id])
+        assert [t.name for t in tags[txn.id]] == ["Travel"]
+
+    @pytest.mark.asyncio
+    async def test_untagging_an_unknown_tag_fails_the_approval(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        txn = await self._fixture(svc, async_db_session)
+        row = await svc.propose_change(
+            "transaction.untag",
+            {"transaction_id": txn.id, "tag": "Nonesuch"},
+            owner_user_id=1,
+        )
+
+        with pytest.raises(Exception):
+            await svc.approve_change(row.id, owner_user_id=1)
+
+        await async_db_session.refresh(row)
+        assert row.status == "pending"
+        assert row.result.get("error")

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
@@ -645,3 +645,50 @@ class TestTagExecutors:
         await async_db_session.refresh(row)
         assert row.status == "pending"
         assert row.result.get("error")
+
+    @pytest.mark.asyncio
+    async def test_the_card_never_shows_a_duplicate_it_will_not_create(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """Execute dedupes by normalized name ("business" attaches the
+        existing "Business" tag); the card must predict with the same
+        rule, not show "Business, business"."""
+        from app.services.finance.domains.ledger.transactions import (
+            tag_transactions,
+        )
+
+        txn = await self._fixture(svc, async_db_session)
+        await tag_transactions(async_db_session, [txn.id], "Business", owner_user_id=1)
+
+        row = await svc.propose_change(
+            "transaction.tag",
+            {"transaction_id": txn.id, "tag": "business"},
+            owner_user_id=1,
+        )
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(row)
+        }
+
+        assert display["Tags"] == "Business \u2192 Business"
+
+    @pytest.mark.asyncio
+    async def test_untag_describe_matches_by_normalized_name_too(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        from app.services.finance.domains.ledger.transactions import (
+            tag_transactions,
+        )
+
+        txn = await self._fixture(svc, async_db_session)
+        await tag_transactions(async_db_session, [txn.id], "Business", owner_user_id=1)
+
+        row = await svc.propose_change(
+            "transaction.untag",
+            {"transaction_id": txn.id, "tag": "BUSINESS!"},
+            owner_user_id=1,
+        )
+        display = {
+            d["label"]: d["value"] for d in await svc.describe_pending_change(row)
+        }
+
+        assert display["Tags"] == "Business \u2192 none"


### PR DESCRIPTION
## What this is

The finance write surface for agents (FW-05 and the first riders on it): agents can propose ledger mutations, and nothing runs until the user approves.

## The queue (FW-05)

- Confirmation is **structural**: the sandbox's only write tools are `propose`/`propose_many`. Every mutation lands as a `finance_pending_change` row; execution happens exclusively through user approval, and the resolved row is the audit trail.
- One component registry renders the stored row on both surfaces - the in-chat card and the Overview tab's pending-changes rail - so what the user sees is what executes, by construction.
- Batches share a `batch_id`: one card, one bulk decision, per-row veto ("Approve all (N)" counts exactly what will land).

## Registered change types

| change_type | payload | rides |
|---|---|---|
| `transaction.categorize` | `{transaction_id, category_id}` | the register's categorize verb |
| `recurring.match` | `{transaction_id, stream_id}` | the same attach verb as the Bills tab's manual picker |
| `transaction.tag` / `transaction.untag` | `{transaction_id, tag}` | the existing tag axis, by name (created on first use) |

New agent read tools: `bills()`, `bill_candidates()` (the app's own ranked match shortlist - the prompt forbids similarity-guessing), `tags()`, plus `tags` on ledger rows so tag rollups are computed from data.

## Card behavior

- Resolved cards auto-collapse to title + outcome (chevron to expand); batches collapse to a count summary.
- "before → after" values render the target in accent teal; vetoed/rejected rows stay dim.
- Cards build from a compact trace marker (immune to the 2KB result clip that silently ate a 9-row batch card), refresh from the queue on tab revisit, and a salvage path recovers cards from pre-marker truncated traces.
- Display resolves names live while pending and freezes at resolution.

## Also in here

- `attach_transaction_to_stream` refuses soft-deleted streams (a queued proposal can outlive its bill).
- Import review gains an "Import up to date" dead end - a file whose every row is already stored gets one OK button, not an Import button.
- Ollama model sync so the picker shows locally installed models.
- The four branchy AI-service templates (`chat`, `streaming`, `agent_loader`, finance `router`) now render byte-identical to a ruff-formatted generated project.

## Testing

- 1,252 generated-project tests green (finance service, API, frontend, AI), typecheck clean
- 1,416 aegis core guards green (module budgets, tree hygiene, generator, render parity)
- Live-verified end to end in a running instance: single proposals, batches with veto, cross-surface refresh, matching, and tagging