### PR TITLE
Default generated projects to Python 3.14; fix RAG and memory-backend template debt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,23 @@
   agent tool-result boundary.
 
 
+### Changed
+- Generated projects default to Python 3.14. The RAG option no longer pins
+  projects below 3.14 (onnxruntime now ships 3.14 wheels), so the interactive
+  RAG compatibility warning is gone. Any supported version (3.11 to 3.14) can
+  still be selected with `--python-version`.
+
+### Fixed
+- Generated projects on the AI memory backend now pass lint, typecheck and
+  tests: `memory_user` and the active-model selector no longer leak into the
+  memory backend, and DB-only endpoint tests are gated out.
+- RAG chunking: an overlap at or above the chunk size no longer loops
+  forever (default overlap is a fifth of the chunk size, larger values are
+  rejected), documents that fit in one chunk are kept whole, a min chunk
+  size at or above the chunk size no longer filters everything, and
+  `estimate_chunks` no longer overcounts by one. The RAG service tests use
+  `RAGServiceConfig` instead of a stale settings mock.
+
 ## [0.10.1] - 2026-07-20
 
 ### Added

--- a/aegis/cli/interactive.py
+++ b/aegis/cli/interactive.py
@@ -5,7 +5,6 @@ This module contains interactive selection and prompting functions
 used by CLI commands.
 """
 
-import sys
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -1150,20 +1149,11 @@ def interactive_ai_service_config(
         # No Ollama selected - set mode to none
         _ollama_mode_selection[service_name] = OllamaMode.NONE
 
-    # RAG selection with Python 3.14 compatibility check
     typer.echo(f"\n{t('interactive.ai_rag_label')}")
-    if sys.version_info >= (3, 14):
-        brand.warn(f"  {t('interactive.ai_rag_warning')}")
-        typer.echo(f"  {t('interactive.ai_rag_compat_note')}")
-        rag_enabled = typer.confirm(
-            f"  {t('interactive.ai_rag_compat_prompt')}",
-            default=True,
-        )
-    else:
-        rag_enabled = typer.confirm(
-            f"  {t('interactive.ai_rag_prompt')}",
-            default=True,
-        )
+    rag_enabled = typer.confirm(
+        f"  {t('interactive.ai_rag_prompt')}",
+        default=True,
+    )
     _ai_rag_selection[service_name] = rag_enabled
     if rag_enabled:
         brand.success(f"  {t('interactive.ai_rag_enabled')}")

--- a/aegis/config/defaults.py
+++ b/aegis/config/defaults.py
@@ -88,16 +88,10 @@ def _generate_supported_versions(min_version: str, max_version: str) -> list[str
 # Parse bounds from pyproject.toml (single source of truth)
 _min_version, _max_version = _parse_python_version_bounds()
 
-# Default Python version for generated projects.
-#
-# Pinned to 3.13 (not the auto-derived max of 3.14) because the 3.14
-# ecosystem is still incomplete: openai 2.x has a circular import on
-# pytest collection under 3.14, and ``requests.compat`` is missing
-# ``JSONDecodeError``. Both break ``make check`` in matrix tests.
-# 3.13 has been out long enough that all our pinned deps work.
-# Users can still opt into 3.14 explicitly via ``--python-version 3.14``
-# (or 3.11 / 3.12 — anything in SUPPORTED_PYTHON_VERSIONS works).
-DEFAULT_PYTHON_VERSION = "3.13"
+# Default Python version for generated projects: the newest supported
+# version. Users can pick any entry in SUPPORTED_PYTHON_VERSIONS via
+# ``--python-version``.
+DEFAULT_PYTHON_VERSION = _max_version
 
 # Supported Python versions (auto-generated from min to max)
 SUPPORTED_PYTHON_VERSIONS = _generate_supported_versions(_min_version, _max_version)

--- a/aegis/core/copier_manager.py
+++ b/aegis/core/copier_manager.py
@@ -12,7 +12,6 @@ from typing import Any, Literal
 import typer
 import yaml
 from copier import run_copy, run_update
-from packaging.version import Version
 
 from aegis import __version__
 from aegis.i18n import t
@@ -112,12 +111,7 @@ def generate_with_copier(
     # Get template context from template generator
     template_context = template_gen.get_template_context()
 
-    # Determine Python version early - may need to override for RAG compatibility
-    # When RAG is enabled, chromadb requires onnxruntime which lacks Python 3.14 wheels
     python_version = template_context.get("python_version", DEFAULT_PYTHON_VERSION)
-    ai_rag = template_context.get(AnswerKeys.AI_RAG, "no") == "yes"
-    if ai_rag and python_version and Version(python_version) >= Version("3.14"):
-        python_version = "3.13"
 
     # Convert template context to Copier data format
     # Copier uses boolean values instead of "yes"/"no" strings

--- a/aegis/core/post_gen_tasks.py
+++ b/aegis/core/post_gen_tasks.py
@@ -362,6 +362,9 @@ def cleanup_components(project_path: Path, context: dict[str, Any]) -> None:
         # Remove LLM tracking models (only needed with persistence)
         # Keep app/services/ai/models/__init__.py - contains core types (AIProvider, ProviderConfig)
         remove_dir(project_path, "app/services/ai/models/llm")
+        # The active-model selector reads the LLM tables removed above.
+        remove_file(project_path, "app/services/ai/domains/llm/active_model.py")
+        remove_file(project_path, "tests/services/ai/test_active_model.py")
         # Agent registry models ride the same persistence gate (the memory
         # backend resolves the default agent from code, not DB rows). The
         # tools.py registry itself stays: it is DB-free and the code-config
@@ -681,7 +684,7 @@ def install_dependencies(project_path: Path, python_version: str | None = None) 
         We pass --python to uv sync when python_version is specified to ensure
         uv uses the correct Python version and respects the requires-python
         constraint in pyproject.toml. This prevents uv from selecting incompatible
-        Python versions (e.g., 3.14 when requires-python = ">=3.11,<3.14").
+        Python versions than the project's requires-python allows.
 
         When python_version is None, uv sync runs without version constraint,
         allowing uv to auto-detect a compatible Python version.

--- a/aegis/i18n/locales/de.py
+++ b/aegis/i18n/locales/de.py
@@ -204,15 +204,6 @@ MESSAGES: dict[str, str] = {
         "Hinweis: Erster Start kann Zeit für den Modell-Download benötigen"
     ),
     "interactive.ai_rag_label": "RAG (Retrieval-Augmented Generation):",
-    "interactive.ai_rag_warning": (
-        "Warnung: RAG benötigt Python <3.14 (chromadb/onnxruntime-Einschränkung)"
-    ),
-    "interactive.ai_rag_compat_note": (
-        "RAG aktivieren generiert ein Projekt, das Python 3.11–3.13 benötigt"
-    ),
-    "interactive.ai_rag_compat_prompt": (
-        "RAG trotz Python-3.14-Inkompatibilität aktivieren?"
-    ),
     "interactive.ai_rag_prompt": (
         "RAG für Dokumentenindexierung und semantische Suche aktivieren?"
     ),

--- a/aegis/i18n/locales/en.py
+++ b/aegis/i18n/locales/en.py
@@ -211,15 +211,6 @@ MESSAGES: dict[str, str] = {
         "Note: First startup may take time to download models"
     ),
     "interactive.ai_rag_label": "RAG (Retrieval-Augmented Generation):",
-    "interactive.ai_rag_warning": (
-        "Warning: RAG requires Python <3.14 (chromadb/onnxruntime limitation)"
-    ),
-    "interactive.ai_rag_compat_note": (
-        "Enabling RAG will generate a project requiring Python 3.11-3.13"
-    ),
-    "interactive.ai_rag_compat_prompt": (
-        "Enable RAG despite Python 3.14 incompatibility?"
-    ),
     "interactive.ai_rag_prompt": (
         "Enable RAG for document indexing and semantic search?"
     ),

--- a/aegis/i18n/locales/es.py
+++ b/aegis/i18n/locales/es.py
@@ -206,15 +206,6 @@ MESSAGES: dict[str, str] = {
         "Nota: El primer inicio puede tardar en descargar modelos"
     ),
     "interactive.ai_rag_label": "RAG (Retrieval-Augmented Generation):",
-    "interactive.ai_rag_warning": (
-        "Advertencia: RAG requiere Python <3.14 (limitación de chromadb/onnxruntime)"
-    ),
-    "interactive.ai_rag_compat_note": (
-        "Habilitar RAG generará un proyecto que requiere Python 3.11-3.13"
-    ),
-    "interactive.ai_rag_compat_prompt": (
-        "¿Habilitar RAG a pesar de incompatibilidad con Python 3.14?"
-    ),
     "interactive.ai_rag_prompt": (
         "¿Habilitar RAG para indexación de documentos y búsqueda semántica?"
     ),

--- a/aegis/i18n/locales/fr.py
+++ b/aegis/i18n/locales/fr.py
@@ -206,15 +206,6 @@ MESSAGES: dict[str, str] = {
         "Note : le premier démarrage peut prendre du temps pour télécharger les modèles"
     ),
     "interactive.ai_rag_label": "RAG (Retrieval-Augmented Generation) :",
-    "interactive.ai_rag_warning": (
-        "Attention : RAG nécessite Python <3.14 (limitation chromadb/onnxruntime)"
-    ),
-    "interactive.ai_rag_compat_note": (
-        "Activer RAG générera un projet nécessitant Python 3.11-3.13"
-    ),
-    "interactive.ai_rag_compat_prompt": (
-        "Activer RAG malgré l'incompatibilité avec Python 3.14 ?"
-    ),
     "interactive.ai_rag_prompt": (
         "Activer RAG pour l'indexation de documents et la recherche sémantique ?"
     ),

--- a/aegis/i18n/locales/ja.py
+++ b/aegis/i18n/locales/ja.py
@@ -196,15 +196,6 @@ MESSAGES: dict[str, str] = {
         "注意：初回起動時はモデルのダウンロードに時間がかかります"
     ),
     "interactive.ai_rag_label": "RAG（検索拡張生成）：",
-    "interactive.ai_rag_warning": (
-        "警告：RAG は Python <3.14 が必要です（chromadb/onnxruntime の制限）"
-    ),
-    "interactive.ai_rag_compat_note": (
-        "RAG を有効にすると Python 3.11〜3.13 が必要なプロジェクトが生成されます"
-    ),
-    "interactive.ai_rag_compat_prompt": (
-        "Python 3.14 非互換ですが RAG を有効にしますか？"
-    ),
     "interactive.ai_rag_prompt": (
         "ドキュメントインデックスとセマンティック検索の RAG を有効にしますか？"
     ),

--- a/aegis/i18n/locales/ko.py
+++ b/aegis/i18n/locales/ko.py
@@ -185,15 +185,6 @@ MESSAGES: dict[str, str] = {
         "참고: 첫 시작 시 모델 다운로드에 시간이 걸릴 수 있습니다"
     ),
     "interactive.ai_rag_label": "RAG (검색 증강 생성):",
-    "interactive.ai_rag_warning": (
-        "경고: RAG는 Python <3.14 필요 (chromadb/onnxruntime 제한)"
-    ),
-    "interactive.ai_rag_compat_note": (
-        "RAG를 활성화하면 Python 3.11-3.13이 필요한 프로젝트가 생성됩니다"
-    ),
-    "interactive.ai_rag_compat_prompt": (
-        "Python 3.14 비호환에도 RAG를 활성화하시겠습니까?"
-    ),
     "interactive.ai_rag_prompt": (
         "문서 인덱싱 및 시맨틱 검색을 위해 RAG를 활성화하시겠습니까?"
     ),

--- a/aegis/i18n/locales/ru.py
+++ b/aegis/i18n/locales/ru.py
@@ -194,15 +194,6 @@ MESSAGES: dict[str, str] = {
         "Примечание: первый запуск может занять время для загрузки моделей"
     ),
     "interactive.ai_rag_label": "RAG (Retrieval-Augmented Generation):",
-    "interactive.ai_rag_warning": (
-        "Внимание: RAG требует Python <3.14 (ограничение chromadb/onnxruntime)"
-    ),
-    "interactive.ai_rag_compat_note": (
-        "Включение RAG ограничит проект версиями Python 3.11–3.13"
-    ),
-    "interactive.ai_rag_compat_prompt": (
-        "Включить RAG несмотря на несовместимость с Python 3.14?"
-    ),
     "interactive.ai_rag_prompt": (
         "Включить RAG для индексации документов и семантического поиска?"
     ),

--- a/aegis/i18n/locales/zh.py
+++ b/aegis/i18n/locales/zh.py
@@ -160,11 +160,6 @@ MESSAGES: dict[str, str] = {
     "interactive.ai_ollama_docker_ok": ("Ollama 服务将写入 docker-compose.yml"),
     "interactive.ai_ollama_docker_hint": "首次启动可能需要较长时间下载模型",
     "interactive.ai_rag_label": "RAG（检索增强生成）：",
-    "interactive.ai_rag_warning": (
-        "注意：RAG 暂不支持 Python 3.14（chromadb / onnxruntime 限制）"
-    ),
-    "interactive.ai_rag_compat_note": ("启用 RAG 后，项目将要求 Python 3.11–3.13"),
-    "interactive.ai_rag_compat_prompt": "尽管如此，仍要启用 RAG？",
     "interactive.ai_rag_prompt": "启用 RAG？（文档索引与语义检索）",
     "interactive.ai_rag_enabled": "已启用 RAG，向量存储使用 ChromaDB",
     "interactive.ai_voice_label": "语音功能（TTS 语音合成 & STT 语音识别）：",

--- a/aegis/i18n/locales/zh_hant.py
+++ b/aegis/i18n/locales/zh_hant.py
@@ -160,11 +160,6 @@ MESSAGES: dict[str, str] = {
     "interactive.ai_ollama_docker_ok": ("Ollama 服務將寫入 docker-compose.yml"),
     "interactive.ai_ollama_docker_hint": "首次啟動可能需要較長時間下載模型",
     "interactive.ai_rag_label": "RAG（檢索增強生成）：",
-    "interactive.ai_rag_warning": (
-        "注意：RAG 暫不支援 Python 3.14（chromadb / onnxruntime 限制）"
-    ),
-    "interactive.ai_rag_compat_note": ("啟用 RAG 後，專案將要求 Python 3.11–3.13"),
-    "interactive.ai_rag_compat_prompt": "盡管如此，仍要啟用 RAG？",
     "interactive.ai_rag_prompt": "啟用 RAG？（文檔索引與語義檢索）",
     "interactive.ai_rag_enabled": "已啟用 RAG，向量存儲使用 ChromaDB",
     "interactive.ai_voice_label": "語音功能（TTS 語音合成 & STT 語音識別）：",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/ai/router.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/ai/router.py.jinja
@@ -16,6 +16,8 @@ from typing import Any
 from app.components.backend.api.ai import memory as memory_routes
 from app.services.ai.domains.chat.attachments import ChatAttachment
 from app.services.ai.domains.chat.user_memory import DEFAULT_MEMORY_USER_ID
+{% else %}
+from app.services.ai.domains.chat.attachments import ChatAttachment
 {% endif %}
 from app.core.config import settings
 from app.core.log import logger

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
@@ -21,16 +21,20 @@ from app.services.ai.domains.chat.attachments import (
     annotate_attachments,
 {% if ai_framework == "pydantic-ai" %}    build_user_content,
 {% endif %})
+{%- if ai_backend != "memory" %}
 from app.services.ai.domains.chat.module_context import render_memory_modules
+{%- endif %}
 from app.services.ai.domains.chat.readings import (
     merge_staged_readings,
     reading_stage,
 )
 from app.services.ai.domains.chat.titles import conversation_title
+{%- if ai_backend != "memory" %}
 from app.services.ai.domains.chat.user_memory import (
     build_user_memory_context,
     memory_user,
 )
+{%- endif %}
 from app.services.ai.models import Conversation, ConversationMessage, MessageRole
 from app.services.ai.service.base import (
     AIServiceError,
@@ -187,6 +191,7 @@ class ChatMixin(PromptMixin):
             # Get AI response. The turn's user rides a ContextVar so a
             # memory write from inside the model call knows whose it is.
             start_time = datetime.now(UTC)
+{% if ai_backend != "memory" %}
             with (
                 memory_user(
                     user_id,
@@ -195,6 +200,9 @@ class ChatMixin(PromptMixin):
                 ),
                 reading_stage() as staged_readings,
             ):
+{% else %}
+            with reading_stage() as staged_readings:
+{% endif %}
                 result = await agent.run(
                     build_user_content(conversation_context, attachments)
                 )

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/streaming.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/streaming.py.jinja
@@ -261,6 +261,7 @@ class StreamingMixin(ChatMixin):
             # The turn's user rides a ContextVar for the whole stream:
             # a memory write lands mid-stream, inside a tool call, and
             # has no other way to know whose fact it is.
+{% if ai_backend != "memory" %}
             with (
                 memory_user(
                     user_id,
@@ -269,6 +270,9 @@ class StreamingMixin(ChatMixin):
                 ),
                 reading_stage() as staged_readings,
             ):
+{% else %}
+            with reading_stage() as staged_readings:
+{% endif %}
                 async with agent.run_stream_events(
                     build_user_content(conversation_context, attachments)
                 ) as events:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/rag/chunking.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/rag/chunking.py
@@ -114,11 +114,21 @@ def chunk_params_for_strategy(strategy: str) -> tuple[int, int]:
     """
     params = CHUNKING_STRATEGIES.get(strategy)
     if params is None:
