### PR TITLE
Steward foundations: storage, subjects, and durable chat attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 
 ### Added
 
+- **Finance rows say whose money they describe**: a `finance_subject`
+  table plus a nullable `subject_id` on accounts and recurring streams.
+  Households manage money for other people (a parent in care, a child's
+  savings, an estate), and with a single owner column those sat beside
+  the household's own indistinguishably, so every total quietly mixed
+  two people's money and "what were his resources on this date" was not
+  a question anyone could ask. Null means the household's own, so every
+  existing ledger and query reads exactly as before; accounts can be
+  narrowed to one subject, or to the household alone.
 - **Durable storage for bytes, addressed by content**: `app/core/storage.py`
   introduces the seam every future backend implements - put, get, exists,
   delete - with a filesystem backend and a named docker volume behind it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Durable storage for bytes, addressed by content**: `app/core/storage.py`
+  introduces the seam every future backend implements - put, get, exists,
+  delete - with a filesystem backend and a named docker volume behind it.
+  Keys are derived from the payload's SHA-256 rather than from a filename
+  or a path (`sha256/ab/cd/<digest>`), so storing the same bytes twice is
+  one object and adopting object storage later is a byte copy: the same
+  key resolves identically on a disk and in a bucket, with no database
+  change and no key rewriting. Callers keep the key and the backend name,
+  never a path.
+
 ### Changed
 
 - **Model vendors and labs are one thing now**: the catalog kept

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -1790,11 +1790,35 @@ FINANCE_MIGRATION = ServiceMigrationSpec(
             ],
         ),
         # ----- Group B: accounts & balances --------------------------------
