### PR TITLE
Carry overdue occurrences into the forecast; offer merchant-labelled income in the match picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **Overdue occurrences vanished from the balance forecast**: the
+  projection fast-forwarded every stream past occurrences dated before
+  today, so a day-late paycheck read as "you are $5,000 poorer for the
+  next two weeks" - the walk started from a balance the check never
+  reached and charged it nowhere. A stream's latest missed occurrence
+  now carries to today's line (money still in flight, both directions);
+  older misses stay with the insight rules' missed-payment chase, and
+  one-time bills are unchanged.
+- **The match picker offered nothing for income**: a candidate already
+  carrying a merchant was treated as "identified as someone else", and
+  paycheck deposits always arrive pre-labelled with the payroll
+  processor's merchant - which never equals the human-named stream.
+  Category agreement now outranks the merchant mismatch, so a deposit
+  sharing the stream's own category stays offered; bills keep their
+  noise protection.
+
 ### Removed
 
 - **The Transfers review queue**: the suggested-transfer lane

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -1046,6 +1046,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 "tests/services/test_finance_payees.py",
                 "tests/services/test_finance_module_layout.py",
                 "tests/services/test_finance_projection_filter.py",
+                "tests/services/test_finance_projection_overdue.py",
                 "tests/services/test_finance_search.py",
                 "tests/services/test_finance_stream_regimes.py",
                 "tests/services/test_merchant_icon.py",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/forecast.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/forecast.py
@@ -13,6 +13,7 @@ from datetime import date, timedelta
 from typing import Any
 
 from sqlmodel.ext.asyncio.session import AsyncSession