-        logger.warning(
-            "Unknown chunking strategy; using paragraph", strategy=strategy
-        )
+        logger.warning("Unknown chunking strategy; using paragraph", strategy=strategy)
         return CHUNKING_STRATEGIES["paragraph"]
     return params
+
+
+def _resolve_overlap(chunk_size: int, chunk_overlap: int | None) -> int:
+    """Default overlap to a fifth of the chunk; reject one that never advances."""
+    if chunk_overlap is None:
+        return chunk_size // 5
+    if chunk_overlap >= chunk_size:
+        raise ValueError(
+            f"chunk_overlap ({chunk_overlap}) must be less than "
+            f"chunk_size ({chunk_size})"
+        )
+    return chunk_overlap
 
 
 class DocumentChunker:
@@ -130,20 +140,30 @@ class DocumentChunker:
     def __init__(
         self,
         chunk_size: int = 2000,
-        chunk_overlap: int = 400,
-        min_chunk_size: int = 50,
+        chunk_overlap: int | None = None,
+        min_chunk_size: int | None = None,
     ):
         """
         Initialize document chunker.
 
         Args:
             chunk_size: Maximum chunk size in characters
-            chunk_overlap: Overlap between chunks in characters
-            min_chunk_size: Minimum chunk size to keep (smaller chunks filtered out)
+            chunk_overlap: Overlap between chunks (default: a fifth of chunk_size)
+            min_chunk_size: Minimum chunk size to keep (default 50, scaled
+                down for small chunk sizes; smaller chunks filtered out)
         """
