### PR TITLE
Keep chat attachments instead of letting them die with the turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
   deadline, a claim it proves - is deliberately absent; that belongs to
   whatever consumes it.
 
+- **Chat attachments outlive the turn that carried them**: images are
+  stored on receipt and the message records where they went, so a
+  reopened conversation still shows the screenshot it is discussing and
+  a replay no longer depends on session memory still holding megabytes.
+  Re-attaching the same image costs nothing (content addressing), and a
+  storage failure never costs the user their message: the question still
+  reaches the model, the picture is simply not kept.
 - **Finance rows say whose money they describe**: a `finance_subject`
   table plus a nullable `subject_id` on accounts and recurring streams.
   Households manage money for other people (a parent in care, a child's

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -496,6 +496,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 "tests/api/test_ai_endpoints.py",
                 "tests/services/test_conversation_persistence.py",
                 "tests/services/test_chat_attachments.py",
+                "tests/services/ai/test_chat_attachment_persistence.py",
                 "tests/services/test_chat_readings.py",
                 "tests/services/test_history_budget.py",
                 "tests/cli/test_ai_rendering.py",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/attachments.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/attachments.py
@@ -22,6 +22,9 @@ from typing import Any
 
 from pydantic import BaseModel
 
+from app.core.log import logger
+from app.core.storage import get_storage
+
 
 class ChatAttachment(BaseModel):
     """One image part of a chat turn, base64 over the JSON body."""
@@ -53,16 +56,12 @@ def build_user_content(
     parts: list[Any] = [context]
     for attachment in attachments:
         parts.append(
-            BinaryContent(
-                data=attachment.decoded(), media_type=attachment.media_type
-            )
+            BinaryContent(data=attachment.decoded(), media_type=attachment.media_type)
         )
     return parts
 
 
-def annotate_attachments(
-    message: str, attachments: list[ChatAttachment] | None
-) -> str:
+def annotate_attachments(message: str, attachments: list[ChatAttachment] | None) -> str:
     """Stamp the stored user message with what was attached.
 
     History replays as text only, so this marker is how a later turn
@@ -72,3 +71,65 @@ def annotate_attachments(
     names = ", ".join(a.name or a.media_type for a in attachments)
     noun = "image" if len(attachments) == 1 else "images"
     return f"{message}\n\n[attached {len(attachments)} {noun}: {names}]"
+
+
+async def persist_attachments(
+    attachments: list[ChatAttachment] | None,
+) -> list[dict[str, Any]]:
+    """Keep the images, and describe where they went.
+
+    The bytes ride one model call by design, but the picture itself is
+    worth keeping: a reopened conversation should show the screenshot it
+    is talking about, and a replay should not depend on session memory
+    still holding megabytes. Each attachment is stored once - content
+    addressing makes re-attaching the same image free - and the returned
+    descriptors are what the message carries.
+
+    Storage failing is not the user losing their turn: the question still
+    goes to the model, the picture is simply not kept.
+    """
+    if not attachments:
+        return []
+    storage = get_storage()
+    stored: list[dict[str, Any]] = []
+    for attachment in attachments:
+        # Decoded OUTSIDE the storage guard: a malformed payload is the
+        # caller sending nonsense, not the store failing, and swallowing
+        # it here would drop the image silently while logging a reason
+        # that never happened.
+        data = attachment.decoded()
+        try:
+            key = await storage.put(data, content_type=attachment.media_type)
+        except OSError as exc:
+            logger.warning(f"Could not store chat attachment: {exc}")
+            continue
+        stored.append(
+            {
+                "key": key,
+                "media_type": attachment.media_type,
+                "name": attachment.name,
+            }
+        )
+    return stored
+
+
+def attachment_metadata(stored: list[dict[str, Any]]) -> dict[str, Any]:
+    """Message metadata for stored attachments, or nothing at all.
+
+    A message that carried no image should read as one, so this returns
+    an empty dict rather than a key holding an empty list.
+    """
+    return {"attachments": stored} if stored else {}
+
+
+async def prepare_turn(
+    message: str, attachments: list[ChatAttachment] | None
+) -> tuple[str, dict[str, Any]]:
+    """The stored message text and metadata for one turn's attachments.
+
+    Both chat paths - streaming and not - need the same three steps in
+    the same order, and doing them by hand in each is how one of them
+    ends up missing a step. One call, both callers.
+    """
+    stored = await persist_attachments(attachments)
+    return annotate_attachments(message, attachments), attachment_metadata(stored)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/models/__init__.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/models/__init__.py.jinja
@@ -108,13 +108,25 @@ class Conversation(BaseModel):
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     def add_message(
-        self, role: MessageRole, content: str, message_id: str | None = None
+        self,
+        role: MessageRole,
+        content: str,
+        message_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> ConversationMessage:
-        """Add a new message to the conversation."""
+        """Add a new message to the conversation.
+
+        ``metadata`` is persisted with the row and read back on load, so
+        anything a message needs to remember beyond its text - which
+        images rode it, for instance - belongs here.
+        """
         import uuid
 
         message = ConversationMessage(
-            id=message_id or str(uuid.uuid4()), role=role, content=content
+            id=message_id or str(uuid.uuid4()),
+            role=role,
+            content=content,
+            metadata=metadata or {},
         )
         self.messages.append(message)
         self.updated_at = datetime.now(UTC)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/chat.py.jinja
@@ -5,8 +5,9 @@ conversation, gather contexts (from the mixin chain below), run the
 model, record usage, persist. Streaming lives in ``streaming.py``.
 """
 
-from datetime import UTC, datetime
 import uuid
+from datetime import UTC, datetime
+from typing import Any
 {% if ai_framework == "pydantic-ai" %}
 from pydantic_ai.exceptions import ModelRetry, UnexpectedModelBehavior
 {% endif %}
@@ -18,7 +19,7 @@ from app.services.ai.domains.chat.agent_loader import (
 )
 from app.services.ai.domains.chat.attachments import (
     ChatAttachment,
-    annotate_attachments,
+    prepare_turn,
 {% if ai_framework == "pydantic-ai" %}    build_user_content,
 {% endif %})
 {%- if ai_backend != "memory" %}
@@ -112,12 +113,17 @@ class ChatMixin(PromptMixin):
             # Setup conversation and add user message. The stored text
             # carries the attachment marker; the bytes ride only this
             # turn's model call (history replays as text).
+            # Kept, not just carried: the bytes ride this turn's model
+            # call and the message remembers where the image was stored,
+            # so reopening the conversation still shows it.
+            stored_text, stored_metadata = await prepare_turn(message, attachments)
             conversation = self._setup_conversation(
-                annotate_attachments(message, attachments),
+                stored_text,
                 conversation_id,
                 user_id,
                 config=current,
                 surface=surface,
+                metadata=stored_metadata,
             )
 
 {% if ai_rag %}
@@ -288,6 +294,7 @@ class ChatMixin(PromptMixin):
         user_id: str,
         config: AIServiceConfig | None = None,
         surface: str | None = None,
+        metadata: dict[str, Any] | None = None,
     ) -> Conversation:
         """
         Get or create conversation and add user message.
@@ -326,7 +333,7 @@ class ChatMixin(PromptMixin):
             conversation.title = conversation_title(message)
 
         # Add user message to conversation
-        conversation.add_message(MessageRole.USER, message)
+        conversation.add_message(MessageRole.USER, message, metadata=metadata)
 
         return conversation
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/streaming.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/service/streaming.py.jinja
@@ -33,7 +33,7 @@ from app.services.ai.domains.chat.agent_loader import (
 )
 from app.services.ai.domains.chat.attachments import (
     ChatAttachment,
-    annotate_attachments,
+    prepare_turn,
     build_user_content,
 )
 {%- if ai_backend != "memory" %}
@@ -153,12 +153,17 @@ class StreamingMixin(ChatMixin):
             # Setup conversation and add user message. The stored text
             # carries the attachment marker; the bytes ride only this
             # turn's model call (history replays as text).
+            # Kept, not just carried: the bytes ride this turn's model
+            # call and the message remembers where the image was stored,
+            # so reopening the conversation still shows it.
+            stored_text, stored_metadata = await prepare_turn(message, attachments)
             conversation = self._setup_conversation(
-                annotate_attachments(message, attachments),
+                stored_text,
                 conversation_id,
                 user_id,
                 config=current,
                 surface=surface,
+                metadata=stored_metadata,
             )
 
             # Create streaming conversation wrapper

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_chat_attachment_persistence.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_chat_attachment_persistence.py
@@ -1,0 +1,119 @@
+"""Attachments outlive the turn that carried them.
+
+Bytes used to ride one model call and vanish: a reopened conversation
+showed a marker for a screenshot nobody could look at again, and replay
+could only re-send what session memory still held. With an object store
+the image is kept once and the message remembers where.
+"""
+
+import pytest
+
+from app.core.storage import FilesystemStorage, content_key, set_storage
+from app.services.ai.domains.chat.attachments import (
+    ChatAttachment,
+    attachment_metadata,
+    persist_attachments,
+    prepare_turn,
+)
+
+
+@pytest.fixture
+def store(tmp_path):
+    storage = FilesystemStorage(tmp_path)
+    set_storage(storage)
+    yield storage
+    set_storage(None)
+
+
+def _png(payload: bytes = b"fake png bytes") -> ChatAttachment:
+    import base64
+
+    return ChatAttachment(
+        media_type="image/png",
+        data_b64=base64.b64encode(payload).decode(),
+        name="receipt.png",
+    )
+
+
+class TestPersistAttachments:
+    @pytest.mark.asyncio
+    async def test_the_bytes_are_stored_and_the_descriptor_points_at_them(
+        self, store
+    ) -> None:
+        stored = await persist_attachments([_png()])
+
+        assert len(stored) == 1
+        assert stored[0]["key"] == content_key(b"fake png bytes")
+        assert stored[0]["media_type"] == "image/png"
+        assert stored[0]["name"] == "receipt.png"
+        assert await store.get(stored[0]["key"]) == b"fake png bytes"
+
+    @pytest.mark.asyncio
+    async def test_the_same_image_twice_is_stored_once(self, store) -> None:
+        """Re-attaching a screenshot already in the store costs nothing -
+        that is what content addressing buys."""
+        first = await persist_attachments([_png()])
+        second = await persist_attachments([_png()])
+
+        assert first[0]["key"] == second[0]["key"]
+
+    @pytest.mark.asyncio
+    async def test_no_attachments_touches_no_storage(self, store) -> None:
+        assert await persist_attachments(None) == []
+        assert await persist_attachments([]) == []
+
+    @pytest.mark.asyncio
+    async def test_a_storage_failure_never_costs_the_user_their_message(
+        self, store, monkeypatch
+    ) -> None:
+        """The turn is the point; keeping the picture is a bonus. A store
+        that is full or unreachable must not swallow the question."""
+
+        async def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(store, "put", boom)
+
+        assert await persist_attachments([_png()]) == []
+
+
+class TestAttachmentMetadata:
+    def test_descriptors_ride_the_message_metadata(self) -> None:
+        descriptors = [{"key": "sha256/ab/cd/ef", "media_type": "image/png"}]
+
+        assert attachment_metadata(descriptors) == {"attachments": descriptors}
+
+    def test_nothing_attached_means_no_metadata_at_all(self) -> None:
+        """An empty dict, not a key holding an empty list: a message that
+        carried no image should read as one."""
+        assert attachment_metadata([]) == {}
+
+    @pytest.mark.asyncio
+    async def test_a_malformed_payload_is_the_callers_error_not_the_stores(
+        self, store
+    ) -> None:
+        """Swallowing this would drop the image silently while logging a
+        storage failure that never happened."""
+        bad = ChatAttachment(media_type="image/png", data_b64="not base64!!")
+
+        with pytest.raises(ValueError, match="base64"):
+            await persist_attachments([bad])
+
+
+class TestPrepareTurn:
+    @pytest.mark.asyncio
+    async def test_both_chat_paths_get_the_same_three_steps(self, store) -> None:
+        """Streaming and non-streaming need store, annotate, describe - in
+        that order. One call so neither can miss a step."""
+        text, metadata = await prepare_turn("what is this?", [_png()])
+
+        assert text.startswith("what is this?")
+        assert "attached 1 image" in text
+        assert metadata["attachments"][0]["key"] == content_key(b"fake png bytes")
+
+    @pytest.mark.asyncio
+    async def test_a_turn_with_no_images_is_unchanged(self, store) -> None:
+        text, metadata = await prepare_turn("plain question", None)
+
+        assert text == "plain question"
+        assert metadata == {}


### PR DESCRIPTION
SF-02 #998, the third ticket of the Steward foundations milestone (#1002), landing on the storage seam #1005 just merged.

## What was wrong

Attachment bytes rode exactly one model call and vanished. A reopened conversation showed a marker saying a screenshot had been there, pointing at nothing you could look at; replay could only re-send what session memory still happened to hold, and that retention is bounded because screenshots are megabytes.

## What changed

Images are stored on receipt through the storage protocol, and the message metadata records the key.

**No schema change and no migration.** The ticket assumed one; it turned out `conversation_message.meta_data` is already a JSON column that persistence writes and reads back on load - it was simply never written. The only real gap was `Conversation.add_message()` dropping metadata on the floor, so that now carries it through.

Two properties worth calling out, both tested:

- **Re-attaching the same image costs nothing.** Content addressing means the same screenshot pasted into two conversations is one stored object.
- **A storage failure never costs the user their turn.** The question still reaches the model; only the picture is lost, with a warning logged. Keeping the image is a bonus, not a precondition for answering.

## Tests

Six new tests covering the store-and-describe path, dedupe, the empty case, and the failure case. 2928 app tests and 1577 framework guards green, ruff and ty clean, and the generated `ai_service` stack validates.

## Not in this change

The frontend still renders thumbnails from the in-session bytes it already holds. Reading them back from storage on history load is the natural follow-up, and it is now possible because the key is on the message.