+
 from app.services.finance.constants import (
     CASH_ACCOUNT_TYPES,
     ONE_TIME_FREQUENCY,
@@ -75,9 +76,10 @@ async def project_balances(
     rollup gate), in both directions: detected merchant rhythms
     would fabricate a five-figure decline, and detected refund or
     transfer rhythms an equally fictional windfall. Muted and
-    transfer streams are skipped. Occurrences already in the past
-    are not re-charged - chasing a missed payment is the insight
-    rules' job, not the forecast's.
+    transfer streams are skipped. Of a stream's past-due
+    occurrences only the latest is charged, carried to today (it is
+    in flight); older ones are the insight rules' missed-payment
+    chase, not the forecast's.
     """
     today = today or date.today()
     horizon = today + timedelta(days=days)
@@ -153,7 +155,17 @@ async def project_balances(
         when = stream.next_expected_date
         guard = 0
         while when < today and guard < 400:
-            when = step(when)
+            nxt = step(when)
+            if nxt > today:
+                # The latest missed occurrence is money still in
+                # flight - a day-late paycheck or an undrafted bill.
+                # Skipping it walks the forecast from a balance the
+                # check never reached; it lands on today's line
+                # instead. Older misses stay skipped: they are
+                # already inside the starting balance or the insight
+                # rules' missed-payment chase.
+                occurrences.append((today, stream, amount))
+            when = nxt
             guard += 1
         while when <= horizon and guard < 400:
             occurrences.append((when, stream, amount))

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/matching.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/matching.py
@@ -92,6 +92,7 @@ async def recurring_match_candidates(
     # amount, dated near the due date) must not drown under a page
     # of newer lookalikes (confirmed live).
     today = date.today()
+
     # Name affinity outranks the figures: a candidate carrying the
     # bill's own payee (or its name in the descriptor) is the answer
     # even when a stranger's amount lands a dollar nearer - ranked
@@ -143,6 +144,15 @@ async def recurring_match_candidates(
         reference_category = await queries.stream_member_category_id(db, stream.id)
 
     def identified_as_other(txn: FinanceTransaction) -> bool:
+        # Category agreement is identification FOR the stream and
+        # outranks a merchant mismatch. Inflows are where this bites:
+        # a paycheck always arrives pre-labelled with the payroll
+        # processor's merchant, which never equals the human-named
+        # stream - ranked on merchant alone, the $5,000 paycheck was
+        # "someone else" and the picker offered nothing (confirmed
+        # live).
+        if reference_category is not None and txn.category_id == reference_category:
+            return False
         if txn.merchant_id is not None and txn.merchant_id != stream.merchant_id:
             return True
         return (

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_attach.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_attach.py
@@ -415,6 +415,47 @@ class TestMatchCandidates:
         assert same_cat.id in [t.id for t in rows]
 
     @pytest.mark.asyncio
+    async def test_a_paycheck_with_its_own_merchant_stays_offered(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        """Income always arrives pre-labelled: the deposit carries the
+        payroll processor's merchant, which never equals the human-named
+        stream. Category agreement is identification FOR the stream and
+        must outrank the merchant mismatch - ranked the old way, the
+        $5,000 paycheck was "identified as someone else" and the picker
+        offered nothing (confirmed live)."""
+        account = await _account(svc)
+        paycheck_cat = await seed_category(async_db_session, "Paycheck")
+        payroll = await svc.create_merchant("Pure Proactive", owner_user_id=1)
+        stream = await seed_stream(
+            svc,
+            name="Betr Health",
+            direction="inflow",
+            frequency="semi_monthly",
+            expected_amount=500_000,
+            next_expected_date=date(2026, 8, 15),
+            account_id=account.id,
+        )
+        await svc.update_recurring(
+            stream.id, owner_user_id=1, category_id=paycheck_cat.id
+        )
+        deposit = await svc.create_transaction(
+            account_id=account.id,
+            amount=500_000,
+            txn_date=date(2026, 8, 17),
+            owner_user_id=1,
+            name="PURE PROACTIVE H PAYROLL PPD ID:",
+            category_id=paycheck_cat.id,
+        )
+        deposit.merchant_id = payroll.id
+        async_db_session.add(deposit)
+        await async_db_session.flush()
+
+        rows = await svc.recurring_match_candidates(stream.id, owner_user_id=1)
+
+        assert deposit.id in [t.id for t in rows]
+
+    @pytest.mark.asyncio
     async def test_bill_without_a_category_infers_one_from_its_members(
         self, svc: FinanceService, async_db_session: AsyncSession
     ) -> None:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_projection_overdue.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_projection_overdue.py
@@ -1,0 +1,137 @@
+"""Overdue occurrences: money still in flight is not money that vanished.
+
+The forecast fast-forwards each stream past occurrences dated before
+today. Skipping ALL of them reads a one-day-late paycheck as "you are
+$5,000 poorer for the next two weeks" - the walk starts from a balance
+the check never reached and never charges the check anywhere. The rule:
+the LATEST missed occurrence carries to today (it is in flight - a late
+check, a bill due but not yet drafted); everything older is a stale
+stream's echo, already in the starting balance or the insight rules'
+missed-payment chase, and stays skipped.
+"""
+
+from datetime import date
+
+import pytest
+
+from app.services.finance.service import FinanceService
+from tests.services._finance_factories import seed_account, seed_stream
+
+TODAY = date(2026, 8, 31)
+
+
+async def _paycheck(svc: FinanceService, *, next_expected: date):
+    account = await seed_account(svc)
+    return await seed_stream(
+        svc,
+        name="BETR HEALTH PAYROLL",
+        direction="inflow",
+        frequency="semi_monthly",
+        expected_amount=500_000,
+        next_expected_date=next_expected,
+        account_id=account.id,
+    )
+
+
+class TestOverdueOccurrencesCarryToToday:
+    @pytest.mark.asyncio
+    async def test_the_latest_missed_occurrence_lands_on_today(
+        self, svc: FinanceService
+    ) -> None:
+        """Next-expected 8/15, today 8/31: the 8/15 check was received
+        (it is inside the starting balance), the 8/30 check is in
+        flight. Exactly one carried occurrence, dated today."""
+        await _paycheck(svc, next_expected=date(2026, 8, 15))
+
+        result = await svc.project_balances(owner_user_id=1, days=30, today=TODAY)
+
+        paydays = [p.date for p in result.points if p.name == "BETR HEALTH PAYROLL"]
+        assert paydays.count(TODAY) == 1
+        assert date(2026, 8, 15) not in paydays
+        carried = next(p for p in result.points if p.date == TODAY)
+        assert carried.amount == 500_000
+        assert carried.direction == "inflow"
+
+    @pytest.mark.asyncio
+    async def test_the_cadence_continues_past_the_carried_one(
+        self, svc: FinanceService
+    ) -> None:
+        """The carry replaces nothing: 9/14 and 9/29 still project."""
+        await _paycheck(svc, next_expected=date(2026, 8, 15))
+
+        result = await svc.project_balances(owner_user_id=1, days=30, today=TODAY)
+
+        paydays = [p.date for p in result.points if p.name == "BETR HEALTH PAYROLL"]
+        assert paydays == [TODAY, date(2026, 9, 14), date(2026, 9, 29)]
+
+    @pytest.mark.asyncio
+    async def test_an_overdue_bill_carries_too(self, svc: FinanceService) -> None:
+        """Both directions: a bill due 8/19 and not yet drafted still
+        drains today's line, not nowhere."""
+        account = await seed_account(svc)
+        await seed_stream(
+            svc,
+            name="ATT",
+            direction="outflow",
+            frequency="monthly",
+            expected_amount=24_300,
+            next_expected_date=date(2026, 8, 19),
+            account_id=account.id,
+        )
+
+        result = await svc.project_balances(owner_user_id=1, days=30, today=TODAY)
+
+        due = [p.date for p in result.points if p.name == "ATT"]
+        assert due == [TODAY, date(2026, 9, 19)]
+
+    @pytest.mark.asyncio
+    async def test_a_future_stream_is_untouched(self, svc: FinanceService) -> None:
+        await _paycheck(svc, next_expected=date(2026, 9, 14))
+
+        result = await svc.project_balances(owner_user_id=1, days=30, today=TODAY)
+
+        paydays = [p.date for p in result.points if p.name == "BETR HEALTH PAYROLL"]
+        assert paydays == [date(2026, 9, 14), date(2026, 9, 29)]
+
+    @pytest.mark.asyncio
+    async def test_only_the_latest_miss_carries_from_deep_overdue(
+        self, svc: FinanceService
+    ) -> None:
+        """Months stale (next-expected 5/10): one carried occurrence,
+        not four - the old misses are already history, not forecast."""
+        account = await seed_account(svc)
+        await seed_stream(
+            svc,
+            name="STALE GYM",
+            direction="outflow",
+            frequency="monthly",
+            expected_amount=5_000,
+            next_expected_date=date(2026, 5, 10),
+            account_id=account.id,
+        )
+
+        result = await svc.project_balances(owner_user_id=1, days=30, today=TODAY)
+
+        due = [p.date for p in result.points if p.name == "STALE GYM"]
+        assert due == [TODAY, date(2026, 9, 10)]
+
+    @pytest.mark.asyncio
+    async def test_a_missed_one_time_bill_still_does_not_carry(
+        self, svc: FinanceService
+    ) -> None:
+        """One-time stays one-time: never stepped, never re-charged from
+        the past - chasing it is the insight rules' job."""
+        account = await seed_account(svc)
+        await seed_stream(
+            svc,
+            name="PAY BACK BOB",
+            direction="outflow",
+            frequency="once",
+            expected_amount=50_000,
+            next_expected_date=date(2026, 8, 15),
+            account_id=account.id,
+        )
+
+        result = await svc.project_balances(owner_user_id=1, days=30, today=TODAY)
+
+        assert not [p for p in result.points if p.name == "PAY BACK BOB"]


### PR DESCRIPTION
## What

Two live-confirmed fixes on the recurring/projection surface:

**Overdue occurrences vanished from the balance forecast.** The projection fast-forwarded every stream past occurrences dated before today, so a day-late paycheck read as "you are $5,000 poorer for the next two weeks": the walk started from a balance the check never reached and charged it nowhere. A stream's latest missed occurrence now carries to today's line (money still in flight, both directions). Older misses stay skipped - they are already inside the starting balance or the insight rules' missed-payment chase - and one-time bills keep their never-recharge rule.

**The match picker offered nothing for income.** A candidate already carrying a merchant was treated as "identified as someone else", and paycheck deposits always arrive pre-labelled with the payroll processor's merchant, which never equals the human-named stream. Category agreement now counts as identification *for* the bill and outranks the merchant mismatch, so a deposit sharing the stream's own category stays offered. Bills keep their noise protection: a row categorized away from the bill still stays out.

## Tests

- New `tests/services/test_finance_projection_overdue.py` (6 tests, registered in the finance manifest): latest miss lands on today exactly once, cadence continues past it, both directions carry, months-stale streams carry one not four, future streams untouched, one-time still never re-charges.
- New case in `test_finance_attach.py`: a paycheck deposit carrying its payroll merchant but sharing the stream's category stays offered.
- Scoped suites green (attach 22, projection/recurring 51), ruff + ty clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)