+        if chunk_size <= 0:
+            raise ValueError(f"chunk_size ({chunk_size}) must be positive")
         self.chunk_size = chunk_size
-        self.chunk_overlap = chunk_overlap
-        self.min_chunk_size = min_chunk_size
+        self.chunk_overlap = _resolve_overlap(chunk_size, chunk_overlap)
+        if min_chunk_size is None:
+            # Default junk-fragment floor, scaled down where separator
+            # splits land just under a small ceiling.
+            self.min_chunk_size = min(50, chunk_size // 2)
+        else:
+            # An explicit floor stands as the caller wrote it, kept just
+            # below the ceiling - at it, every chunk would be filtered.
+            self.min_chunk_size = min(min_chunk_size, chunk_size - 1)
 
     async def chunk(
         self,
@@ -162,8 +182,16 @@ class DocumentChunker:
         Returns:
             list[Document]: Chunked documents with preserved metadata
         """
-        size = chunk_size or self.chunk_size
-        overlap = chunk_overlap or self.chunk_overlap
+        size = self.chunk_size if chunk_size is None else chunk_size
+        if size <= 0:
+            # ``or`` used to swallow 0 silently; a negative walked the
+            # splitter into a non-advancing loop.
+            raise ValueError(f"chunk_size ({size}) must be positive")
+        overlap = (
+            self.chunk_overlap
+            if chunk_size is None and chunk_overlap is None
+            else _resolve_overlap(size, chunk_overlap)
+        )
 
         # Run chunking in thread pool (CPU-bound)
         chunks = await asyncio.to_thread(
@@ -215,10 +243,14 @@ class DocumentChunker:
                 content, chunk_size, chunk_overlap, separators
             )
 
-            # Filter out low-quality chunks and track valid ones
+            # Filter out low-quality chunks and track valid ones. A document
+            # that fits in a single chunk is kept whole: dropping it would
+            # erase short files from the index entirely.
             valid_chunks: list[tuple[str, int, int]] = []
             for chunk_text, start_line, end_line in doc_chunks:
-                if not self._is_low_quality_chunk(chunk_text, language):
+                if len(doc_chunks) == 1 or not self._is_low_quality_chunk(
+                    chunk_text, language
+                ):
                     valid_chunks.append((chunk_text, start_line, end_line))
 
             for i, (chunk_text, start_line, end_line) in enumerate(valid_chunks):
@@ -245,13 +277,21 @@ class DocumentChunker:
 
         return chunks
 
+    # Line prefixes that mark code-file boilerplate (imports/comments):
+    # a chunk that is mostly these embeds poorly and pollutes search.
+    _BOILERPLATE_PREFIXES: dict[str, tuple[str, ...]] = {
+        "python": ("import ", "from ", "#"),
+        "javascript": ("import ", "export {", "export *", "require(", "//"),
+        "typescript": ("import ", "export {", "export *", "require(", "//"),
+    }
+
     def _is_low_quality_chunk(self, content: str, language: str | None) -> bool:
         """
         Check if a chunk is low-quality and should be filtered out.
 
         Filters:
         - Chunks smaller than min_chunk_size characters
-        - Chunks that are mostly import statements (for code files)
+        - Code-file chunks that are >70% imports/comments
 
         Args:
             content: The chunk content
@@ -264,37 +304,13 @@ class DocumentChunker:
         if len(content.strip()) < self.min_chunk_size:
             return True
 
-        # For Python files, filter chunks that are mostly imports
-        if language and language.lower() == "python":
+        prefixes = self._BOILERPLATE_PREFIXES.get((language or "").lower())
+        if prefixes:
             lines = [line.strip() for line in content.split("\n") if line.strip()]
             if not lines:
                 return True
-
-            import_lines = sum(
-                1
-                for line in lines
-                if line.startswith(("import ", "from ")) or line.startswith("#")
-            )
-
-            # Filter if more than 70% of lines are imports/comments
-            if len(lines) > 0 and (import_lines / len(lines)) > 0.7:
-                return True
-
-        # For JS/TS files, filter chunks that are mostly imports
-        if language and language.lower() in ("javascript", "typescript"):
-            lines = [line.strip() for line in content.split("\n") if line.strip()]
-            if not lines:
-                return True
-
-            import_lines = sum(
-                1
-                for line in lines
-                if line.startswith(("import ", "export {", "export *", "require("))
-                or line.startswith("//")
-            )
-
-            # Filter if more than 70% of lines are imports/comments
-            if len(lines) > 0 and (import_lines / len(lines)) > 0.7:
+            boilerplate = sum(1 for line in lines if line.startswith(prefixes))
+            if boilerplate / len(lines) > 0.7:
                 return True
 
         return False
@@ -479,4 +495,5 @@ def estimate_chunks(content_length: int, chunk_size: int, chunk_overlap: int) ->
     if effective_size <= 0:
         return 1
 
-    return max(1, (content_length - chunk_overlap) // effective_size + 1)
+    remaining = content_length - chunk_overlap
+    return max(1, (remaining + effective_size - 1) // effective_size)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
@@ -3,9 +3,8 @@ name = "{{ project_slug }}"
 version = "{{ version }}"
 description = "{{ project_description }}"
 readme = "README.md"
-{% if ai_rag %}requires-python = ">=3.11,<3.14"  # chromadb→onnxruntime lacks Python 3.14 wheels
-{% else %}requires-python = ">={{ python_version }},<3.15"
-{% endif %}
+requires-python = ">={{ python_version }},<3.15"
+
 authors = [
     {name = "{{ author_name }}", email = "{{ author_email }}"}
 ]

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_ai_endpoints.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_ai_endpoints.py.jinja
@@ -57,6 +57,7 @@ def mock_usage_stats() -> dict[str, Any]:
     }
 
 
+{% if ai_backend != "memory" %}
 class TestUsageStatsEndpoint:
     """Tests for /api/v1/ai/usage/stats endpoint."""
 
@@ -169,6 +170,7 @@ class TestUsageStatsEndpoint:
         assert data["recent_activity"] == []
 
 
+{% endif %}
 class TestChatAgentSlug:
     """The chat endpoints thread agent_slug through to the service."""
 
@@ -243,6 +245,7 @@ class TestChatAgentSlug:
         assert mock_chat.call_args.kwargs["attachments"] == []
 
 
+{% if ai_backend != "memory" %}
 class TestLLMPickerGating:
     """The picker's usable filter: no key, no models."""
 
@@ -401,3 +404,4 @@ class TestUserMemoryEndpoints:
             response = client.delete("/api/v1/ai/user-memory/7")
 
         assert response.status_code == 404
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
@@ -42,7 +42,7 @@ from app.services.payment.models import (  # noqa: F401
 # Import blog models to register them with SQLModel metadata
 from app.services.blog.models import BlogPost, BlogPostTag, BlogTag  # noqa: F401
 {% endif %}
-{%- if include_ai %}
+{%- if include_ai and ai_backend != "memory" %}
 # Import AI models to register them with SQLModel metadata. The agents and
 # llm subpackages each import every model module they own, so these two
 # names pull in the whole set.

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/rag/test_chunking.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/rag/test_chunking.py
@@ -101,6 +101,35 @@ class TestDocumentChunker:
         assert "file2.py" in sources
 
 
+class TestChunkSizeValidation:
+    """Non-positive sizes must fail loudly, not hang the splitter."""
+
+    def test_zero_chunk_size_is_rejected_at_construction(self) -> None:
+        with pytest.raises(ValueError, match="chunk_size"):
+            DocumentChunker(chunk_size=0)
+
+    @pytest.mark.asyncio
+    async def test_zero_chunk_size_override_is_rejected(self) -> None:
+        """``chunk_size=0`` used to silently fall back to the default;
+        a negative value walked into a non-advancing split loop."""
+        chunker = DocumentChunker(chunk_size=100)
+        docs = [Document(content="A" * 200, metadata={"source": "test"})]
+
+        with pytest.raises(ValueError, match="chunk_size"):
+            await chunker.chunk(docs, chunk_size=0)
+
+    def test_min_chunk_size_keeps_caller_intent(self) -> None:
+        """The floor is only kept below the ceiling - it is not halved.
+        Clamping 900 to 500 silently changed what the caller asked for."""
+        chunker = DocumentChunker(chunk_size=1000, min_chunk_size=900)
+        assert chunker.min_chunk_size == 900
+
+    def test_min_chunk_size_never_reaches_the_ceiling(self) -> None:
+        """A floor at or above the chunk size would filter every chunk."""
+        chunker = DocumentChunker(chunk_size=1000, min_chunk_size=1000)
+        assert chunker.min_chunk_size == 999
+
+
 class TestEstimateChunks:
     """Tests for chunk estimation utility."""
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/rag/test_service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/rag/test_service.py
@@ -3,26 +3,20 @@
 from pathlib import Path
 
 import pytest
+from app.services.rag.config import RAGServiceConfig
 from app.services.rag.service import LoaderError, RAGService
-
-
-class MockSettings:
-    """Mock settings for testing."""
-
-    RAG_ENABLED = True
-    RAG_PERSIST_DIRECTORY = "./test_data/chromadb"
-    RAG_EMBEDDING_MODEL = "all-MiniLM-L6-v2"
-    RAG_CHUNK_SIZE = 500
-    RAG_CHUNK_OVERLAP = 100
-    RAG_DEFAULT_TOP_K = 3
 
 
 @pytest.fixture
 def rag_service(tmp_path: Path) -> RAGService:
     """Create RAG service instance with temporary storage."""
-    settings = MockSettings()
-    settings.RAG_PERSIST_DIRECTORY = str(tmp_path / "chromadb")
-    return RAGService(settings)
+    config = RAGServiceConfig(
+        persist_directory=str(tmp_path / "chromadb"),
+        chunk_size=500,
+        chunk_overlap=100,
+        default_top_k=3,
+    )
+    return RAGService(config)
 
 
 @pytest.fixture

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_conversation_persistence.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_conversation_persistence.py
@@ -50,11 +50,16 @@ def _no_user_memory_db(monkeypatch: pytest.MonkeyPatch) -> None:
     async def no_memory(user_id: str, **kwargs: object) -> None:
         return None
 
+    # raising=False: the memory backend ships without the user-memory block.
     monkeypatch.setattr(
-        "app.services.ai.service.chat.build_user_memory_context", no_memory
+        "app.services.ai.service.chat.build_user_memory_context",
+        no_memory,
+        raising=False,
     )
     monkeypatch.setattr(
-        "app.services.ai.service.streaming.build_user_memory_context", no_memory
+        "app.services.ai.service.streaming.build_user_memory_context",
+        no_memory,
+        raising=False,
     )
 
 

--- a/copier.yml
+++ b/copier.yml
@@ -63,12 +63,7 @@ aegis_version:
 python_version:
   type: str
   help: "Python version to use"
-  # Default 3.13 (not 3.14) because the 3.14 ecosystem still has gaps:
-  # openai 2.x circular-imports during pytest collection on 3.14, and
-  # requests' ``compat.py`` is missing ``JSONDecodeError`` on 3.14.
-  # 3.13 has been out long enough that all our deps work cleanly.
-  # Users can still opt into 3.14 explicitly when they want it.
-  default: "3.13"
+  default: "3.14"
   choices:
     - "3.11"
     - "3.12"

--- a/tests/cli/test_python_version.py
+++ b/tests/cli/test_python_version.py
@@ -221,6 +221,30 @@ class TestPythonVersionGeneration:
         assert_file_contains(project_path, "Dockerfile", "FROM python:3.14-slim")
 
     @pytest.mark.slow
+    def test_python_version_3_14_with_rag(
+        self,
+        temp_output_dir: Any,
+        skip_slow_tests: Any,
+    ) -> None:
+        """RAG no longer clamps the project to 3.13 (onnxruntime ships 3.14 wheels)."""
+        result = run_aegis_init(
+            project_name="test-python-314-rag",
+            output_dir=temp_output_dir,
+            python_version="3.14",
+            services=["ai[rag]"],
+        )
+
+        assert result.success, f"CLI command failed: {result.stderr}"
+        project_path = result.project_path
+        assert project_path is not None
+
+        content = (project_path / ".python-version").read_text().strip()
+        assert content == "3.14", f"Expected Python 3.14, got {content}"
+        assert_file_contains(
+            project_path, "pyproject.toml", 'requires-python = ">=3.14,<3.15"'
+        )
+
+    @pytest.mark.slow
     def test_python_version_with_components(
         self,
         temp_output_dir: Any,

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -121,14 +121,8 @@ class TestConfigurationConstants:
         assert parts[1].isdigit()
 
     def test_default_python_version_current_value(self) -> None:
-        """Test DEFAULT_PYTHON_VERSION equals expected value.
-
-        Hardcoded to 3.13 even though pyproject.toml supports up to 3.14
-        — see ``aegis/config/defaults.py`` for why (third-party 3.14
-        ecosystem gaps in openai/requests). When 3.14 is widely
-        compatible we can revert to ``_max_version``.
-        """
-        assert DEFAULT_PYTHON_VERSION == "3.13"
+        """Test DEFAULT_PYTHON_VERSION tracks the newest supported version."""
+        assert DEFAULT_PYTHON_VERSION == "3.14"
 
     def test_supported_python_versions_is_list(self) -> None:
         """Test SUPPORTED_PYTHON_VERSIONS is a list."""


### PR DESCRIPTION
## Summary
- Generated projects default to Python 3.14 (3.11-3.14 selectable); the RAG `<3.14` pin, copier clamp, and interactive warning are removed now that onnxruntime ships cp314 wheels
- Memory-backend AI projects pass lint/typecheck/tests again: user-memory and active-model code no longer leak into that backend, DB-only endpoint test classes are gated (`test_ai_endpoints.py.jinja`), and the router imports `ChatAttachment` on every backend
- RAG chunker hardening: overlap >= chunk size can no longer loop forever (default overlap is a fifth of the chunk size), one-chunk documents are kept whole, `min_chunk_size` clamps below the chunk size, `estimate_chunks` rounding fixed; RAG service tests use a real `RAGServiceConfig`

## Testing
- Generated fresh from this tree on Python 3.14: `ai[rag]` (memory backend) ruff + ty + 867 tests green; `ai[rag,sqlite]` + database ruff + ty + 1289 tests green
- Aegis side: ruff, ty, and the post-gen/manifest/template-hygiene/defaults/i18n suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCkfQDaN1KgQduexAHDZHS