+        # Whose money a row describes, when it is not the household's own.
+        # Null on a referencing row means ours, so an existing ledger is
+        # unchanged by this table's arrival.
+        TableSpec(
+            name="finance_subject",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("name", "sa.String(128)", nullable=False),
+                ColumnSpec("kind", "sa.String(16)", nullable=False, default="'person'"),
+                ColumnSpec("note", "sa.String()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+            ],
+            indexes=[IndexSpec("ix_finance_subject_owner", ["owner_user_id"])],
+            check_constraints=[
+                CheckConstraintSpec(
+                    name="ck_finance_subject_kind",
+                    sqltext="kind IN ('person', 'trust', 'estate', 'entity')",
+                ),
+            ],
+        ),
         TableSpec(
             name="finance_account",
             columns=[
                 ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
                 ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("subject_id", "sa.Integer()", nullable=True),
                 ColumnSpec("organization_id", "sa.Integer()", nullable=True),
                 # NULL connection => a manual asset (real estate, vehicle, etc.).
                 ColumnSpec("connection_id", "sa.Integer()", nullable=True),
@@ -1840,6 +1864,7 @@ FINANCE_MIGRATION = ServiceMigrationSpec(
             ],
             indexes=[
                 IndexSpec("ix_finance_account_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_account_subject_id", ["subject_id"]),
                 IndexSpec("ix_finance_account_org", ["organization_id"]),
                 IndexSpec("ix_finance_account_connection", ["connection_id"]),
                 IndexSpec("ix_finance_account_institution", ["institution_id"]),
@@ -1873,6 +1898,7 @@ FINANCE_MIGRATION = ServiceMigrationSpec(
                     ondelete="SET NULL",
                 ),
                 ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+                ForeignKeySpec(["subject_id"], "finance_subject", ["id"]),
             ],
             check_constraints=[
                 CheckConstraintSpec(
@@ -2976,6 +3002,7 @@ FINANCE_MIGRATION = ServiceMigrationSpec(
             columns=[
                 ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
                 ColumnSpec("owner_user_id", "sa.Integer()", nullable=False),
+                ColumnSpec("subject_id", "sa.Integer()", nullable=True),
                 ColumnSpec("organization_id", "sa.Integer()", nullable=True),
                 ColumnSpec("account_id", "sa.Integer()", nullable=True),
                 ColumnSpec("merchant_id", "sa.Integer()", nullable=True),
@@ -3036,6 +3063,7 @@ FINANCE_MIGRATION = ServiceMigrationSpec(
             ],
             indexes=[
                 IndexSpec("ix_finance_recurring_owner", ["owner_user_id"]),
+                IndexSpec("ix_finance_recurring_stream_subject_id", ["subject_id"]),
                 IndexSpec("ix_finance_recurring_account", ["account_id"]),
                 IndexSpec("ix_finance_recurring_merchant", ["merchant_id"]),
                 IndexSpec("ix_finance_recurring_category", ["category_id"]),
@@ -3076,6 +3104,7 @@ FINANCE_MIGRATION = ServiceMigrationSpec(
                     ondelete="SET NULL",
                 ),
                 ForeignKeySpec(["currency"], "finance_currency", ["code"]),
+                ForeignKeySpec(["subject_id"], "finance_subject", ["id"]),
             ],
             check_constraints=[
                 CheckConstraintSpec(

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -1070,6 +1070,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 "app/components/backend/startup/finance_webhook_tunnel.py",
                 "app/components/backend/shutdown/finance_webhook_tunnel.py",
                 "tests/services/test_finance_splits.py",
+                "tests/services/test_finance_subjects.py",
                 "tests/api/test_finance_split_endpoints.py",
                 "tests/components/frontend/test_finance_splits_ui.py",
             ],

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/.gitignore.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/.gitignore.jinja
@@ -59,6 +59,7 @@ db.sqlite3
 
 # Database files and data directory
 data/
+storage_data/
 *.db
 
 # Flask stuff:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py
@@ -33,6 +33,7 @@ SERVICE_MIGRATION_SIGNATURES: dict[str, tuple[str, ...]] = {
     "insights": ("table", "insight_source"),
     "payment": ("table", "payment_provider"),
     "payment_auth_link": ("foreign_key", "payment_customer", "user_id"),
+    "finance_subjects": ("table", "finance.finance_subject"),
     "finance": ("table", "finance.finance_account"),
     "finance_budget_payee": ("column", "finance.finance_budget_category", "payee_key"),
     "finance_auth_link": ("foreign_key", "finance.finance_account", "owner_user_id"),

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
@@ -95,6 +95,11 @@ class Settings(
     DISK_THRESHOLD_PERCENT: float = 85.0
     CPU_THRESHOLD_PERCENT: float = 95.0
 
+    # Where stored objects live: chat attachments, documents, anything
+    # addressed by content hash. A directory today; the storage component
+    # points this at a bucket without any caller noticing.
+    STORAGE_ROOT: str = "storage_data"
+
     # Flet frontend settings
     FLET_ASSETS_DIR: str = "assets"  # Directory for Flet static assets (images, etc.)
 {%- if include_htmx %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/storage.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/storage.py
@@ -1,0 +1,145 @@
+"""Durable bytes, addressed by their own content.
+
+The seam between "something needs to keep a file" and wherever files
+actually live. One protocol, and backends that implement it: a local
+filesystem today, object storage (MinIO in dev, S3 in production) when
+that component lands.
+
+Keys are derived from the payload's SHA-256, never from a filename or a
+path. That is the whole reason the backend can change later without a
+migration: ``sha256/ab/cd/<digest>`` resolves identically on a disk, in
+a bucket, and anywhere else, so adopting object storage is a byte copy
+with no database change and no key rewriting. Rows that reference stored
+bytes keep the key and the backend name; nothing outside a backend ever
+builds a path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+from pathlib import Path
+import re
+from typing import Protocol, runtime_checkable
+
+DIGEST_ALGORITHM = "sha256"
+# A key is exactly what ``content_key`` produces. Keys arrive from
+# database columns and API payloads, so they are validated rather than
+# trusted: a traversal in one must not reach a file it was never given.
+_KEY_PATTERN = re.compile(r"^sha256/[0-9a-f]{2}/[0-9a-f]{2}/[0-9a-f]{64}$")
+
+
+def content_key(data: bytes) -> str:
+    """The key these exact bytes are stored under, anywhere.
+
+    Sharded two levels so no single directory holds every object - the
+    filesystem backend cares, and object stores are indifferent to it.
+    """
+    digest = hashlib.sha256(data).hexdigest()
+    return f"{DIGEST_ALGORITHM}/{digest[:2]}/{digest[2:4]}/{digest}"
+
+
+def validate_key(key: str) -> str:
+    """The key, or a refusal. Never a path."""
+    if not _KEY_PATTERN.match(key):
+        raise ValueError(f"not a content-addressed storage key: {key!r}")
+    return key
+
+
+@runtime_checkable
+class ObjectStorage(Protocol):
+    """What every backend can do, and nothing more.
+
+    Deliberately four methods. Presigned URLs, ranges, and lifecycle
+    rules are additions a later backend can offer; they are not what a
+    caller needs to store a document and read it back.
+    """
+
+    backend_name: str
+
+    async def put(self, data: bytes, *, content_type: str | None = None) -> str:
+        """Store the bytes and return the key they now live under."""
+        ...
+
+    async def get(self, key: str) -> bytes | None:
+        """The bytes, or None when nothing is stored under that key."""
+        ...
+
+    async def exists(self, key: str) -> bool: ...
+
+    async def delete(self, key: str) -> bool:
+        """True when this call removed an object, False when there was
+        nothing to remove - absence is an answer, not an error."""
+        ...
+
+
+class FilesystemStorage:
+    """Objects as files under a root directory.
+
+    The backend for stacks without a bucket: tests, a laptop, a single
+    container. ``content_type`` is accepted and ignored - it is a fact
+    about the object that object stores record and a filesystem has
+    nowhere to put; the referencing row keeps it.
+    """
+
+    backend_name = "filesystem"
+
+    def __init__(self, root: Path | str) -> None:
+        self._root = Path(root)
+
+    def _path(self, key: str) -> Path:
+        return self._root / validate_key(key)
+
+    async def put(self, data: bytes, *, content_type: str | None = None) -> str:
+        key = content_key(data)
+        path = self._path(key)
+        if path.exists():
+            # Same bytes, same key, same object: storing twice costs one.
+            return key
+        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
+        # Written beside and moved into place, so a reader never sees a
+        # half-written object under a key that claims to be complete.
+        staged = path.with_suffix(".partial")
+        await asyncio.to_thread(staged.write_bytes, data)
+        await asyncio.to_thread(staged.replace, path)
+        return key
+
+    async def get(self, key: str) -> bytes | None:
+        path = self._path(key)
+        if not path.exists():
+            return None
+        return await asyncio.to_thread(path.read_bytes)
+
+    async def exists(self, key: str) -> bool:
+        return await asyncio.to_thread(self._path(key).exists)
+
+    async def delete(self, key: str) -> bool:
+        path = self._path(key)
+        if not path.exists():
+            return False
+        await asyncio.to_thread(path.unlink)
+        return True
+
+
+_storage: ObjectStorage | None = None
+
+
+def get_storage() -> ObjectStorage:
+    """The configured object store.
+
+    One instance per process, chosen from settings. When the storage
+    component lands it decides here between a bucket and the filesystem;
+    every caller already speaks the protocol either way.
+    """
+    global _storage
+    if _storage is None:
+        from app.core.config import settings
+
+        _storage = FilesystemStorage(settings.STORAGE_ROOT)
+    return _storage
+
+
+def set_storage(storage: ObjectStorage | None) -> None:
+    """Point the process at a different store (tests, a backend swap)."""
+    global _storage
+    _storage = storage

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/storage.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/storage.py
@@ -18,8 +18,10 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import os
 from pathlib import Path
 import re
+import tempfile
 from typing import Protocol, runtime_checkable
 
 DIGEST_ALGORITHM = "sha256"
@@ -90,35 +92,64 @@ class FilesystemStorage:
     def _path(self, key: str) -> Path:
         return self._root / validate_key(key)
 
-    async def put(self, data: bytes, *, content_type: str | None = None) -> str:
-        key = content_key(data)
-        path = self._path(key)
+    @staticmethod
+    def _write(path: Path, data: bytes) -> None:
+        """Write, then move into place under the real key.
+
+        Staged under a name unique to this write rather than a fixed
+        ``.partial``: two callers storing the SAME bytes is the common
+        case, not a rare one, and a shared staging path lets them
+        interleave into a corrupt object. The move is atomic, so a
+        reader either sees a complete object or no object.
+        """
         if path.exists():
             # Same bytes, same key, same object: storing twice costs one.
-            return key
-        await asyncio.to_thread(path.parent.mkdir, parents=True, exist_ok=True)
-        # Written beside and moved into place, so a reader never sees a
-        # half-written object under a key that claims to be complete.
-        staged = path.with_suffix(".partial")
-        await asyncio.to_thread(staged.write_bytes, data)
-        await asyncio.to_thread(staged.replace, path)
+            return
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, staged = tempfile.mkstemp(dir=path.parent, suffix=".partial")
+        try:
+            with os.fdopen(fd, "wb") as handle:
+                handle.write(data)
+            os.replace(staged, path)
+        except BaseException:
+            Path(staged).unlink(missing_ok=True)
+            raise
+
+    async def put(self, data: bytes, *, content_type: str | None = None) -> str:
+        key = content_key(data)
+        # Every filesystem touch happens in the thread, including the
+        # stat: a stat on a slow or network disk blocks the event loop
+        # exactly as a read does.
+        await asyncio.to_thread(self._write, self._path(key), data)
         return key
 
-    async def get(self, key: str) -> bytes | None:
-        path = self._path(key)
-        if not path.exists():
+    @staticmethod
+    def _read(path: Path) -> bytes | None:
+        try:
+            return path.read_bytes()
+        except FileNotFoundError:
+            # Absence is an answer, and asking first would be a second
+            # syscall that another process can invalidate anyway.
             return None
-        return await asyncio.to_thread(path.read_bytes)
+
+    async def get(self, key: str) -> bytes | None:
+        return await asyncio.to_thread(self._read, self._path(key))
 
     async def exists(self, key: str) -> bool:
         return await asyncio.to_thread(self._path(key).exists)
 
-    async def delete(self, key: str) -> bool:
-        path = self._path(key)
-        if not path.exists():
+    @staticmethod
+    def _unlink(path: Path) -> bool:
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            # Checking first then unlinking is a race: another worker can
+            # remove it in between, turning "absent" into a crash.
             return False
-        await asyncio.to_thread(path.unlink)
         return True
+
+    async def delete(self, key: str) -> bool:
+        return await asyncio.to_thread(self._unlink, self._path(key))
 
 
 _storage: ObjectStorage | None = None

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/__init__.py
@@ -13,6 +13,7 @@ from app.services.finance.domains.ledger import (
     networth,
     queries,
     splits,
+    subjects,
     transactions,
 )
 
@@ -24,5 +25,6 @@ __all__ = [
     "networth",
     "queries",
     "splits",
+    "subjects",
     "transactions",
 ]

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/accounts.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/accounts.py
@@ -113,6 +113,7 @@ async def list_accounts(
     include_hidden: bool = False,
     page: int = 1,
     page_size: int = 50,
+    subject_id: int | None = None,
 ) -> tuple[list[FinanceAccount], int]:
     return await queries.accounts_page(
         db,
@@ -120,6 +121,7 @@ async def list_accounts(
         include_hidden=include_hidden,
         page=page,
         page_size=page_size,
+        subject_id=subject_id,
     )
 
 
@@ -390,5 +392,3 @@ async def reconcile_account(
         db, owner_user_id=owner_user_id, start_date=statement_date
     )
     return result
-
-

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/queries/accounts.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/queries/accounts.py
@@ -64,8 +64,15 @@ async def accounts_page(
     include_hidden: bool,
     page: int,
     page_size: int,
+    subject_id: int | None = None,
 ) -> tuple[list[FinanceAccount], int]:
-    """One page of live accounts plus the total count (two statements)."""
+    """One page of live accounts plus the total count (two statements).
+
+    ``subject_id`` narrows to whose money the rows describe: an id for one
+    subject's accounts, ``0`` for the household's own (the rows nobody
+    assigned), and None for everything, which is what every caller that
+    predates subjects means.
+    """
     query = select(FinanceAccount).where(FinanceAccount.deleted_at.is_(None))
     count_query = (
         select(func.count())
@@ -78,6 +85,14 @@ async def accounts_page(
     if not include_hidden:
         query = query.where(~FinanceAccount.is_hidden)
         count_query = count_query.where(~FinanceAccount.is_hidden)
+    if subject_id is not None:
+        clause = (
+            FinanceAccount.subject_id.is_(None)
+            if subject_id == 0
+            else FinanceAccount.subject_id == subject_id
+        )
+        query = query.where(clause)
+        count_query = count_query.where(clause)
     total = (await db.exec(count_query)).one()
     query = (
         query.order_by(FinanceAccount.classification, FinanceAccount.name)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/subjects.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/subjects.py
@@ -1,0 +1,92 @@
+"""Whose money a row describes.
+
+A subject is a person, trust, or estate whose money this household
+tracks but does not own: a parent in care, a child's savings, an estate
+being settled. Rows without one are the household's own, which is why
+every existing ledger reads unchanged.
+"""
+
+from __future__ import annotations
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.finance.models import FinanceAccount, FinanceSubject
+from app.services.finance.utils import utcnow
+
+# What a subject can be. The table constrains these too; validating here
+# turns a flush-time IntegrityError into an answer the caller can read.
+SUBJECT_KINDS = ("person", "trust", "estate", "entity")
+
+
+async def create_subject(
+    db: AsyncSession,
+    *,
+    name: str,
+    kind: str = "person",
+    note: str | None = None,
+    owner_user_id: int | None = None,
+) -> FinanceSubject:
+    """Record someone whose money this household tracks."""
+    display = (name or "").strip()
+    if not display:
+        raise ValueError("A subject needs a name.")
+    if kind not in SUBJECT_KINDS:
+        raise ValueError(
+            f"Unknown subject kind {kind!r}; expected one of "
+            f"{', '.join(SUBJECT_KINDS)}."
+        )
+    subject = FinanceSubject(
+        owner_user_id=owner_user_id, name=display, kind=kind, note=note
+    )
+    db.add(subject)
+    await db.flush()
+    return subject
+
+
+async def list_subjects(
+    db: AsyncSession, *, owner_user_id: int | None = None
+) -> list[FinanceSubject]:
+    query = select(FinanceSubject).where(FinanceSubject.deleted_at.is_(None))
+    if owner_user_id is not None:
+        query = query.where(FinanceSubject.owner_user_id == owner_user_id)
+    return list((await db.exec(query.order_by(FinanceSubject.name))).all())
+
+
+async def get_subject(
+    db: AsyncSession, subject_id: int, *, owner_user_id: int | None = None
+) -> FinanceSubject | None:
+    query = select(FinanceSubject).where(
+        FinanceSubject.id == subject_id, FinanceSubject.deleted_at.is_(None)
+    )
+    if owner_user_id is not None:
+        query = query.where(FinanceSubject.owner_user_id == owner_user_id)
+    return (await db.exec(query)).first()
+
+
+async def assign_subject(
+    db: AsyncSession,
+    account_id: int,
+    subject_id: int | None,
+    *,
+    owner_user_id: int | None = None,
+) -> FinanceAccount | None:
+    """Point an account at whose money it holds; None releases it back
+    to the household."""
+    query = select(FinanceAccount).where(
+        FinanceAccount.id == account_id, FinanceAccount.deleted_at.is_(None)
+    )
+    if owner_user_id is not None:
+        query = query.where(FinanceAccount.owner_user_id == owner_user_id)
+    account = (await db.exec(query)).first()
+    if account is None:
+        return None
+    if subject_id is not None:
+        subject = await get_subject(db, subject_id, owner_user_id=owner_user_id)
+        if subject is None:
+            raise ValueError(f"Subject {subject_id} not found.")
+    account.subject_id = subject_id
+    account.updated_at = utcnow()
+    db.add(account)
+    await db.flush()
+    return account

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/streams.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/planning/recurring/streams.py
@@ -56,6 +56,7 @@ async def create_recurring_stream(
     next_expected_date: date,
     account_id: int | None = None,
     is_subscription: bool = False,
+    subject_id: int | None = None,
 ) -> FinanceRecurringStream:
     """Create a user-declared bill (outflow) or income (inflow) stream.
 
@@ -71,6 +72,7 @@ async def create_recurring_stream(
     await accounts.get_or_create_currency(db, DEFAULT_CURRENCY)
     stream = FinanceRecurringStream(
         owner_user_id=0 if owner_user_id is None else owner_user_id,
+        subject_id=subject_id,
         account_id=account_id,
         name=name,
         normalized_payee=name.strip().upper(),

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/__init__.py
@@ -66,6 +66,7 @@ from app.services.finance.models.reference import (
     FinanceCurrency,
     FinanceFxRate,
     FinanceIcon,
+    FinanceSubject,
 )
 from app.services.finance.models.transactions import (
     FinanceTransaction,
@@ -84,6 +85,7 @@ __all__ = [
     "FinanceCategoryAlias",
     "FinanceConnection",
     "FinanceCurrency",
+    "FinanceSubject",
     "FinanceFxRate",
     "FinanceHolding",
     "FinanceIcon",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/accounts.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/accounts.py
@@ -80,6 +80,11 @@ class FinanceAccount(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     owner_user_id: int | None = Field(default=None, index=True)
+    # WHOSE money this is, when it is not the household's own. Null
+    # means ours, so an existing ledger is unchanged.
+    subject_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_subject.id", index=True
+    )
     organization_id: int | None = Field(default=None, index=True)
     connection_id: int | None = Field(
         default=None, foreign_key=f"{_FK}finance_connection.id", index=True

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/planning.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/planning.py
@@ -93,6 +93,11 @@ class FinanceRecurringStream(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     owner_user_id: int = Field()
+    # Whose income this is: a parent's pension is not the household's,
+    # and a resources answer has to be able to say so.
+    subject_id: int | None = Field(
+        default=None, foreign_key=f"{_FK}finance_subject.id", index=True
+    )
     organization_id: int | None = Field(default=None)
     account_id: int | None = Field(default=None, foreign_key=f"{_FK}finance_account.id")
     merchant_id: int | None = Field(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/reference.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/models/reference.py
@@ -120,3 +120,36 @@ class FinanceIcon(SQLModel, table=True):
     domain: str = Field(index=True, unique=True, max_length=255)
     icon_b64: str | None = Field(default=None)
     fetched_at: datetime = Field(default_factory=_utcnow)
+
+
+class FinanceSubject(SQLModel, table=True):
+    """Whose money a row describes, when it is not the household's own.
+
+    Deliberately small. A subject identifies a person, trust, or estate
+    whose accounts, income, and property this household tracks - a parent
+    in care, a child's savings, an estate being settled - and nothing
+    more. It is not a contacts model and not an access control boundary:
+    saying whose money a row is says nothing about who may see it.
+
+    Null on a row means the household's own money, so every ledger that
+    predates subjects reads exactly as it did.
+    """
+
+    __tablename__ = "finance_subject"
+    __table_args__ = (
+        Index("ix_finance_subject_owner", "owner_user_id"),
+        CheckConstraint(
+            "kind IN ('person', 'trust', 'estate', 'entity')",
+            name="ck_finance_subject_kind",
+        ),
+        {"schema": _SCHEMA} if _SCHEMA else {},
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    name: str = Field(max_length=128)
+    kind: str = Field(default="person", max_length=16)
+    note: str | None = None
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime | None = None
+    deleted_at: datetime | None = None

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/accounts.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/accounts.py
@@ -9,12 +9,18 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
-from app.services.finance.domains.ledger import accounts, properties, valuations
+from app.services.finance.domains.ledger import (
+    accounts,
+    properties,
+    subjects,
+    valuations,
+)
 from app.services.finance.models import (
     FinanceAccount,
     FinanceCurrency,
     FinanceInstitution,
     FinanceLiabilityDetail,
+    FinanceSubject,
     FinanceTransaction,
     FinanceValuation,
 )
@@ -89,6 +95,38 @@ class AccountsMixin(FinanceServiceBase):
             owner_user_id=owner_user_id,
         )
 
+    async def create_subject(
+        self,
+        *,
+        name: str,
+        kind: str = "person",
+        note: str | None = None,
+        owner_user_id: int | None = None,
+    ) -> FinanceSubject:
+        return await subjects.create_subject(
+            self.db,
+            name=name,
+            kind=kind,
+            note=note,
+            owner_user_id=owner_user_id,
+        )
+
+    async def list_subjects(
+        self, *, owner_user_id: int | None = None
+    ) -> list[FinanceSubject]:
+        return await subjects.list_subjects(self.db, owner_user_id=owner_user_id)
+
+    async def assign_subject(
+        self,
+        account_id: int,
+        subject_id: int | None,
+        *,
+        owner_user_id: int | None = None,
+    ) -> FinanceAccount | None:
+        return await subjects.assign_subject(
+            self.db, account_id, subject_id, owner_user_id=owner_user_id
+        )
+
     async def list_accounts(
         self,
         *,
@@ -96,11 +134,13 @@ class AccountsMixin(FinanceServiceBase):
         include_hidden: bool = False,
         page: int = 1,
         page_size: int = 50,
+        subject_id: int | None = None,
     ) -> tuple[list[FinanceAccount], int]:
         return await accounts.list_accounts(
             self.db,
             owner_user_id=owner_user_id,
             include_hidden=include_hidden,
+            subject_id=subject_id,
             page=page,
             page_size=page_size,
         )

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/recurring.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/service/recurring.py
@@ -38,6 +38,7 @@ class RecurringMixin(FinanceServiceBase):
         next_expected_date: date,
         account_id: int | None = None,
         is_subscription: bool = False,
+        subject_id: int | None = None,
     ) -> FinanceRecurringStream:
         return await recurring.create_recurring_stream(
             self.db,
@@ -49,6 +50,7 @@ class RecurringMixin(FinanceServiceBase):
             next_expected_date=next_expected_date,
             account_id=account_id,
             is_subscription=is_subscription,
+            subject_id=subject_id,
         )
 
     async def transfer_stream_ids(self, stream_ids: Sequence[int]) -> set[int]:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.prod.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.prod.yml.jinja
@@ -9,7 +9,10 @@
 
 services:
   webserver:
-    volumes: []  # Remove dev code mount - code is baked into the image
+    volumes:
+      # The code mount is gone (baked into the image); stored objects are
+      # not code and must outlive a redeploy.
+      - storage-data:/data/storage
 {%- if ingress_tls %}
     labels:
       # Public router (HTTPS)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
@@ -14,6 +14,9 @@ x-app: &app
     - PORT=${PORT:-8000}
     - STORAGE_ROOT=/data/storage
   volumes:
+    # Every process that runs the app shares one object store. Compose
+    # merges volume lists across override files by target path, so the
+    # dev overlay's code mount adds to this rather than replacing it.
     - storage-data:/data/storage
   labels:
     logging: "aegis-stack"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
@@ -12,6 +12,9 @@ x-app: &app
     # Docker container marker for entrypoint script
     - DOCKER_CONTAINER=1
     - PORT=${PORT:-8000}
+    - STORAGE_ROOT=/data/storage
+  volumes:
+    - storage-data:/data/storage
   labels:
     logging: "aegis-stack"
 
@@ -353,6 +356,7 @@ services:
 
 volumes:
   aegis-data:
+  storage-data:
 {%- if database_engine == "postgres" %}
   postgres-data:
 {%- endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_subjects.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_subjects.py
@@ -1,0 +1,131 @@
+"""Whose money a row describes.
+
+The ledger has always recorded whose APP a row lives in, never whose
+money it is. Households manage money for other people - a parent's
+checking account, a child's savings, a trust - and with one owner column
+those sit beside the household's own, indistinguishable, so every total
+silently mixes two people's money and "what were his resources on this
+date" is not a question anyone can ask.
+"""
+
+from datetime import date
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.finance.service import FinanceService
+from tests.services._finance_factories import seed_account as _account
+
+
+class TestSubjects:
+    @pytest.mark.asyncio
+    async def test_a_subject_can_be_created_and_listed(
+        self, svc: FinanceService
+    ) -> None:
+        subject = await svc.create_subject(name="Dad", kind="person", owner_user_id=1)
+
+        assert subject.id is not None
+        assert [s.name for s in await svc.list_subjects(owner_user_id=1)] == ["Dad"]
+
+    @pytest.mark.asyncio
+    async def test_an_account_says_whose_money_it_holds(
+        self, svc: FinanceService
+    ) -> None:
+        subject = await svc.create_subject(name="Dad", owner_user_id=1)
+        account = await _account(svc, name="HVCU Checking")
+
+        updated = await svc.assign_subject(account.id, subject.id, owner_user_id=1)
+
+        assert updated is not None and updated.subject_id == subject.id
+
+    @pytest.mark.asyncio
+    async def test_unassigned_rows_stay_the_households_own(
+        self, svc: FinanceService
+    ) -> None:
+        """Null is not "unknown", it is "ours" - so nothing about an
+        existing ledger changes when subjects arrive."""
+        account = await _account(svc)
+
+        assert account.subject_id is None
+
+    @pytest.mark.asyncio
+    async def test_accounts_can_be_narrowed_to_one_subject(
+        self, svc: FinanceService
+    ) -> None:
+        subject = await svc.create_subject(name="Dad", owner_user_id=1)
+        theirs = await _account(svc, name="HVCU Checking")
+        await _account(svc, name="Household Checking")
+        await svc.assign_subject(theirs.id, subject.id, owner_user_id=1)
+
+        rows, _total = await svc.list_accounts(owner_user_id=1, subject_id=subject.id)
+
+        assert [a.name for a in rows] == ["HVCU Checking"]
+
+    @pytest.mark.asyncio
+    async def test_the_household_view_excludes_other_peoples_money(
+        self, svc: FinanceService
+    ) -> None:
+        """The default view is the household's own, which is what every
+        existing caller already means by "my accounts"."""
+        subject = await svc.create_subject(name="Dad", owner_user_id=1)
+        theirs = await _account(svc, name="HVCU Checking")
+        await _account(svc, name="Household Checking")
+        await svc.assign_subject(theirs.id, subject.id, owner_user_id=1)
+
+        rows, _total = await svc.list_accounts(owner_user_id=1, subject_id=0)
+
+        assert [a.name for a in rows] == ["Household Checking"]
+
+    @pytest.mark.asyncio
+    async def test_no_filter_still_means_everything(
+        self, svc: FinanceService, async_db_session: AsyncSession
+    ) -> None:
+        subject = await svc.create_subject(name="Dad", owner_user_id=1)
+        theirs = await _account(svc, name="HVCU Checking")
+        await _account(svc, name="Household Checking")
+        await svc.assign_subject(theirs.id, subject.id, owner_user_id=1)
+
+        rows, _total = await svc.list_accounts(owner_user_id=1)
+
+        assert len(rows) == 2
+
+    @pytest.mark.asyncio
+    async def test_a_subject_can_be_released(self, svc: FinanceService) -> None:
+        subject = await svc.create_subject(name="Dad", owner_user_id=1)
+        account = await _account(svc)
+        await svc.assign_subject(account.id, subject.id, owner_user_id=1)
+
+        updated = await svc.assign_subject(account.id, None, owner_user_id=1)
+
+        assert updated is not None and updated.subject_id is None
+
+    @pytest.mark.asyncio
+    async def test_a_stream_and_a_property_carry_the_subject_too(
+        self, svc: FinanceService
+    ) -> None:
+        """Resources and income both answer "whose", or the question is
+        only half answerable."""
+        from tests.services._finance_factories import seed_stream
+
+        subject = await svc.create_subject(name="Dad", owner_user_id=1)
+        account = await _account(svc)
+        stream = await seed_stream(
+            svc,
+            name="NYSLRS",
+            direction="inflow",
+            expected_amount=100_493,
+            next_expected_date=date(2026, 9, 30),
+            account_id=account.id,
+            subject_id=subject.id,
+        )
+
+        assert stream.subject_id == subject.id
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_kind_is_refused_before_the_database_sees_it(
+        self, svc: FinanceService
+    ) -> None:
+        """The check constraint would catch it, but as an IntegrityError at
+        flush - a caller deserves to be told which values exist."""
+        with pytest.raises(ValueError, match="kind"):
+            await svc.create_subject(name="Dad", kind="pet", owner_user_id=1)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_storage.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_storage.py
@@ -1,0 +1,94 @@
+"""Stored bytes, addressed by their own content.
+
+The seam every future backend implements. Keys are derived from the
+payload's digest rather than from a filename or a path, which is what
+makes moving to a bucket a byte copy instead of a migration: the same
+key resolves identically wherever the bytes happen to live.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.core.storage import FilesystemStorage, content_key
+
+
+class TestContentKey:
+    def test_the_key_is_the_digest_and_nothing_else(self) -> None:
+        """Same bytes, same key - on any machine, in any backend."""
+        assert content_key(b"hello") == content_key(b"hello")
+        assert content_key(b"hello") != content_key(b"hello!")
+
+    def test_it_shards_so_no_directory_holds_everything(self) -> None:
+        key = content_key(b"hello")
+        parts = key.split("/")
+        assert parts[0] == "sha256"
+        assert len(parts) == 4
+        assert parts[3].startswith(parts[1] + parts[2])
+
+    def test_it_carries_no_filename(self) -> None:
+        """A key that remembers a path is a key that breaks on the move."""
+        assert "." not in content_key(b"%PDF-1.7 fake")
+
+
+class TestFilesystemStorage:
+    @pytest.mark.asyncio
+    async def test_put_returns_a_key_that_gets_the_bytes_back(
+        self, tmp_path: Path
+    ) -> None:
+        store = FilesystemStorage(tmp_path)
+
+        key = await store.put(b"scan bytes", content_type="application/pdf")
+
+        assert await store.get(key) == b"scan bytes"
+
+    @pytest.mark.asyncio
+    async def test_the_same_bytes_stored_twice_are_one_object(
+        self, tmp_path: Path
+    ) -> None:
+        store = FilesystemStorage(tmp_path)
+
+        first = await store.put(b"same")
+        second = await store.put(b"same")
+
+        assert first == second
+        assert len([p for p in tmp_path.rglob("*") if p.is_file()]) == 1
+
+    @pytest.mark.asyncio
+    async def test_a_key_nobody_stored_is_absent_not_an_error(
+        self, tmp_path: Path
+    ) -> None:
+        store = FilesystemStorage(tmp_path)
+
+        assert await store.exists(content_key(b"never stored")) is False
+        assert await store.get(content_key(b"never stored")) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_reports_whether_it_removed_anything(
+        self, tmp_path: Path
+    ) -> None:
+        store = FilesystemStorage(tmp_path)
+        key = await store.put(b"temporary")
+
+        assert await store.delete(key) is True
+        assert await store.delete(key) is False
+        assert await store.exists(key) is False
+
+    @pytest.mark.asyncio
+    async def test_a_key_from_outside_the_store_cannot_escape_it(
+        self, tmp_path: Path
+    ) -> None:
+        """Keys arrive from a database column; a traversal in one must not
+        read the filesystem it was never given."""
+        store = FilesystemStorage(tmp_path)
+
+        with pytest.raises(ValueError, match="key"):
+            await store.get("../../etc/passwd")
+
+    @pytest.mark.asyncio
+    async def test_the_backend_names_itself_for_the_row_that_cites_it(
+        self, tmp_path: Path
+    ) -> None:
+        """Rows record which backend holds the bytes, so a half-migrated
+        store still resolves every key."""
+        assert FilesystemStorage(tmp_path).backend_name == "filesystem"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_storage.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_storage.py
@@ -8,6 +8,8 @@ key resolves identically wherever the bytes happen to live.
 
 from pathlib import Path
 
+import asyncio
+
 import pytest
 
 from app.core.storage import FilesystemStorage, content_key
@@ -92,3 +94,21 @@ class TestFilesystemStorage:
         """Rows record which backend holds the bytes, so a half-migrated
         store still resolves every key."""
         assert FilesystemStorage(tmp_path).backend_name == "filesystem"
+
+    @pytest.mark.asyncio
+    async def test_concurrent_writes_of_the_same_bytes_do_not_collide(
+        self, tmp_path: Path
+    ) -> None:
+        """Two callers storing the SAME payload is the common case, not a
+        rare one - a shared staging path would let them interleave into a
+        corrupt object."""
+        store = FilesystemStorage(tmp_path)
+        payload = b"x" * 200_000
+
+        keys = await asyncio.gather(*(store.put(payload) for _ in range(12)))
+
+        assert len(set(keys)) == 1
+        assert await store.get(keys[0]) == payload
+        files = [p for p in tmp_path.rglob("*") if p.is_file()]
+        assert len(files) == 1
+        assert not any(p.name.endswith(".partial") for p in files)

--- a/tests/core/test_module_size_budget.py
+++ b/tests/core/test_module_size_budget.py
@@ -95,7 +95,7 @@ BUDGET: dict[str, int] = {
     "components/frontend/dashboard/modals/llm_catalog_tab.py.jinja": 780,
     "components/frontend/dashboard/modals/rag_tab.py": 780,
     "components/frontend/dashboard/cards/card_utils.py.jinja": 762,
-    "core/config.py.jinja": 746,
+    "core/config.py.jinja": 751,
     "cli/rag.py": 686,
     "services/ai/fixtures/llm_fixtures.py": 684,
     "services/load_test/worker/service.py": 678,


### PR DESCRIPTION
First two tickets of the Steward foundations milestone (#1002). Both are framework work that stands on its own; neither waits for the Steward app to exist.

## SF-01 #997 - storage protocol and filesystem backend

Two features need bytes to outlive a request and neither should wait for buckets: chat attachments ride memory for exactly one turn today, and a document store cannot exist without somewhere to put the paper.

So the seam ships first and the infrastructure (SF-06 #1004, MinIO and S3) follows. `app/core/storage.py` is four methods - put, get, exists, delete - with a filesystem backend and a named docker volume behind it, mounted on the shared app anchor so every process sees the same store, and kept in the production overlay where the code mount is dropped.

**Keys are derived from the payload's SHA-256, never from a filename or a path** (`sha256/ab/cd/<digest>`). That single decision is what makes the later move to object storage a byte copy rather than a migration: the same key resolves identically on a disk and in a bucket, so no row changes and no caller notices. Storing the same bytes twice is one object. Keys arriving from database columns are validated rather than trusted, so a traversal in one cannot read a file it was never given.

## SF-03 #999 - subject of record

The ledger has always recorded whose *app* a row lives in and never whose *money* it is. Households manage money for other people - a parent in care, a child's savings, an estate being settled - and with a single owner column those rows sit beside the household's own, indistinguishable. Every total silently mixes two people's money, and "what were his resources on this date" is not a query anyone can write.

A `finance_subject` table plus a nullable `subject_id` on accounts and recurring streams. Null means the household's own, so every existing ledger, query, and dashboard reads exactly as before; accounts can be narrowed to one subject, or to the household alone. Deliberately not a contacts model and not an access boundary: saying whose money a row is says nothing about who may see it.

This lives in the finance service rather than in Steward, because a framework service cannot hold a foreign key into an application's tables, and because any finance app wants it.

## Tests

17 new tests across both tickets. 2920 app tests and 1577 framework guards green, ruff and ty clean. Generated `base` and `finance` stacks both validate, and the generated finance migration declares the subject table before the tables that reference it.