### PR TITLE
Add the document store service

### DIFF
--- a/.github/workflows/stack-matrix.yml
+++ b/.github/workflows/stack-matrix.yml
@@ -91,6 +91,7 @@ jobs:
           - insights_per_user
           - payment
           - blog
+          - documents
           - finance
           - finance_auth
           - comms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 
 ### Added
 
+- **Document store service**: an optional `documents` service that keeps
+  the paper an application accumulates - scans, statements, letters,
+  forms - with ingest, tagging, listing, download, and soft delete.
+  Documents ride the storage seam, so a row records a content-derived
+  key and never a path: the same scan uploaded twice is one document and
+  one object, which makes a retried upload or a scanner that runs twice
+  free rather than duplicative. What a document MEANS - a case, a
+  deadline, a claim it proves - is deliberately absent; that belongs to
+  whatever consumes it.
+
 - **Finance rows say whose money they describe**: a `finance_subject`
   table plus a nullable `subject_id` on accounts and recurring streams.
   Households manage money for other people (a parent in care, a child's

--- a/aegis/commands/update.py
+++ b/aegis/commands/update.py
@@ -666,6 +666,7 @@ def update_command(
             include_insights = answers.get(AnswerKeys.INSIGHTS, False)
             include_payment = answers.get(AnswerKeys.PAYMENT, False)
             include_blog = answers.get(AnswerKeys.BLOG, False)
+            include_documents = answers.get(AnswerKeys.DOCUMENTS, False)
             ai_backend = answers.get(AnswerKeys.AI_BACKEND, StorageBackends.MEMORY)
             ai_needs_migrations = include_ai and ai_backend != StorageBackends.MEMORY
             include_migrations = (
@@ -674,6 +675,7 @@ def update_command(
                 or include_insights
                 or include_payment
                 or include_blog
+                or include_documents
             )
 
             typer.echo(t("update.running_postgen"))

--- a/aegis/constants.py
+++ b/aegis/constants.py
@@ -208,6 +208,7 @@ class AnswerKeys:
     PAYMENT = "include_payment"
     BLOG = "include_blog"
     FINANCE = "include_finance"
+    DOCUMENTS = "include_documents"
 
     # Service names (used for selection/lookup)
     SERVICE_AUTH = "auth"
@@ -217,6 +218,7 @@ class AnswerKeys:
     SERVICE_PAYMENT = "payment"
     SERVICE_BLOG = "blog"
     SERVICE_FINANCE = "finance"
+    SERVICE_DOCUMENTS = "documents"
 
     # Insights source flags
     INSIGHTS_GITHUB = "insights_github"

--- a/aegis/core/copier_manager.py
+++ b/aegis/core/copier_manager.py
@@ -320,6 +320,7 @@ def generate_with_copier(
     include_ai = copier_data.get(AnswerKeys.AI, False)
     include_insights = copier_data.get(AnswerKeys.INSIGHTS, False)
     include_blog = copier_data.get(AnswerKeys.BLOG, False)
+    include_documents = copier_data.get(AnswerKeys.DOCUMENTS, False)
     ai_backend = copier_data.get(AnswerKeys.AI_BACKEND, StorageBackends.MEMORY)
     database_engine = copier_data.get(
         AnswerKeys.DATABASE_ENGINE, StorageBackends.SQLITE
@@ -334,6 +335,7 @@ def generate_with_copier(
 
     is_insights_included: bool = include_insights is True
     is_blog_included: bool = include_blog is True
+    is_documents_included: bool = include_documents is True
     ai_needs_migrations = is_ai_included and ai_backend_str != StorageBackends.MEMORY
     needs_migration_files = (
         is_auth_included
@@ -381,6 +383,7 @@ def generate_with_copier(
             )
             is True,
             AnswerKeys.BLOG: is_blog_included,
+            AnswerKeys.DOCUMENTS: is_documents_included,
             AnswerKeys.PAYMENT: is_payment_included,
             AnswerKeys.FINANCE: is_finance_included,
             AnswerKeys.SCHEDULER: is_scheduler_included,

--- a/aegis/core/copier_updater.py
+++ b/aegis/core/copier_updater.py
@@ -224,6 +224,7 @@ def update_with_copier_native(
         include_insights = answers.get(AnswerKeys.INSIGHTS, False)
         include_payment = answers.get(AnswerKeys.PAYMENT, False)
         include_blog = answers.get(AnswerKeys.BLOG, False)
+        include_documents = answers.get(AnswerKeys.DOCUMENTS, False)
         include_scheduler = answers.get(AnswerKeys.SCHEDULER, False)
         ai_backend = answers.get(AnswerKeys.AI_BACKEND, StorageBackends.MEMORY)
         scheduler_backend = answers.get(
@@ -239,6 +240,7 @@ def update_with_copier_native(
             or include_insights
             or include_payment
             or include_blog
+            or include_documents
             or scheduler_needs_migrations
         )
         # AI needs seeding when using persistence backend (same condition as migrations)

--- a/aegis/core/manual_updater.py
+++ b/aegis/core/manual_updater.py
@@ -107,6 +107,7 @@ _SERVICE_ANSWER_KEYS = (
     AnswerKeys.INSIGHTS,
     AnswerKeys.PAYMENT,
     AnswerKeys.BLOG,
+    AnswerKeys.DOCUMENTS,
     AnswerKeys.FINANCE,
 )
 
@@ -989,6 +990,7 @@ class ManualUpdater:
             or answers.get(AnswerKeys.INSIGHTS)
             or answers.get(AnswerKeys.PAYMENT)
             or answers.get(AnswerKeys.BLOG)
+            or answers.get(AnswerKeys.DOCUMENTS)
             or answers.get(AnswerKeys.FINANCE)
             or scheduler_needs
         )
@@ -1510,6 +1512,8 @@ class ManualUpdater:
             inferred[AnswerKeys.INSIGHTS] = True
         if has_nonstub_dir("app", "services", "blog"):
             inferred[AnswerKeys.BLOG] = True
+        if has_nonstub_dir("app", "services", "documents"):
+            inferred[AnswerKeys.DOCUMENTS] = True
         if has_nonstub_dir("app", "services", "payment"):
             inferred[AnswerKeys.PAYMENT] = True
         if has_nonstub_dir("app", "services", "comms"):

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -1490,6 +1490,90 @@ PAYMENT_AUTH_LINK_MIGRATION = ServiceMigrationSpec(
 # migration too (a Postgres-only ``schema=`` would forfeit that). Money and
 # scaled-integer columns use BigInteger — net worth / brokerage balances and
 # ``*_e8`` quantities/rates overflow int32.
+DOCUMENTS_MIGRATION = ServiceMigrationSpec(
+    service_name="documents",
+    description="Document store: the paper, addressed by its own content",
+    tables=[
+        # One row per stored document. The bytes live in object storage
+        # under ``storage_key``, which is derived from their SHA-256, so
+        # the same scan uploaded twice is one row and one object. What a
+        # document MEANS - a case, a deadline, an obligation - belongs to
+        # whatever consumes it, not here.
+        TableSpec(
+            name="document",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("owner_user_id", "sa.Integer()", nullable=True),
+                ColumnSpec("title", "sa.String(255)", nullable=False),
+                ColumnSpec("kind", "sa.String(32)", nullable=False, default="'other'"),
+                ColumnSpec("storage_key", "sa.String(128)", nullable=False),
+                ColumnSpec(
+                    "storage_backend",
+                    "sa.String(32)",
+                    nullable=False,
+                    default="'filesystem'",
+                ),
+                ColumnSpec("content_hash", "sa.String(64)", nullable=False),
+                ColumnSpec("media_type", "sa.String(128)", nullable=True),
+                ColumnSpec("byte_size", "sa.Integer()", nullable=False, default="0"),
+                ColumnSpec("page_count", "sa.Integer()", nullable=True),
+                ColumnSpec("document_date", "sa.Date()", nullable=True),
+                ColumnSpec("received_at", "sa.DateTime()", nullable=True),
+                ColumnSpec(
+                    "source", "sa.String(32)", nullable=False, default="'upload'"
+                ),
+                ColumnSpec("note", "sa.String()", nullable=True),
+                ColumnSpec("meta_data", "sa.JSON()", nullable=False, default="{}"),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=True),
+                ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
+            ],
+            indexes=[
+                IndexSpec("ix_document_owner", ["owner_user_id"]),
+                # The dedupe lookup: same bytes, same owner, same row.
+                # The dedupe rule, enforced rather than merely checked:
+                # ingest reads before it writes, and two concurrent
+                # uploads of the same bytes can both miss that read.
+                # Partial, so retiring a document does not block filing
+                # the same paper again.
+                IndexSpec(
+                    "ix_document_owner_hash",
+                    ["owner_user_id", "content_hash"],
+                    unique=True,
+                    where="deleted_at IS NULL",
+                ),
+                IndexSpec("ix_document_kind", ["kind"]),
+            ],
+            check_constraints=[
+                CheckConstraintSpec(
+                    name="ck_document_kind",
+                    sqltext=(
+                        "kind IN ('letter', 'statement', 'form', "
+                        "'identification', 'receipt', 'other')"
+                    ),
+                ),
+            ],
+        ),
+        # Free-form labels rather than a fixed taxonomy: the framework
+        # stores paper, it does not decide what kinds of paper exist.
+        TableSpec(
+            name="document_tag",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("document_id", "sa.Integer()", nullable=False),
+                ColumnSpec("label", "sa.String(64)", nullable=False),
+            ],
+            indexes=[
+                IndexSpec("ix_document_tag_document", ["document_id"]),
+                IndexSpec("uq_document_tag", ["document_id", "label"], unique=True),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(["document_id"], "document", ["id"], ondelete="CASCADE"),
+            ],
+        ),
+    ],
+)
+
 FINANCE_MIGRATION = ServiceMigrationSpec(
     service_name="finance",
     description="Finance service tables (currencies, fx rates)",

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -25,6 +25,7 @@ from .migration_generator import (
     AUTH_RBAC_MIGRATION,
     AUTH_TOKENS_MIGRATION,
     BLOG_MIGRATION,
+    DOCUMENTS_MIGRATION,
     FINANCE_AUTH_LINK_MIGRATION,
     FINANCE_MIGRATION,
     INSIGHTS_MIGRATION,
@@ -1073,6 +1074,58 @@ SERVICES: dict[str, ServiceSpec] = {
                 "tests/services/test_finance_subjects.py",
                 "tests/api/test_finance_split_endpoints.py",
                 "tests/components/frontend/test_finance_splits_ui.py",
+            ],
+        ),
+    ),
+    "documents": ServiceSpec(
+        name="documents",
+        docs_path="",
+        marker_path="app/services/documents",
+        type=ServiceType.STORAGE,
+        description="Document store: keep the paper, deduped and findable",
+        long_description=(
+            "Durable storage for the paper an application accumulates: "
+            "scans, statements, letters, forms. Bytes are addressed by "
+            "their own content hash, so the same file uploaded twice is "
+            "one document and one object, and moving to a bucket later "
+            "is a copy rather than a migration. What a document MEANS - "
+            "a case, a deadline, an obligation - belongs to whatever "
+            "consumes it."
+        ),
+        required_components=[
+            ComponentNames.BACKEND,
+            ComponentNames.DATABASE,
+        ],
+        wiring=PluginWiring(
+            routers=[
+                RouterWiring(
+                    module="app.components.backend.api.documents.router",
+                    symbol="router",
+                    alias="documents_router",
+                    prefix="/api/v1",
+                ),
+            ],
+            deps_providers=[
+                SymbolWiring(
+                    module="app.services.documents.deps",
+                    symbol="get_document_service",
+                ),
+            ],
+        ),
+        migrations=[DOCUMENTS_MIGRATION],
+        pyproject_deps=[
+            "alembic==1.16.5",
+        ],
+        template_files=[
+            "app/services/documents/",
+            "app/components/backend/api/documents/",
+        ],
+        files=FileManifest(
+            primary=[
+                "app/components/backend/api/documents",
+                "app/services/documents",
+                "tests/services/test_documents_service.py",
+                "tests/api/test_documents_endpoints.py",
             ],
         ),
     ),

--- a/aegis/i18n/locales/de.py
+++ b/aegis/i18n/locales/de.py
@@ -78,6 +78,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "Benutzerauthentifizierung und -autorisierung mit JWT-Tokens",
     "service.ai": "AI Chatbot Service mit Multi-Framework-Unterstützung",
     "service.comms": "Kommunikationsservice mit E-Mail, SMS und Sprache",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "Markdown-Blog mit Entwurfs-, Veröffentlichungs- und Tag-Workflow",
     # ── Interactive: component prompts ─────────────────────────────────
     "interactive.add_prompt": "{description} hinzufügen?",
@@ -436,6 +437,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "Kommunikation",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "Dokumentation",
@@ -1118,6 +1120,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "E-Mail, SMS und Sprachanrufe über etablierte Anbieter: Resend für E-Mail, Twilio für SMS und Sprache. Beide haben kostenlose Kontingente, sodass Sie ohne Kreditkarte starten können.",
     "service.insights.long": "Automatisches Tracking der Verbreitung Ihres Projekts über GitHub, PyPI, Plausible Analytics und Reddit. Erfasst planmäßig, speichert den Verlauf und visualisiert das Wachstum im Dashboard.",
     "service.payment.long": "Zahlungsabwicklung mit Stripe: Checkout-Sessions, Abonnements, Webhooks und Rückerstattungen. Der Testmodus von Stripe braucht keine Kreditkarte, sodass Sie den gesamten Ablauf vor dem Produktivstart aufbauen können.",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "Hauseigenes Markdown-Publishing mit datenbankgestützten Beiträgen, Tags, Entwürfen und einer Editor-Oberfläche im Dashboard. Importieren und exportieren Sie Beiträge als reines Markdown mit Frontmatter.",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "In-Memory",

--- a/aegis/i18n/locales/en.py
+++ b/aegis/i18n/locales/en.py
@@ -80,6 +80,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "User authentication and authorization with JWT tokens",
     "service.ai": "AI chatbot service with multi-framework support",
     "service.comms": "Communications service with email, SMS and voice",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "Markdown blog with draft/publish workflow and tags",
     # ── Interactive: component prompts ─────────────────────────────────
     "interactive.add_prompt": "Add {description}?",
@@ -446,6 +447,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "Communications",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "Documentation",
@@ -1222,6 +1224,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "Email, SMS, and voice calls using industry providers: Resend for email, Twilio for SMS and voice. Both have free tiers, so you can start without a credit card.",
     "service.insights.long": "Automated tracking of your project's adoption across GitHub, PyPI, Plausible Analytics, and Reddit. Collects on a schedule, stores history, and visualizes growth in the dashboard.",
     "service.payment.long": "Payment processing with Stripe: checkout sessions, subscriptions, webhooks, and refunds. Stripe's test mode needs no credit card, so you can build the full flow before going live.",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "First-party Markdown publishing with database-backed posts, tags, drafts, and an editor UI in the dashboard. Import and export posts as plain Markdown with frontmatter.",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "In-memory",

--- a/aegis/i18n/locales/es.py
+++ b/aegis/i18n/locales/es.py
@@ -80,6 +80,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "Autenticación y autorización de usuarios con tokens JWT",
     "service.ai": "Servicio de chatbot IA con soporte multi-framework",
     "service.comms": "Servicio de comunicaciones con email, SMS y voz",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "Blog Markdown con borradores, publicación y etiquetas",
     # ── Interactive: component prompts ─────────────────────────────────
     "interactive.add_prompt": "¿Agregar {description}?",
@@ -438,6 +439,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "Comunicaciones",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "Documentación",
@@ -1122,6 +1124,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "Correo, SMS y llamadas de voz con proveedores del sector: Resend para correo, Twilio para SMS y voz. Ambos tienen planes gratuitos, así que puedes empezar sin tarjeta de crédito.",
     "service.insights.long": "Seguimiento automático de la adopción de tu proyecto en GitHub, PyPI, Plausible Analytics y Reddit. Recopila según un horario, guarda el historial y visualiza el crecimiento en el panel.",
     "service.payment.long": "Procesamiento de pagos con Stripe: sesiones de pago, suscripciones, webhooks y reembolsos. El modo de prueba de Stripe no necesita tarjeta de crédito, así que puedes construir todo el flujo antes de salir a producción.",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "Publicación nativa en Markdown con entradas respaldadas por base de datos, etiquetas, borradores y una interfaz de editor en el panel. Importa y exporta entradas como Markdown plano con frontmatter.",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "En memoria",

--- a/aegis/i18n/locales/fr.py
+++ b/aegis/i18n/locales/fr.py
@@ -78,6 +78,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "Authentification et autorisation avec jetons JWT",
     "service.ai": "Service de chatbot IA avec support multi-framework",
     "service.comms": "Service de communications : e-mail, SMS et voix",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "Blog Markdown avec brouillons, publication et tags",
     # ── Interactive: component prompts ─────────────────────────────────
     "interactive.add_prompt": "Ajouter {description} ?",
@@ -438,6 +439,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "Communications",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "Documentation",
@@ -1123,6 +1125,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "E-mail, SMS et appels vocaux via des fournisseurs reconnus : Resend pour l'e-mail, Twilio pour le SMS et la voix. Les deux proposent des offres gratuites, vous pouvez donc démarrer sans carte bancaire.",
     "service.insights.long": "Suivi automatique de l'adoption de votre projet sur GitHub, PyPI, Plausible Analytics et Reddit. Collecte selon un calendrier, conserve l'historique et visualise la croissance dans le tableau de bord.",
     "service.payment.long": "Traitement des paiements avec Stripe : sessions de paiement, abonnements, webhooks et remboursements. Le mode test de Stripe ne nécessite pas de carte bancaire, vous pouvez donc construire tout le parcours avant la mise en production.",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "Publication Markdown native avec des billets stockés en base de données, des tags, des brouillons et une interface d'édition dans le tableau de bord. Importez et exportez les billets en Markdown brut avec frontmatter.",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "En mémoire",

--- a/aegis/i18n/locales/ja.py
+++ b/aegis/i18n/locales/ja.py
@@ -73,6 +73,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "JWT トークンによるユーザー認証・認可",
     "service.ai": "マルチフレームワーク対応 AI チャットボットサービス",
     "service.comms": "メール・SMS・音声のコミュニケーションサービス",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "下書き、公開、タグに対応した Markdown ブログ",
     # ── 対話モード：コンポーネントプロンプト ────────────────────────────
     "interactive.add_prompt": "{description} を追加しますか？",
@@ -426,6 +427,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "コミュニケーション",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "ドキュメント",
@@ -1103,6 +1105,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "主要なプロバイダーを使ったメール、SMS、音声通話：メールは Resend、SMS と音声は Twilio。どちらも無料枠があるので、クレジットカードなしで始められます。",
     "service.insights.long": "GitHub、PyPI、Plausible Analytics、Reddit にまたがってプロジェクトの普及状況を自動的に追跡。スケジュールに沿って収集し、履歴を保存し、ダッシュボードで成長を可視化します。",
     "service.payment.long": "Stripe による決済処理：チェックアウトセッション、サブスクリプション、Webhook、返金。Stripe のテストモードはクレジットカード不要なので、本番前にフロー全体を構築できます。",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "データベースに保存される投稿、タグ、下書き、ダッシュボード内のエディター UI を備えた、ファーストパーティの Markdown パブリッシング。投稿は frontmatter 付きのプレーン Markdown としてインポート・エクスポートできます。",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "インメモリ",

--- a/aegis/i18n/locales/ko.py
+++ b/aegis/i18n/locales/ko.py
@@ -74,6 +74,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "JWT 토큰 기반 사용자 인증 및 권한 부여",
     "service.ai": "멀티 프레임워크 지원 AI 챗봇 서비스",
     "service.comms": "이메일, SMS, 음성 통신 서비스",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "초안, 게시, 태그 워크플로가 있는 Markdown 블로그",
     # ── Interactive: component prompts ─────────────────────────────────
     "interactive.add_prompt": "{description}을(를) 추가하시겠습니까?",
@@ -413,6 +414,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "통신",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "문서",
@@ -1068,6 +1070,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "업계 프로바이더를 사용한 이메일, SMS, 음성 통화: 이메일은 Resend, SMS와 음성은 Twilio. 둘 다 무료 등급이 있어 신용카드 없이 시작할 수 있습니다.",
     "service.insights.long": "GitHub, PyPI, Plausible Analytics, Reddit 전반에서 프로젝트의 채택 현황을 자동으로 추적합니다. 일정에 따라 수집하고 기록을 저장하며 대시보드에서 성장을 시각화합니다.",
     "service.payment.long": "Stripe를 이용한 결제 처리: 체크아웃 세션, 구독, 웹훅, 환불. Stripe의 테스트 모드는 신용카드가 필요 없어 출시 전에 전체 흐름을 만들 수 있습니다.",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "데이터베이스 기반 게시물, 태그, 초안, 대시보드 내 편집기 UI를 갖춘 자체 Markdown 퍼블리싱. 게시물을 frontmatter가 포함된 일반 Markdown으로 가져오고 내보낼 수 있습니다.",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "인메모리",

--- a/aegis/i18n/locales/ru.py
+++ b/aegis/i18n/locales/ru.py
@@ -78,6 +78,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "Аутентификация и авторизация с JWT-токенами",
     "service.ai": "AI-чатбот с поддержкой нескольких фреймворков",
     "service.comms": "Сервис коммуникаций: email, SMS и голос",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "Markdown-блог с черновиками, публикацией и тегами",
     # ── Интерактив: запросы для компонентов ─────────────────────────────
     "interactive.add_prompt": "Добавить {description}?",
@@ -416,6 +417,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "Коммуникации",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "Документация",
@@ -1085,6 +1087,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "Email, SMS и голосовые вызовы через ведущих провайдеров: Resend для почты, Twilio для SMS и голоса. У обоих есть бесплатные тарифы, так что можно начать без кредитной карты.",
     "service.insights.long": "Автоматическое отслеживание распространения вашего проекта в GitHub, PyPI, Plausible Analytics и Reddit. Собирает по расписанию, хранит историю и визуализирует рост на панели.",
     "service.payment.long": "Обработка платежей через Stripe: сессии оплаты, подписки, вебхуки и возвраты. Тестовый режим Stripe не требует кредитной карты, так что можно построить весь процесс до запуска.",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "Встроенная публикация в Markdown с хранением постов в базе данных, тегами, черновиками и редактором в панели. Импорт и экспорт постов в виде обычного Markdown с frontmatter.",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "В памяти",

--- a/aegis/i18n/locales/zh.py
+++ b/aegis/i18n/locales/zh.py
@@ -65,6 +65,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "用户认证与授权（JWT）",
     "service.ai": "AI 对话服务，支持多框架",
     "service.comms": "通信服务（邮件、短信、语音）",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "支持草稿、发布和标签的 Markdown 博客",
     # ── 交互：组件选择提示 ────────────────────────────────────────────
     "interactive.add_prompt": "添加{description}？",
@@ -342,6 +343,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "通信",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "文档",
@@ -955,6 +957,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "使用主流服务商实现邮件、短信和语音通话：邮件用 Resend，短信和语音用 Twilio。两者都有免费额度，无需信用卡即可开始。",
     "service.insights.long": "自动追踪你的项目在 GitHub、PyPI、Plausible Analytics 和 Reddit 上的采用情况。按计划采集、保存历史，并在仪表盘中可视化增长。",
     "service.payment.long": "使用 Stripe 处理支付：结账会话、订阅、Webhook 和退款。Stripe 的测试模式无需信用卡，因此你可以在上线前构建完整流程。",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "原生的 Markdown 发布功能，文章由数据库支撑，支持标签、草稿，以及仪表盘中的编辑器界面。可将文章作为带 frontmatter 的纯 Markdown 导入和导出。",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "内存",

--- a/aegis/i18n/locales/zh_hant.py
+++ b/aegis/i18n/locales/zh_hant.py
@@ -65,6 +65,7 @@ MESSAGES: dict[str, str] = {
     "service.auth": "用戶認證與授權（JWT）",
     "service.ai": "AI 對話服務，支援多框架",
     "service.comms": "通信服務（郵件、短信、語音）",
+    "service.documents": "Document store: keep the paper, deduped and findable",
     "service.blog": "支援草稿、發佈和標籤的 Markdown 部落格",
     # ── 交互：元件選擇提示 ────────────────────────────────────────────
     "interactive.add_prompt": "添加{description}？",
@@ -342,6 +343,7 @@ MESSAGES: dict[str, str] = {
     "projectmap.comms": "通信",
     "projectmap.insights": "Adoption metrics",
     "projectmap.payment": "Payments and subscriptions",
+    "projectmap.documents": "Document store",
     "projectmap.blog": "Markdown blog",
     "projectmap.finance": "Personal finance",
     "projectmap.docs": "文檔",
@@ -955,6 +957,7 @@ MESSAGES: dict[str, str] = {
     "service.comms.long": "使用主流服務商實現電子郵件、簡訊和語音通話：電子郵件用 Resend，簡訊和語音用 Twilio。兩者都有免費額度，無需信用卡即可開始。",
     "service.insights.long": "自動追蹤你的專案在 GitHub、PyPI、Plausible Analytics 和 Reddit 上的採用情況。按排程採集、保存歷史，並在儀表板中視覺化成長。",
     "service.payment.long": "使用 Stripe 處理付款：結帳工作階段、訂閱、Webhook 和退款。Stripe 的測試模式無需信用卡，因此你可以在上線前建構完整流程。",
+    "service.documents.long": "Durable storage for the paper an application accumulates: scans, statements, letters, forms. Bytes are addressed by their own content hash, so the same file uploaded twice is one document and one object, and moving to a bucket later is a copy rather than a migration.",
     "service.blog.long": "原生的 Markdown 發布功能，文章由資料庫支撐，支援標籤、草稿，以及儀表板中的編輯器介面。可將文章作為帶 frontmatter 的純 Markdown 匯入和匯出。",
     # ── Guided setup: choice descriptions + build steps ──
     "guided.choice.name.in_memory": "記憶體內",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/.copier-answers.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/.copier-answers.yml.jinja
@@ -27,6 +27,7 @@ include_ai: {{ include_ai }}
 include_comms: {{ include_comms }}
 include_payment: {{ include_payment }}
 include_blog: {{ include_blog }}
+include_documents: {{ include_documents }}
 include_finance: {{ include_finance }}
 payment_provider: {{ payment_provider }}
 finance_plaid: {{ finance_plaid }}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/alembic/env.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/alembic/env.py.jinja
@@ -39,6 +39,9 @@ from app.services.insights.models import (  # noqa: E402,F401
 {% if include_blog %}
 from app.services.blog.models import BlogPost, BlogPostTag, BlogTag  # noqa: E402,F401
 {% endif %}
+{% if include_documents %}
+from app.services.documents.models import Document, DocumentTag  # noqa: F401
+{% endif %}
 {% if include_finance %}
 from app.services.finance.models import (  # noqa: E402,F401
     FinanceAccount,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/__init__.py
@@ -1,0 +1,1 @@
+"""Documents API package."""

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
@@ -1,0 +1,218 @@
+"""Document store API routes.
+
+Upload, list, fetch metadata, download bytes, tag, retire. What a
+document means is the caller's business; these routes only keep it and
+give it back.
+"""
+
+from datetime import date, datetime
+import re
+
+from fastapi import (
+    APIRouter,
+    Depends,
+    File,
+    Form,
+    HTTPException,
+    Response,
+    UploadFile,
+    status,
+)
+from pydantic import BaseModel, Field
+
+from app.services.documents.deps import get_document_service, get_owner_user_id
+from app.services.documents.models import Document
+from app.services.documents.service import DocumentService
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+_NOT_FOUND = "Document not found"
+# Anything that could end a header line or a quoted filename. The title is
+# user input and lands in Content-Disposition, so a stray newline there is
+# header injection, not a formatting nuisance.
+_UNSAFE_FILENAME = re.compile(r'[\r\n"\\]+')
+
+
+def _safe_filename(title: str) -> str:
+    return _UNSAFE_FILENAME.sub("", title).strip() or "document"
+
+
+class DocumentResponse(BaseModel):
+    """A document as the API describes it.
+
+    ``storage_key`` is deliberately included: it is content-addressed
+    and therefore stable across backends, which makes it a safe handle
+    for a caller that wants to reference the same bytes elsewhere.
+    """
+
+    id: int
+    title: str
+    kind: str
+    media_type: str | None
+    byte_size: int
+    page_count: int | None
+    document_date: date | None
+    received_at: datetime | None
+    source: str
+    storage_key: str
+    storage_backend: str
+    note: str | None
+    tags: list[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_row(
+        cls, row: Document, tags: list[str] | None = None
+    ) -> "DocumentResponse":
+        return cls(
+            id=row.id or 0,
+            title=row.title,
+            kind=row.kind,
+            media_type=row.media_type,
+            byte_size=row.byte_size,
+            page_count=row.page_count,
+            document_date=row.document_date,
+            received_at=row.received_at,
+            source=row.source,
+            storage_key=row.storage_key,
+            storage_backend=row.storage_backend,
+            note=row.note,
+            tags=tags or [],
+        )
+
+
+class DocumentListResponse(BaseModel):
+    items: list[DocumentResponse]
+    total: int
+
+
+class TagRequest(BaseModel):
+    label: str
+
+
+@router.post("", response_model=DocumentResponse, status_code=status.HTTP_201_CREATED)
+async def upload_document(
+    file: UploadFile = File(...),
+    title: str | None = Form(None),
+    kind: str = Form("other"),
+    note: str | None = Form(None),
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> DocumentResponse:
+    """Store an uploaded file.
+
+    Uploading the same bytes twice returns the existing document rather
+    than a second one, so a retried upload is safe.
+    """
+    data = await file.read()
+    try:
+        document = await service.ingest(
+            data,
+            title=title or file.filename or "Untitled",
+            kind=kind,
+            media_type=file.content_type,
+            source="upload",
+            note=note,
+            owner_user_id=owner_user_id,
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from None
+    return DocumentResponse.from_row(document)
+
+
+@router.get("", response_model=DocumentListResponse)
+async def list_documents(
+    kind: str | None = None,
+    tag: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> DocumentListResponse:
+    rows, total = await service.list_documents(
+        kind=kind,
+        tag=tag,
+        page=page,
+        page_size=page_size,
+        owner_user_id=owner_user_id,
+    )
+    # One tags query for the whole page, not one per row.
+    tags = await service.tags_for_many([row.id for row in rows if row.id])
+    items = [DocumentResponse.from_row(row, tags.get(row.id or 0, [])) for row in rows]
+    return DocumentListResponse(items=items, total=total)
+
+
+@router.get("/{document_id}", response_model=DocumentResponse)
+async def get_document(
+    document_id: int,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> DocumentResponse:
+    document = await service.get(document_id, owner_user_id=owner_user_id)
+    if document is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    return DocumentResponse.from_row(document, await service.tags_for(document_id))
+
+
+@router.get("/{document_id}/content")
+async def download_document(
+    document_id: int,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> Response:
+    """The bytes themselves, read through whichever backend holds them."""
+    document = await service.get(document_id, owner_user_id=owner_user_id)
+    if document is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    data = await service.content(document_id, owner_user_id=owner_user_id)
+    if data is None:
+        # The row outlived its object: a real failure, not a 404 - the
+        # document exists and the store lost it.
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Document content is not retrievable from storage",
+        )
+    return Response(
+        content=data,
+        media_type=document.media_type or "application/octet-stream",
+        headers={
+            "Content-Disposition": (
+                f'inline; filename="{_safe_filename(document.title)}"'
+            ),
+        },
+    )
+
+
+@router.post("/{document_id}/tags", response_model=DocumentResponse)
+async def tag_document(
+    document_id: int,
+    body: TagRequest,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> DocumentResponse:
+    try:
+        tagged = await service.tag(document_id, body.label)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
+        ) from None
+    if tagged is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    document = await service.get(document_id, owner_user_id=owner_user_id)
+    if document is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    return DocumentResponse.from_row(document, await service.tags_for(document_id))
+
+
+@router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_document(
+    document_id: int,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> Response:
+    """Retire a document. The bytes stay: another document may hold the
+    same content, and the audit trail should not lose its subject."""
+    if not await service.soft_delete(document_id, owner_user_id=owner_user_id):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/routing.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/routing.py.jinja
@@ -48,6 +48,9 @@ from app.components.backend.api.payment.pages import router as payment_pages_rou
 {%- if include_blog %}
 from app.components.backend.api.blog.router import router as blog_router
 {%- endif %}
+{%- if include_documents %}
+from app.components.backend.api.documents.router import router as documents_router
+{%- endif %}
 {%- if include_finance %}
 from app.components.backend.api.finance.router import router as finance_router
 {%- endif %}
@@ -107,6 +110,9 @@ def include_routers(app: FastAPI) -> None:
     {%- endif %}
     {%- if include_blog %}
     app.include_router(blog_router, prefix="/api/v1")
+    {%- endif %}
+    {%- if include_documents %}
+    app.include_router(documents_router, prefix="/api/v1")
     {%- endif %}
     {%- if include_finance %}
     app.include_router(finance_router, prefix="/api/v1")

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/database_init.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/database_init.py.jinja
@@ -28,11 +28,14 @@ from app.models.org import Organization, OrganizationMember  # noqa: F401
 {% if include_blog %}
 from app.services.blog.models import BlogPost, BlogPostTag, BlogTag  # noqa: F401
 {% endif %}
+{% if include_documents %}
+from app.services.documents.models import Document, DocumentTag  # noqa: F401
+{% endif %}
 {% if include_scheduler and scheduler_backend != "memory" %}
 from app.services.scheduler.models import JobExecution  # noqa: F401
 {% endif %}
 
-{% set needs_migrations = include_auth or include_blog or include_insights or include_payment or include_finance or (include_ai and ai_backend != "memory") or (include_scheduler and scheduler_backend != "memory") %}
+{% set needs_migrations = include_auth or include_blog or include_documents or include_insights or include_payment or include_finance or (include_ai and ai_backend != "memory") or (include_scheduler and scheduler_backend != "memory") %}
 {% if database_engine == "postgres" and needs_migrations %}
 def _check_and_stamp_existing_tables() -> None:
     """

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/__init__.py
@@ -1,0 +1,6 @@
+"""Document store: keep the paper, deduped and findable."""
+
+from app.services.documents.models import DOCUMENT_KINDS, Document, DocumentTag
+from app.services.documents.service import DocumentService
+
+__all__ = ["DOCUMENT_KINDS", "Document", "DocumentTag", "DocumentService"]

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/deps.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/deps.py.jinja
@@ -1,0 +1,44 @@
+"""FastAPI dependency providers for the document service.
+
+Mirrors ``finance/deps.py``. ``get_owner_user_id`` centralizes owner
+scoping in one place: it resolves to the authenticated user's id when the
+auth service is present, else ``None`` (single-user / standalone) - so
+route handlers stay auth-agnostic and never repeat the guard per
+endpoint. Documents dedupe PER OWNER, so getting this wrong would make
+one person's scan collide with another's.
+"""
+
+from fastapi import Depends
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.db import get_async_db
+from app.services.documents.service import DocumentService
+{%- if include_auth %}
+from app.models.user import User
+from app.services.auth.deps import get_current_active_user
+{%- endif %}
+
+
+async def get_document_service(
+    db: AsyncSession = Depends(get_async_db),
+) -> DocumentService:
+    """Provide a DocumentService.
+
+    ``get_async_db`` is the FastAPI-dependency form of the session, and
+    what every other service injects; ``get_async_session`` is the same
+    transaction handling wrapped as a context manager, for scripts and
+    background jobs that own their own scope. Both commit on success.
+    """
+    return DocumentService(db)
+
+{% if include_auth %}
+async def get_owner_user_id(
+    current_user: User = Depends(get_current_active_user),
+) -> int | None:
+    """Owner scope = the authenticated user (auth service present)."""
+    return current_user.id
+{%- else %}
+async def get_owner_user_id() -> int | None:
+    """No auth service - the store is single-user, so rows are unscoped."""
+    return None
+{%- endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/models.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/models.py
@@ -1,0 +1,113 @@
+"""The document row: where the paper is, and what it is.
+
+Bytes live in object storage under a key derived from their own SHA-256
+(see ``app.core.storage``), so this table never holds a path and the same
+scan uploaded twice is one row pointing at one object.
+
+What a document MEANS - the case it belongs to, the deadline it creates,
+the claim it proves - is deliberately absent. That is the consuming
+application's business; this service stores paper and finds it again.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any
+
+from sqlalchemy import JSON, CheckConstraint, Column, Index
+from sqlmodel import Field, SQLModel
+
+# What kind of paper this is. Coarse on purpose: a fixed taxonomy would
+# be the framework deciding what documents exist, which it should not.
+# Anything finer rides tags.
+DOCUMENT_KINDS = (
+    "letter",
+    "statement",
+    "form",
+    "identification",
+    "receipt",
+    "other",
+)
+
+
+def _utcnow() -> datetime:
+    """Naive UTC, matching the timestamp columns across services."""
+    from datetime import UTC
+
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class Document(SQLModel, table=True):
+    """One stored document."""
+
+    __tablename__ = "document"
+    __table_args__ = (
+        Index("ix_document_owner", "owner_user_id"),
+        # The dedupe rule, enforced rather than merely checked: ingest
+        # reads before it writes, and two concurrent uploads of the same
+        # bytes can both miss that read. Partial, so a retired document
+        # does not block re-filing the same paper later - the same shape
+        # the soft-delete uniques elsewhere use.
+        Index(
+            "ix_document_owner_hash",
+            "owner_user_id",
+            "content_hash",
+            unique=True,
+            sqlite_where=Column("deleted_at").is_(None),
+            postgresql_where=Column("deleted_at").is_(None),
+        ),
+        Index("ix_document_kind", "kind"),
+        CheckConstraint(
+            "kind IN ('letter', 'statement', 'form', 'identification', "
+            "'receipt', 'other')",
+            name="ck_document_kind",
+        ),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    owner_user_id: int | None = Field(default=None)
+    title: str = Field(max_length=255)
+    kind: str = Field(default="other", max_length=32)
+    # Where the bytes are. The key is content-derived, so it is portable
+    # across backends; the backend name is recorded so a half-migrated
+    # store still resolves every row.
+    storage_key: str = Field(max_length=128)
+    storage_backend: str = Field(default="filesystem", max_length=32)
+    content_hash: str = Field(max_length=64)
+    media_type: str | None = Field(default=None, max_length=128)
+    byte_size: int = Field(default=0)
+    page_count: int | None = None
+    # When the DOCUMENT is dated (the letter's own date), as opposed to
+    # when it arrived - a renewal request dated the 27th can land in
+    # August's post.
+    document_date: date | None = None
+    received_at: datetime | None = None
+    source: str = Field(default="upload", max_length=32)
+    note: str | None = None
+    meta_data: dict[str, Any] = Field(
+        default_factory=dict, sa_column=Column("meta_data", JSON, nullable=False)
+    )
+    created_at: datetime = Field(default_factory=_utcnow)
+    updated_at: datetime | None = None
+    deleted_at: datetime | None = None
+
+    def __repr__(self) -> str:
+        return f"<Document id={self.id} title={self.title!r} kind={self.kind}>"
+
+
+class DocumentTag(SQLModel, table=True):
+    """A free-form label on a document.
+
+    Tags rather than a taxonomy: what counts as a meaningful category
+    differs per application, and the framework has no business guessing.
+    """
+
+    __tablename__ = "document_tag"
+    __table_args__ = (
+        Index("ix_document_tag_document", "document_id"),
+        Index("uq_document_tag", "document_id", "label", unique=True),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id")
+    label: str = Field(max_length=64)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/service.py
@@ -1,0 +1,240 @@
+"""Storing paper and finding it again.
+
+Ingest is idempotent by construction: the storage key is derived from
+the payload's SHA-256, so re-uploading a scan returns the document that
+already exists rather than a second row. That is the property the whole
+service is built around - a scanner that runs twice, an email fetched
+again, a user who clicks upload twice all cost one document.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+from typing import Any
+
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.storage import content_key, get_storage
+from app.services.documents.models import DOCUMENT_KINDS, Document, DocumentTag
+
+
+def _utcnow() -> datetime:
+    """Naive UTC, the timestamp convention every service here shares.
+
+    A local-time timestamp reads differently depending on where the
+    process runs, which makes "received on the 27th" a question about
+    the server rather than about the document.
+    """
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
+class DocumentService:
+    """The document store's whole surface."""
+
+    def __init__(self, db: AsyncSession) -> None:
+        self.db = db
+
+    async def ingest(
+        self,
+        data: bytes,
+        *,
+        title: str,
+        kind: str = "other",
+        media_type: str | None = None,
+        owner_user_id: int | None = None,
+        document_date: date | None = None,
+        source: str = "upload",
+        note: str | None = None,
+        page_count: int | None = None,
+    ) -> Document:
+        """Store bytes and record the document, or return the one that
+        already holds these exact bytes.
+
+        Deduped per owner rather than globally: two people holding the
+        same form is two documents, and one person scanning it twice is
+        one.
+        """
+        if not data:
+            raise ValueError("A document needs content.")
+        display = (title or "").strip()
+        if not display:
+            raise ValueError("A document needs a title.")
+        if kind not in DOCUMENT_KINDS:
+            raise ValueError(
+                f"Unknown document kind {kind!r}; expected one of "
+                f"{', '.join(DOCUMENT_KINDS)}."
+            )
+
+        key = content_key(data)
+        existing = await self.by_content(key, owner_user_id=owner_user_id)
+        if existing is not None:
+            return existing
+
+        storage = get_storage()
+        stored_key = await storage.put(data, content_type=media_type)
+        document = Document(
+            owner_user_id=owner_user_id,
+            title=display,
+            kind=kind,
+            storage_key=stored_key,
+            storage_backend=storage.backend_name,
+            content_hash=stored_key.rsplit("/", 1)[-1],
+            media_type=media_type,
+            byte_size=len(data),
+            page_count=page_count,
+            document_date=document_date,
+            received_at=_utcnow(),
+            source=source,
+            note=note,
+        )
+        self.db.add(document)
+        await self.db.flush()
+        return document
+
+    async def by_content(
+        self, key: str, *, owner_user_id: int | None = None
+    ) -> Document | None:
+        """The live document holding these bytes, if there is one."""
+        digest = key.rsplit("/", 1)[-1]
+        query = select(Document).where(
+            Document.content_hash == digest, Document.deleted_at.is_(None)
+        )
+        if owner_user_id is not None:
+            query = query.where(Document.owner_user_id == owner_user_id)
+        return (await self.db.exec(query)).first()
+
+    async def get(
+        self, document_id: int, *, owner_user_id: int | None = None
+    ) -> Document | None:
+        query = select(Document).where(
+            Document.id == document_id, Document.deleted_at.is_(None)
+        )
+        if owner_user_id is not None:
+            query = query.where(Document.owner_user_id == owner_user_id)
+        return (await self.db.exec(query)).first()
+
+    async def content(
+        self, document_id: int, *, owner_user_id: int | None = None
+    ) -> bytes | None:
+        """The stored bytes, read through the storage backend the row
+        names rather than a path this service constructs."""
+        document = await self.get(document_id, owner_user_id=owner_user_id)
+        if document is None:
+            return None
+        return await get_storage().get(document.storage_key)
+
+    async def list_documents(
+        self,
+        *,
+        owner_user_id: int | None = None,
+        kind: str | None = None,
+        tag: str | None = None,
+        page: int = 1,
+        page_size: int = 50,
+    ) -> tuple[list[Document], int]:
+        """A page of live documents, newest first, plus the total."""
+        from sqlalchemy import func
+
+        query = select(Document).where(Document.deleted_at.is_(None))
+        count_query = (
+            select(func.count())
+            .select_from(Document)
+            .where(Document.deleted_at.is_(None))
+        )
+        if owner_user_id is not None:
+            query = query.where(Document.owner_user_id == owner_user_id)
+            count_query = count_query.where(Document.owner_user_id == owner_user_id)
+        if kind is not None:
+            query = query.where(Document.kind == kind)
+            count_query = count_query.where(Document.kind == kind)
+        if tag is not None:
+            tagged = select(DocumentTag.document_id).where(DocumentTag.label == tag)
+            query = query.where(Document.id.in_(tagged))
+            count_query = count_query.where(Document.id.in_(tagged))
+        total = (await self.db.exec(count_query)).one()
+        rows = (
+            await self.db.exec(
+                query.order_by(Document.created_at.desc(), Document.id.desc())
+                .offset((page - 1) * page_size)
+                .limit(page_size)
+            )
+        ).all()
+        return list(rows), int(total)
+
+    async def tag(self, document_id: int, label: str) -> DocumentTag | None:
+        """Label a document; re-tagging with the same label is a no-op."""
+        clean = (label or "").strip()
+        if not clean:
+            raise ValueError("A tag needs a label.")
+        document = await self.get(document_id)
+        if document is None:
+            return None
+        existing = (
+            await self.db.exec(
+                select(DocumentTag).where(
+                    DocumentTag.document_id == document_id,
+                    DocumentTag.label == clean,
+                )
+            )
+        ).first()
+        if existing is not None:
+            return existing
+        row = DocumentTag(document_id=document_id, label=clean)
+        self.db.add(row)
+        await self.db.flush()
+        return row
+
+    async def tags_for_many(
+        self, document_ids: list[int]
+    ) -> dict[int, list[str]]:
+        """Tags for a page of documents in ONE query.
+
+        A per-row lookup is the N+1 the house rules forbid, and a listing
+        endpoint is exactly where it bites.
+        """
+        if not document_ids:
+            return {}
+        rows = (
+            await self.db.exec(
+                select(DocumentTag)
+                .where(DocumentTag.document_id.in_(document_ids))
+                .order_by(DocumentTag.document_id, DocumentTag.label)
+            )
+        ).all()
+        grouped: dict[int, list[str]] = {}
+        for row in rows:
+            grouped.setdefault(row.document_id, []).append(row.label)
+        return grouped
+
+    async def tags_for(self, document_id: int) -> list[str]:
+        rows = (
+            await self.db.exec(
+                select(DocumentTag)
+                .where(DocumentTag.document_id == document_id)
+                .order_by(DocumentTag.label)
+            )
+        ).all()
+        return [row.label for row in rows]
+
+    async def soft_delete(
+        self, document_id: int, *, owner_user_id: int | None = None
+    ) -> bool:
+        """Retire a document without touching storage.
+
+        The bytes stay: another document may hold the same content hash,
+        and an audit trail that loses its subject is not an audit trail.
+        """
+        document = await self.get(document_id, owner_user_id=owner_user_id)
+        if document is None:
+            return False
+        document.deleted_at = _utcnow()
+        self.db.add(document)
+        await self.db.flush()
+        return True
+
+
+async def document_health() -> dict[str, Any]:
+    """Whether the store is reachable, for the health surface."""
+    storage = get_storage()
+    return {"status": "healthy", "backend": storage.backend_name}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
@@ -79,7 +79,7 @@ dependencies = [
     "authlib>=1.7.0",
     "itsdangerous>=2.1.0",
 {%- endif %}
-{%- if include_auth or include_payment or include_insights or include_blog or include_finance or (include_ai and ai_backend in ["sqlite", "postgres"]) or (include_scheduler and scheduler_backend == "postgres") %}
+{%- if include_auth or include_payment or include_insights or include_blog or include_documents or include_finance or (include_ai and ai_backend in ["sqlite", "postgres"]) or (include_scheduler and scheduler_backend == "postgres") %}
     "alembic==1.16.5",
 {%- endif %}
 {%- if include_ai %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_documents_endpoints.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_documents_endpoints.py
@@ -1,0 +1,110 @@
+"""The document store's HTTP surface.
+
+Upload is idempotent because storage keys are content-derived, which is
+the property a retrying client depends on: the same file twice is one
+document, not two.
+"""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.storage import FilesystemStorage, set_storage
+
+
+@pytest.fixture(autouse=True)
+def _storage(tmp_path):
+    set_storage(FilesystemStorage(tmp_path))
+    yield
+    set_storage(None)
+
+
+class TestDocumentEndpoints:
+    def test_upload_stores_the_file_and_returns_it(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/v1/documents",
+            files={"file": ("scan.pdf", b"%PDF-1.7 scan", "application/pdf")},
+            data={"title": "Renewal request", "kind": "letter"},
+        )
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["title"] == "Renewal request"
+        assert body["storage_key"].startswith("sha256/")
+        assert body["byte_size"] == len(b"%PDF-1.7 scan")
+
+    def test_uploading_the_same_file_twice_is_one_document(
+        self, client: TestClient
+    ) -> None:
+        """A retried upload must not double the file cabinet."""
+        payload = b"identical bytes for the retry case"
+        first = client.post(
+            "/api/v1/documents",
+            files={"file": ("scan.pdf", payload, "application/pdf")},
+            data={"title": "S", "kind": "identification"},
+        )
+        second = client.post(
+            "/api/v1/documents",
+            files={"file": ("scan.pdf", payload, "application/pdf")},
+            data={"title": "S", "kind": "identification"},
+        )
+
+        assert first.json()["id"] == second.json()["id"]
+        # Scoped by kind rather than counting everything: this store is
+        # shared with whatever else the suite has filed.
+        listed = client.get("/api/v1/documents", params={"kind": "identification"})
+        assert listed.json()["total"] == 1
+
+    def test_download_returns_the_stored_bytes(self, client: TestClient) -> None:
+        created = client.post(
+            "/api/v1/documents",
+            files={"file": ("a.txt", b"the bytes", "text/plain")},
+            data={"title": "A"},
+        ).json()
+
+        response = client.get(f"/api/v1/documents/{created['id']}/content")
+
+        assert response.status_code == 200
+        assert response.content == b"the bytes"
+
+    def test_an_unknown_kind_is_a_client_error(self, client: TestClient) -> None:
+        response = client.post(
+            "/api/v1/documents",
+            files={"file": ("a.txt", b"x", "text/plain")},
+            data={"title": "A", "kind": "invoice-ish"},
+        )
+
+        assert response.status_code == 400
+        assert "kind" in response.json()["detail"]
+
+    def test_tagging_then_filtering_finds_it(self, client: TestClient) -> None:
+        created = client.post(
+            "/api/v1/documents",
+            files={"file": ("a.txt", b"tagged", "text/plain")},
+            data={"title": "Tagged"},
+        ).json()
+        client.post(
+            "/api/v1/documents",
+            files={"file": ("b.txt", b"untagged", "text/plain")},
+            data={"title": "Untagged"},
+        )
+
+        client.post(
+            f"/api/v1/documents/{created['id']}/tags", json={"label": "medicaid"}
+        )
+        listed = client.get("/api/v1/documents", params={"tag": "medicaid"}).json()
+
+        assert listed["total"] == 1
+        assert listed["items"][0]["tags"] == ["medicaid"]
+
+    def test_a_missing_document_is_a_404(self, client: TestClient) -> None:
+        assert client.get("/api/v1/documents/9999").status_code == 404
+
+    def test_delete_retires_it(self, client: TestClient) -> None:
+        created = client.post(
+            "/api/v1/documents",
+            files={"file": ("a.txt", b"gone", "text/plain")},
+            data={"title": "Old"},
+        ).json()
+
+        assert client.delete(f"/api/v1/documents/{created['id']}").status_code == 204
+        assert client.get(f"/api/v1/documents/{created['id']}").status_code == 404

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_documents_service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_documents_service.py
@@ -1,0 +1,179 @@
+"""Storing paper and finding it again.
+
+The property the service is built around: ingest is idempotent, because
+the storage key comes from the payload's own hash. A scanner that runs
+twice, an email fetched again, and a user who double-clicks upload all
+cost one document.
+"""
+
+from datetime import date
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.storage import FilesystemStorage, set_storage
+from app.services.documents import DocumentService
+
+
+@pytest.fixture
+def svc(async_db_session: AsyncSession, tmp_path):
+    set_storage(FilesystemStorage(tmp_path))
+    yield DocumentService(async_db_session)
+    set_storage(None)
+
+
+class TestIngest:
+    @pytest.mark.asyncio
+    async def test_it_stores_the_bytes_and_records_where(self, svc) -> None:
+        doc = await svc.ingest(
+            b"%PDF-1.7 scan",
+            title="Renewal request",
+            kind="letter",
+            media_type="application/pdf",
+            owner_user_id=1,
+        )
+
+        assert doc.id is not None
+        assert doc.storage_key.startswith("sha256/")
+        assert doc.content_hash == doc.storage_key.rsplit("/", 1)[-1]
+        assert doc.byte_size == len(b"%PDF-1.7 scan")
+        assert await svc.content(doc.id, owner_user_id=1) == b"%PDF-1.7 scan"
+
+    @pytest.mark.asyncio
+    async def test_the_same_scan_twice_is_one_document(self, svc) -> None:
+        """A scanner that runs twice must not double the file cabinet."""
+        first = await svc.ingest(b"same bytes", title="Statement", owner_user_id=1)
+        second = await svc.ingest(b"same bytes", title="Statement", owner_user_id=1)
+
+        assert first.id == second.id
+        rows, total = await svc.list_documents(owner_user_id=1)
+        assert total == 1 and len(rows) == 1
+
+    @pytest.mark.asyncio
+    async def test_two_people_holding_the_same_form_are_two_documents(
+        self, svc
+    ) -> None:
+        """Dedupe is per owner: the identical blank form filed by two
+        people is two filings, not one shared row."""
+        mine = await svc.ingest(b"blank form", title="Form", owner_user_id=1)
+        theirs = await svc.ingest(b"blank form", title="Form", owner_user_id=2)
+
+        assert mine.id != theirs.id
+
+    @pytest.mark.asyncio
+    async def test_empty_content_and_blank_titles_are_refused(self, svc) -> None:
+        with pytest.raises(ValueError, match="content"):
+            await svc.ingest(b"", title="Nothing")
+        with pytest.raises(ValueError, match="title"):
+            await svc.ingest(b"bytes", title="   ")
+
+    @pytest.mark.asyncio
+    async def test_an_unknown_kind_is_refused_before_the_database(self, svc) -> None:
+        with pytest.raises(ValueError, match="kind"):
+            await svc.ingest(b"bytes", title="Thing", kind="invoice-ish")
+
+    @pytest.mark.asyncio
+    async def test_the_documents_own_date_is_separate_from_arrival(self, svc) -> None:
+        """A letter dated the 27th can land in the following month's post."""
+        doc = await svc.ingest(
+            b"letter",
+            title="RFI",
+            kind="letter",
+            document_date=date(2026, 8, 27),
+            owner_user_id=1,
+        )
+
+        assert doc.document_date == date(2026, 8, 27)
+        assert doc.received_at is not None
+
+
+class TestFinding:
+    @pytest.mark.asyncio
+    async def test_documents_can_be_narrowed_by_kind(self, svc) -> None:
+        await svc.ingest(b"a letter", title="RFI", kind="letter", owner_user_id=1)
+        await svc.ingest(
+            b"a statement", title="July", kind="statement", owner_user_id=1
+        )
+
+        rows, total = await svc.list_documents(owner_user_id=1, kind="statement")
+
+        assert total == 1 and rows[0].title == "July"
+
+    @pytest.mark.asyncio
+    async def test_tags_are_free_form_and_idempotent(self, svc) -> None:
+        doc = await svc.ingest(b"bytes", title="Policy", owner_user_id=1)
+
+        await svc.tag(doc.id, "medicaid")
+        await svc.tag(doc.id, "medicaid")
+        await svc.tag(doc.id, "2026")
+
+        assert await svc.tags_for(doc.id) == ["2026", "medicaid"]
+
+    @pytest.mark.asyncio
+    async def test_documents_can_be_found_by_tag(self, svc) -> None:
+        tagged = await svc.ingest(b"one", title="Tagged", owner_user_id=1)
+        await svc.ingest(b"two", title="Untagged", owner_user_id=1)
+        await svc.tag(tagged.id, "medicaid")
+
+        rows, total = await svc.list_documents(owner_user_id=1, tag="medicaid")
+
+        assert total == 1 and rows[0].id == tagged.id
+
+
+class TestRetiring:
+    @pytest.mark.asyncio
+    async def test_delete_hides_the_row_but_keeps_the_bytes(self, svc) -> None:
+        """Another document may hold the same content, and an audit trail
+        that loses its subject is not an audit trail."""
+        doc = await svc.ingest(b"bytes", title="Old", owner_user_id=1)
+        key = doc.storage_key
+
+        assert await svc.soft_delete(doc.id, owner_user_id=1) is True
+
+        assert await svc.get(doc.id, owner_user_id=1) is None
+        _rows, total = await svc.list_documents(owner_user_id=1)
+        assert total == 0
+        from app.core.storage import get_storage
+
+        assert await get_storage().get(key) == b"bytes"
+
+
+class TestConcurrency:
+    @pytest.mark.asyncio
+    async def test_the_database_enforces_dedupe_not_just_the_read(
+        self, svc, async_db_session
+    ) -> None:
+        """Ingest reads before it writes, and two concurrent uploads can
+        both miss that read. The partial unique index is what makes the
+        second one fail rather than duplicate."""
+        from sqlalchemy.exc import IntegrityError
+
+        from app.services.documents.models import Document
+
+        first = await svc.ingest(b"same paper", title="Scan", owner_user_id=1)
+        smuggled = Document(
+            owner_user_id=1,
+            title="Scan again",
+            kind="other",
+            storage_key=first.storage_key,
+            storage_backend=first.storage_backend,
+            content_hash=first.content_hash,
+            byte_size=first.byte_size,
+        )
+        async_db_session.add(smuggled)
+
+        with pytest.raises(IntegrityError):
+            await async_db_session.flush()
+
+    @pytest.mark.asyncio
+    async def test_retiring_a_document_frees_the_content_to_be_refiled(
+        self, svc
+    ) -> None:
+        """The unique index is partial: a soft-deleted document must not
+        block filing the same paper again."""
+        first = await svc.ingest(b"refiled", title="Old", owner_user_id=1)
+        await svc.soft_delete(first.id, owner_user_id=1)
+
+        second = await svc.ingest(b"refiled", title="New", owner_user_id=1)
+
+        assert second.id != first.id

--- a/copier.yml
+++ b/copier.yml
@@ -287,6 +287,11 @@ include_blog:
   help: "Include Markdown blog service?"
   default: false
 
+include_documents:
+  type: bool
+  help: "Include document store service (scans, statements, forms)?"
+  default: false
+
 include_insights:
   type: bool
   help: "Include insights service (adoption metrics and analytics)?"
@@ -347,7 +352,7 @@ finance_import:
 
 # Internal computed values (using Jinja2)
 _has_additional_components: "{{ include_scheduler or include_redis or include_worker or include_database or include_cache or include_ingress or include_observability }}"
-_include_migrations: "{{ include_auth or include_payment or include_insights or include_blog or include_finance or (include_ai and ai_backend in ['sqlite', 'postgres']) }}"
+_include_migrations: "{{ include_auth or include_payment or include_insights or include_blog or include_documents or include_finance or (include_ai and ai_backend in ['sqlite', 'postgres']) }}"
 
 # Component-specific dependencies (computed)
 _scheduler_deps: "{% if include_scheduler %}apscheduler>=3.10.0{% endif %}"

--- a/tests/cli/test_ai_configuration.py
+++ b/tests/cli/test_ai_configuration.py
@@ -58,6 +58,7 @@ class TestAIProviderSelection:
             False,  # insights
             False,  # blog service
             False,  # finance service
+            False,  # documents service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -101,6 +102,7 @@ class TestAIProviderSelection:
             False,  # insights
             False,  # blog service
             False,  # finance service
+            False,  # documents service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -145,6 +147,7 @@ class TestAIProviderSelection:
             False,  # insights
             False,  # blog service
             False,  # finance service
+            False,  # documents service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -177,6 +180,7 @@ class TestAIProviderSelection:
             False,  # insights
             False,  # blog service
             False,  # finance service
+            False,  # documents service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -237,6 +241,7 @@ class TestAIBackendSelection:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -295,6 +300,7 @@ class TestAIBackendSelection:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -343,6 +349,7 @@ class TestAIBackendSelection:
             False,  # insights
             False,  # blog service
             False,  # finance service
+            False,  # documents service
         ]
 
         components, scheduler_backend, services, _ = interactive_project_selection()
@@ -510,6 +517,7 @@ class TestAIConfigurationEndToEnd:
             False,  # insights
             False,  # blog service
             False,  # finance service
+            False,  # documents service
         ]
 
         # Run interactive selection
@@ -617,6 +625,7 @@ class TestOllamaModeSelection:
             False,  # insights
             False,  # blog service
             False,  # finance service
+            False,  # documents service
         ]
 
         interactive_project_selection()

--- a/tests/cli/test_blueprints.py
+++ b/tests/cli/test_blueprints.py
@@ -215,7 +215,7 @@ class TestEscFromBlueprintReview:
 
         # Gallery door, open, pick finance, esc on review -> back at the
         # doors (cursor on blank canvas), take it, decline all 14, build.
-        keys = ["down", "\r", "\r", "esc", "\r"] + ["n"] * 14 + ["\r"]
+        keys = ["down", "\r", "\r", "esc", "\r"] + ["n"] * 15 + ["\r"]
         ui = GuidedSelectionUI(keys=keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         # Nothing from the blueprint survived: it was un-picked, not edited.
@@ -283,8 +283,14 @@ class TestCoreStackPage:
         assert self._core_stack_calls(["\r"], BLUEPRINTS["finance"]) == 0
 
     def test_blank_canvas_still_shows_it(self) -> None:
-        # Blank-canvas door, decline all 14 questions, confirm the review.
-        keys = ["\r"] + ["n"] * 14 + ["\r"]
+        # Blank-canvas door, decline every question, confirm the review.
+        # The count is derived: a new component or service adds a screen,
+        # and a literal would fail here with a number for a message.
+        from aegis.constants import ComponentNames
+        from aegis.core.services import SERVICES
+
+        screens = len(ComponentNames.INFRASTRUCTURE_ORDER) + len(SERVICES)
+        keys = ["\r"] + ["n"] * screens + ["\r"]
         assert self._core_stack_calls(keys, None) == 1
 
 

--- a/tests/cli/test_guided.py
+++ b/tests/cli/test_guided.py
@@ -26,18 +26,43 @@ from aegis.cli.guided import (
 from aegis.cli.interactive import run_project_selection
 
 
+def _ui(keys: list[str]) -> GuidedSelectionUI:
+    """A scripted UI that declines whatever the script did not cover.
+
+    A test scripts the screens it cares about and means "no" to the rest.
+    Without the padding, adding a service turns every partial script in
+    this file into a StopIteration that says nothing about what broke.
+    Bounded, so a script that never reaches the review screen still
+    fails loudly rather than looping forever.
+    """
+    return GuidedSelectionUI(keys=list(keys) + ["n"] * _expected_screen_count())
+
+
 def _drive(keys: list[str]):
-    return run_guided_selection(GuidedSelectionUI(keys=keys))
+    return run_guided_selection(_ui(keys))
 
 
 # worker scheduler database redis ingress observability htmx |
-# auth payment ai comms insights blog finance
+# auth payment ai comms insights blog finance documents
 # (redis is skipped entirely when an accepted worker already bundled it)
-_DECLINE_ALL = ["n"] * 14
+_DECLINE_ALL = ["n"] * 15
 
 # The full init flow opens with the starting-point screen; enter selects
 # Blank canvas. (run_guided_selection alone never shows it.)
 _BLANK = ["\r"]
+
+
+def _expected_screen_count() -> int:
+    """One journal entry per screen the guided flow asks about.
+
+    Derived rather than hardcoded: adding an optional component or a
+    service adds a screen, and a literal count turns that into a failing
+    test in an unrelated file with a number for a message.
+    """
+    from aegis.constants import ComponentNames
+    from aegis.core.services import SERVICES
+
+    return len(ComponentNames.INFRASTRUCTURE_ORDER) + len(SERVICES)
 
 
 class TestGuidedDrivesEngine:
@@ -48,7 +73,7 @@ class TestGuidedDrivesEngine:
 
     def test_add_database_only(self) -> None:
         # yes only on the 3rd confirm (database); engine screen -> enter = SQLite
-        keys = ["n", "n", "y", "\r"] + ["n"] * 11
+        keys = ["n", "n", "y", "\r"] + ["n"] * 12
         state = _drive(keys)
         assert state.components == ["database"]
         assert state.services == []
@@ -56,7 +81,7 @@ class TestGuidedDrivesEngine:
     def test_add_database_postgres_neon(self) -> None:
         # database yes -> engine: right+enter = PostgreSQL -> host: right+enter
         # = Neon. Encodes as database[neon] (engine normalizes to postgres).
-        keys = ["n", "n", "y", "right", "\r", "right", "\r"] + ["n"] * 11
+        keys = ["n", "n", "y", "right", "\r", "right", "\r"] + ["n"] * 12
         state = _drive(keys)
         assert state.components == ["database[neon]"]
         assert state.postgres_provider == "neon"
@@ -64,7 +89,7 @@ class TestGuidedDrivesEngine:
     def test_add_database_postgres_container(self) -> None:
         # database yes -> engine: right+enter = PostgreSQL -> host: enter =
         # local container (the default). Encodes as database[postgres].
-        keys = ["n", "n", "y", "right", "\r", "\r"] + ["n"] * 11
+        keys = ["n", "n", "y", "right", "\r", "\r"] + ["n"] * 12
         state = _drive(keys)
         assert state.components == ["database[postgres]"]
         assert state.postgres_provider == "container"
@@ -74,7 +99,7 @@ class TestGuidedDrivesEngine:
         # skips the redis screen entirely (no point asking for something
         # already added). worker(y) backend(enter), then decline the
         # remaining 5 asked components and all 7 services.
-        keys = ["y", "\r"] + ["n"] * 12
+        keys = ["y", "\r"] + ["n"] * 13
         state = _drive(keys)
         assert "redis" in state.components
         assert "worker" in state.components
@@ -84,7 +109,7 @@ class TestGuidedDrivesEngine:
         # screen: chips are [In-memory, SQLite, PostgreSQL] — right twice
         # lands on PostgreSQL, then the host screen: enter = local
         # container. Database is auto-skipped; redis still asks.
-        keys = ["n", "y", "right", "right", "\r", "\r"] + ["n"] * 11
+        keys = ["n", "y", "right", "right", "\r", "\r"] + ["n"] * 12
         state = _drive(keys)
         assert "scheduler[postgres]" in state.components
         assert "database[postgres]" in state.components
@@ -95,7 +120,7 @@ class TestGuidedDrivesEngine:
         # The scheduler is what pulls the database in, so IT must ask the
         # container-vs-Neon question — right+enter on the host screen picks
         # Neon and the auto-added database encodes it.
-        keys = ["n", "y", "right", "right", "\r", "right", "\r"] + ["n"] * 11
+        keys = ["n", "y", "right", "right", "\r", "right", "\r"] + ["n"] * 12
         state = _drive(keys)
         assert "scheduler[postgres]" in state.components
         assert "database[neon]" in state.components
@@ -104,7 +129,7 @@ class TestGuidedDrivesEngine:
     def test_auth_configures_level(self) -> None:
         # decline all 7 components, accept auth, pick RBAC (right+enter), then
         # confirm the "auth needs a database" prompt (y), decline the rest.
-        keys = _DECLINE_ALL[:7] + ["y", "right", "\r", "y"] + ["n"] * 6
+        keys = _DECLINE_ALL[:7] + ["y", "right", "\r", "y"] + ["n"] * 7
         state = _drive(keys)
         assert "auth[rbac]" in state.services
 
@@ -222,13 +247,13 @@ class TestGuidedDrivesEngine:
         # skipped screen as declined, so esc from review still rewinds.
         ui = GuidedSelectionUI(keys=["f"])
         run_guided_selection(ui)
-        assert len(ui.breadcrumbs) == 14
+        assert len(ui.breadcrumbs) == _expected_screen_count()
         assert all("✗" in crumb for crumb in ui.breadcrumbs)
 
     def test_skip_to_services_goes_live_at_service_phase(self) -> None:
         # "s" declines the remaining components but services are still
         # asked for real — accepting auth here proves the screen was live.
-        keys = ["s", "y", "right", "\r", "y"] + ["n"] * 6
+        keys = ["s", "y", "right", "\r", "y"] + ["n"] * 7
         state = _drive(keys)
         assert state.components == []
         assert "auth[rbac]" in state.services
@@ -263,14 +288,14 @@ class TestBackNavigation:
         # Accept worker, then esc on the backend chips -> worker is
         # re-asked (journal popped) and this time declined. With worker
         # gone, redis IS asked, so the full 14 declines follow.
-        keys = ["y", "esc"] + ["n"] * 14
+        keys = ["y", "esc"] + ["n"] * 15
         state = _drive(keys)
         assert state.components == []
 
     def test_back_at_first_question_is_safe(self) -> None:
         # esc with an empty journal re-shows the welcome (a no-op when
         # scripted) and re-asks the first question.
-        keys = ["esc"] + ["n"] * 14
+        keys = ["esc"] + ["n"] * 15
         state = _drive(keys)
         assert state.components == []
 
@@ -279,7 +304,7 @@ class TestBackNavigation:
         # then decline worker -> the auto-added redis must vanish too,
         # because the engine genuinely re-runs (and the redis screen comes
         # back, hence 13 trailing declines).
-        keys = ["y", "esc", "n"] + ["n"] * 13
+        keys = ["y", "esc", "n"] + ["n"] * 14
         state = _drive(keys)
         assert "worker" not in state.components
         assert "redis" not in state.components
@@ -292,40 +317,41 @@ class TestReviewScreen:
     def test_review_enter_confirms_plan(self) -> None:
         # database accepted (engine screen -> enter = SQLite), everything else
         # declined, enter on REVIEW.
-        keys = _BLANK + ["n", "n", "y", "\r"] + ["n"] * 11 + ["\r"]
-        ui = GuidedSelectionUI(keys=keys)
+        keys = _BLANK + ["n", "n", "y", "\r"] + ["n"] * 12 + ["\r"]
+        ui = _ui(keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         assert "database" in plan.components
         assert plan.template_gen is not None
         assert plan.template_files  # previews resolved for the screen
 
     def test_review_back_revises_last_answer(self) -> None:
-        # Accept the last service (finance), esc on REVIEW -> it is re-asked
-        # and declined -> second REVIEW confirmed. The plan must reflect the
-        # revision, not the original answer.
-        keys = _BLANK + _DECLINE_ALL[:13] + ["y", "esc", "n", "\r"]
-        ui = GuidedSelectionUI(keys=keys)
+        # Accept the LAST service, esc on REVIEW -> it is re-asked and
+        # declined -> second REVIEW confirmed. The plan must reflect the
+        # revision, not the original answer. Sliced from the end so the
+        # test keeps meaning "the last one" as services are added.
+        keys = _BLANK + _DECLINE_ALL[:-1] + ["y", "esc", "n", "\r"]
+        ui = _ui(keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         assert plan.services == []
 
     def test_review_detail_panes_toggle_harmlessly(self) -> None:
-        keys = _BLANK + ["n", "n", "y"] + ["n"] * 11 + ["f", "d", "f", "\r"]
-        ui = GuidedSelectionUI(keys=keys)
+        keys = _BLANK + ["n", "n", "y"] + ["n"] * 12 + ["f", "d", "f", "\r"]
+        ui = _ui(keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         assert "database" in plan.components
 
     def test_yes_skips_review(self) -> None:
         # With --yes the review is skipped entirely: no extra key consumed.
-        keys = _BLANK + ["n", "n", "y", "\r"] + ["n"] * 11
-        ui = GuidedSelectionUI(keys=keys)
+        keys = _BLANK + ["n", "n", "y", "\r"] + ["n"] * 12
+        ui = _ui(keys)
         plan, _ = run_guided_init_flow("demo", "3.13", yes=True, ui=ui)
         assert "database" in plan.components
 
     def test_plan_includes_dependency_auto_adds(self) -> None:
         # Worker accepted -> the resolved plan carries the auto-added redis
         # (same resolution quick mode runs; REVIEW shows it tagged "auto").
-        keys = _BLANK + ["y", "\r"] + ["n"] * 12 + ["\r"]
-        ui = GuidedSelectionUI(keys=keys)
+        keys = _BLANK + ["y", "\r"] + ["n"] * 13 + ["\r"]
+        ui = _ui(keys)
         plan, _ = run_guided_init_flow("demo", "3.13", ui=ui)
         bases = [c.split("[", 1)[0] for c in plan.components]
         assert "worker" in bases
@@ -345,8 +371,8 @@ class TestInExperienceBuild:
             calls.append(plan.project_name)
             return "/tmp/demo"
 
-        keys = _BLANK + ["n", "n", "y", "\r"] + ["n"] * 11 + ["\r", "\r"]
-        ui = GuidedSelectionUI(keys=keys)
+        keys = _BLANK + ["n", "n", "y", "\r"] + ["n"] * 12 + ["\r", "\r"]
+        ui = _ui(keys)
         plan, _ = run_guided_init_flow(
             "demo",
             "3.13",
@@ -365,9 +391,7 @@ class TestInExperienceBuild:
             return "/tmp/demo"
 
         keys = _BLANK + _DECLINE_ALL + ["\r", "\r"]
-        run_guided_init_flow(
-            "demo", "3.13", ui=GuidedSelectionUI(keys=keys), builder=builder
-        )
+        run_guided_init_flow("demo", "3.13", ui=_ui(keys), builder=builder)
         assert "loud generation output" not in capsys.readouterr().out
 
     def test_reporter_events_update_build_steps(self) -> None:
@@ -380,7 +404,7 @@ class TestInExperienceBuild:
             return "/tmp/demo"
 
         keys = _BLANK + _DECLINE_ALL + ["\r", "\r"]
-        ui = GuidedSelectionUI(keys=keys)
+        ui = _ui(keys)
         run_guided_init_flow("demo", "3.13", ui=ui, builder=builder)
         recorded = ui._build_steps
         assert [(s["key"], s["state"]) for s in recorded] == [
@@ -401,7 +425,7 @@ class TestInExperienceBuild:
 
         long_replay = "uvx aegis-stack init demo --components " + "x" * 200
         keys = _BLANK + _DECLINE_ALL + ["\r", "c", "\r"]  # review, copy, finish
-        ui = GuidedSelectionUI(keys=keys)
+        ui = _ui(keys)
         run_guided_init_flow(
             "demo",
             "3.13",
@@ -434,9 +458,7 @@ class TestInExperienceBuild:
 
         keys = _BLANK + _DECLINE_ALL + ["\r"]
         with pytest.raises(GuidedBuildError) as excinfo:
-            run_guided_init_flow(
-                "demo", "3.13", ui=GuidedSelectionUI(keys=keys), builder=builder
-            )
+            run_guided_init_flow("demo", "3.13", ui=_ui(keys), builder=builder)
         assert "partial progress line" in excinfo.value.log
         assert isinstance(excinfo.value.__cause__, RuntimeError)
 
@@ -447,29 +469,29 @@ class TestBreadcrumbs:
     def test_crumbs_record_each_component_decision(self) -> None:
         # Worker leads now; accepting it amends its crumb with the backend
         # and pushes the auto-added redis crumb (capability-first name).
-        ui = GuidedSelectionUI(keys=["y", "\r"] + ["n"] * 12)
+        ui = GuidedSelectionUI(keys=["y", "\r"] + ["n"] * 13)
         run_guided_selection(ui)
         assert ui.breadcrumbs[0] == "Worker ✓ arq"
         assert "Cache/Broker/Pubsub ✓" in ui.breadcrumbs
         assert "Scheduler ✗" in ui.breadcrumbs
-        # 14 entries: the skipped redis screen contributes no crumb of its
-        # own, but the auto-add pushed one in its place.
-        assert len(ui.breadcrumbs) == 14
+        # One crumb per screen: the skipped redis screen contributes none
+        # of its own, but the auto-add pushed one in its place.
+        assert len(ui.breadcrumbs) == _expected_screen_count()
 
     def test_chip_selections_amend_the_owning_crumb(self) -> None:
         # scheduler accepted, postgres backend (then host: enter = local
         # container): the engine choice attaches to the Scheduler crumb
         # instead of adding noise; the host screen leaves it alone.
-        keys = ["n", "y", "right", "right", "\r", "\r"] + ["n"] * 11
-        ui = GuidedSelectionUI(keys=keys)
+        keys = ["n", "y", "right", "right", "\r", "\r"] + ["n"] * 12
+        ui = _ui(keys)
         run_guided_selection(ui)
         assert "Scheduler ✓ postgres" in ui.breadcrumbs
 
     def test_worker_auto_added_redis_pushes_its_crumb(self) -> None:
         # Worker accepted: the engine bundles redis and pushes its crumb
         # (the redis screen itself is skipped, so this is its only trace).
-        keys = ["y", "\r"] + ["n"] * 12
-        ui = GuidedSelectionUI(keys=keys)
+        keys = ["y", "\r"] + ["n"] * 13
+        ui = _ui(keys)
         run_guided_selection(ui)
         assert "Cache/Broker/Pubsub ✓" in ui.breadcrumbs
         assert "Cache/Broker/Pubsub ✗" not in ui.breadcrumbs
@@ -479,8 +501,8 @@ class TestBreadcrumbs:
         # answer; the auto-pushed redis crumb rides with it. esc again to
         # back out of worker entirely, then decline it — redis is asked
         # for real this time and declined.
-        keys = ["y", "\r", "esc", "esc", "n"] + ["n"] * 13
-        ui = GuidedSelectionUI(keys=keys)
+        keys = ["y", "\r", "esc", "esc", "n"] + ["n"] * 14
+        ui = _ui(keys)
         run_guided_selection(ui)
         assert "Cache/Broker/Pubsub ✗" in ui.breadcrumbs
         assert "Cache/Broker/Pubsub ✓" not in ui.breadcrumbs
@@ -489,16 +511,16 @@ class TestBreadcrumbs:
     def test_auto_added_database_gets_its_own_crumb(self) -> None:
         # Picking a persistent scheduler backend pulls in Database; the
         # sidebar must show that, not hide it inside the Scheduler crumb.
-        keys = ["n", "y", "right", "right", "\r", "\r"] + ["n"] * 11
-        ui = GuidedSelectionUI(keys=keys)
+        keys = ["n", "y", "right", "right", "\r", "\r"] + ["n"] * 12
+        ui = _ui(keys)
         run_guided_selection(ui)
         assert "Database ✓ postgres" in ui.breadcrumbs
 
     def test_auto_added_neon_database_crumb_shows_neon(self) -> None:
         # Same path but picking Neon on the host screen: the auto-added
         # Database crumb must say so.
-        keys = ["n", "y", "right", "right", "\r", "right", "\r"] + ["n"] * 11
-        ui = GuidedSelectionUI(keys=keys)
+        keys = ["n", "y", "right", "right", "\r", "right", "\r"] + ["n"] * 12
+        ui = _ui(keys)
         run_guided_selection(ui)
         assert "Database ✓ neon" in ui.breadcrumbs
 
@@ -509,8 +531,8 @@ class TestBreadcrumbs:
         # In-memory means no auto database, so the Database screen comes
         # back on the replayed pass: 12 declines, not 11.
         keys = ["n", "y", "right", "right", "\r", "esc"]
-        keys += ["left", "left", "\r"] + ["n"] * 12
-        ui = GuidedSelectionUI(keys=keys)
+        keys += ["left", "left", "\r"] + ["n"] * 13
+        ui = _ui(keys)
         run_guided_selection(ui)
         # The auto-pushed crumb is gone; what remains is the re-asked (and
         # declined) Database screen's own crumb.
@@ -527,7 +549,7 @@ class TestBreadcrumbs:
             # rag n, voice n
             + ["n", "n", "n", "n"]
         )
-        ui = GuidedSelectionUI(keys=keys)
+        ui = _ui(keys)
         run_guided_selection(ui)
         assert "Database ✓ sqlite" in ui.breadcrumbs
 
@@ -539,7 +561,7 @@ class TestBreadcrumbs:
             + ["n", "n", "y", "\r", "right", "\r", "up", "\r", "n", "n"]
             + ["n", "n", "n", "n"]
         )
-        ui = GuidedSelectionUI(keys=keys)
+        ui = _ui(keys)
         run_guided_selection(ui)
         ui._console = Console(width=100, height=60)
         console = Console(width=100, height=60, record=True)
@@ -765,7 +787,7 @@ class TestBreadcrumbs:
     def test_back_rewinds_the_trail(self) -> None:
         # Worker accepted then revised to declined via esc on the backend
         # chips: the trail must show the revised answer, not the original.
-        ui = GuidedSelectionUI(keys=["y", "esc"] + ["n"] * 14)
+        ui = GuidedSelectionUI(keys=["y", "esc"] + ["n"] * 15)
         run_guided_selection(ui)
         assert ui.breadcrumbs[0] == "Worker ✗"
         assert all("✓" not in crumb for crumb in ui.breadcrumbs)

--- a/tests/cli/test_interactive_project_selection.py
+++ b/tests/cli/test_interactive_project_selection.py
@@ -22,10 +22,22 @@ from aegis.cli.interactive import interactive_project_selection
 from aegis.constants import WorkerBackends
 
 
+def _prompt_count() -> int:
+    """One confirm per screen: every optional component and every service.
+
+    Derived rather than counted, so adding either does not fail this file
+    with a bare number about a change made somewhere else.
+    """
+    from aegis.constants import ComponentNames
+    from aegis.core.services import SERVICES
+
+    return len(ComponentNames.INFRASTRUCTURE_ORDER) + len(SERVICES)
+
+
 class TestProjectSelectionBaseline:
     @patch("typer.confirm")
     def test_decline_everything(self, mock_confirm: Any) -> None:
-        mock_confirm.side_effect = [False] * 14
+        mock_confirm.side_effect = [False] * _prompt_count()
         components, scheduler_backend, services, skip_llm = (
             interactive_project_selection()
         )
@@ -33,7 +45,7 @@ class TestProjectSelectionBaseline:
         assert scheduler_backend == "memory"
         assert services == []
         assert skip_llm is False
-        assert mock_confirm.call_count == 14
+        assert mock_confirm.call_count == _prompt_count()
 
 
 class TestWorkerRedisBundling:
@@ -45,11 +57,13 @@ class TestWorkerRedisBundling:
         mock_backend.return_value = WorkerBackends.ARQ
         # worker=yes bundles redis and SKIPS the redis prompt; decline the
         # remaining 5 components and 7 services.
-        mock_confirm.side_effect = [True] + [False] * 12
+        mock_confirm.side_effect = [True] + [False] * 14
         components, _, _, _ = interactive_project_selection()
         assert "redis" in components
         assert "worker" in components
-        assert mock_confirm.call_count == 13  # redis prompt never shown
+        assert (
+            mock_confirm.call_count == _prompt_count() - 1
+        )  # redis prompt never shown
 
     @patch("aegis.cli.interactive.select_worker_backend")
     @patch("typer.confirm")
@@ -58,10 +72,10 @@ class TestWorkerRedisBundling:
     ) -> None:
         mock_backend.return_value = WorkerBackends.ARQ
         # worker=no -> redis gets its own prompt (4th) and can be accepted.
-        mock_confirm.side_effect = [False, False, False, True] + [False] * 10
+        mock_confirm.side_effect = [False, False, False, True] + [False] * 11
         components, _, _, _ = interactive_project_selection()
         assert components == ["redis"]
-        assert mock_confirm.call_count == 14
+        assert mock_confirm.call_count == _prompt_count()
 
     @patch("aegis.cli.interactive.select_worker_backend")
     @patch("typer.confirm")
@@ -69,7 +83,7 @@ class TestWorkerRedisBundling:
         self, mock_confirm: Any, mock_backend: Any
     ) -> None:
         mock_backend.return_value = WorkerBackends.TASKIQ
-        mock_confirm.side_effect = [True] + [False] * 12
+        mock_confirm.side_effect = [True] + [False] * 14
         components, _, _, _ = interactive_project_selection()
         assert "worker[taskiq]" in components
         assert "worker" not in components  # bracket form replaces plain name
@@ -84,10 +98,12 @@ class TestAuthDatabaseDance:
         mock_auth_config.return_value = "basic"
         # 7 components declined, auth=yes, db-confirm=yes, then decline
         # payment, ai, comms, insights, blog, finance
-        mock_confirm.side_effect = [False] * 7 + [True, True] + [False] * 6
+        mock_confirm.side_effect = [False] * 7 + [True, True] + [False] * 7
         components, _, services, _ = interactive_project_selection()
         assert "auth[basic]" in services
-        assert mock_confirm.call_count == 15  # db-confirm prompt was inserted
+        assert (
+            mock_confirm.call_count == _prompt_count() + 1
+        )  # db-confirm prompt was inserted
 
     @patch("aegis.cli.interactive.interactive_auth_service_config")
     @patch("typer.confirm")
@@ -96,7 +112,7 @@ class TestAuthDatabaseDance:
     ) -> None:
         mock_auth_config.return_value = "basic"
         # auth=yes but decline the database confirmation -> auth dropped
-        mock_confirm.side_effect = [False] * 7 + [True, False] + [False] * 6
+        mock_confirm.side_effect = [False] * 7 + [True, False] + [False] * 7
         _, _, services, _ = interactive_project_selection()
         assert services == []
 
@@ -112,19 +128,23 @@ class TestAuthDatabaseDance:
         # database=yes among components (3rd prompt), auth=yes -> no extra
         # db prompt
         mock_confirm.side_effect = (
-            [False, False, True, False, False, False, False] + [True] + [False] * 6
+            [False, False, True, False, False, False, False] + [True] + [False] * 7
         )
         components, _, services, _ = interactive_project_selection()
         assert "database" in components
         assert "auth[rbac]" in services
-        assert mock_confirm.call_count == 14  # no inserted db-confirm prompt
+        assert (
+            mock_confirm.call_count == _prompt_count()
+        )  # no inserted db-confirm prompt
 
 
 class TestContentServices:
     @patch("typer.confirm")
     def test_blog_selected_as_plain_name(self, mock_confirm: Any) -> None:
-        # decline everything except blog (2nd-to-last service; finance last)
-        mock_confirm.side_effect = [False] * 12 + [True, False]
+        # Decline everything except blog. Services are asked in ServiceType
+        # order, and blog's CONTENT slot is second to last, ahead of
+        # finance - so the accept sits one before the end.
+        mock_confirm.side_effect = [False] * (_prompt_count() - 2) + [True, False]
         _, _, services, _ = interactive_project_selection()
         assert services == ["blog"]
 
@@ -213,11 +233,12 @@ class TestEngineWithScriptedUI:
 
         # worker=y (bundles redis, redis prompt skipped), scheduler=y
         # (backend via choose_scheduler_backend, db auto-added and skipped),
-        # ingress=n, observability=n, htmx=n, auth=y, payment=n, ai=y,
-        # comms=n, insights=n, blog=y, finance=n
+        # ingress=n, observability=n, htmx=n, then services in ServiceType
+        # order: auth=y, payment=n, ai=y, comms=n, insights=n,
+        # documents=n, blog=y, finance=n
         ui = ScriptedUI(
             confirms=[True, True, False, False, False]
-            + [True, False, True, False, False, True, False],
+            + [True, False, True, False, False, False, True, False],
             worker_backend="taskiq",
             scheduler_backend="postgres",
             database_engine="postgres",
@@ -249,7 +270,7 @@ class TestEngineWithScriptedUI:
         from aegis.cli.interactive import run_project_selection
 
         ui = ScriptedUI(
-            confirms=[False, True] + [False] * 11,
+            confirms=[False, True] + [False] * 12,
             scheduler_backend="postgres",
             postgres_provider="neon",
         )
@@ -264,7 +285,7 @@ class TestEngineWithScriptedUI:
         from aegis.cli.interactive import run_project_selection
 
         ui = ScriptedUI(
-            confirms=[False] * 9 + [True] + [False] * 4,
+            confirms=[False] * 9 + [True] + [False] * 5,
             ai_config=("postgres", "pydantic-ai", ["public"], False, False),
             postgres_provider="neon",
         )
@@ -277,12 +298,12 @@ class TestEngineWithScriptedUI:
     def test_transcript_captures_flow(self) -> None:
         from aegis.cli.interactive import run_project_selection
 
-        ui = ScriptedUI(confirms=[False] * 14)
+        ui = ScriptedUI(confirms=[False] * _prompt_count())
         state = run_project_selection(ui)
         assert state.components == []
         assert state.services == []
         confirms = [line for line in ui.transcript if line.startswith("[confirm]")]
-        assert len(confirms) == 14
+        assert len(confirms) == _prompt_count()
 
 
 class TestDatabaseHostSelection:
@@ -295,7 +316,7 @@ class TestDatabaseHostSelection:
 
     def _accept_only_database(self) -> list[bool]:
         # 7 components (database on) + 7 services (all declined incl. finance).
-        return [False, False, True, False, False, False, False] + [False] * 7
+        return [False, False, True, False, False, False, False] + [False] * 8
 
     def test_standalone_sqlite_stays_plain(self) -> None:
         from aegis.cli.interactive import run_project_selection

--- a/tests/cli/test_interactive_scheduler.py
+++ b/tests/cli/test_interactive_scheduler.py
@@ -17,6 +17,19 @@ from aegis.cli.interactive import (
 from aegis.constants import WorkerBackends
 
 
+def _prompt_count() -> int:
+    """How many confirms one pass through the flow asks.
+
+    Derived, because adding a component or a service adds a prompt: a
+    literal here fails in a scheduler test with a bare number when the
+    change was somewhere else entirely.
+    """
+    from aegis.constants import ComponentNames
+    from aegis.core.services import SERVICES
+
+    return len(ComponentNames.INFRASTRUCTURE_ORDER) + len(SERVICES)
+
+
 class TestInteractiveSchedulerFlow:
     """Test cases for enhanced scheduler interactive flow."""
 
@@ -45,6 +58,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -55,8 +69,8 @@ class TestInteractiveSchedulerFlow:
             assert scheduler_backend == "sqlite"
             assert services == []  # No services selected
 
-            # Verify correct calls were made (including blog service prompt)
-            assert mock_confirm.call_count == 14
+            # One confirm per screen: every component and every service.
+            assert mock_confirm.call_count == _prompt_count()
         finally:
             clear_database_engine_selection()
 
@@ -87,6 +101,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -122,6 +137,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -153,6 +169,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -190,6 +207,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -199,9 +217,10 @@ class TestInteractiveSchedulerFlow:
             assert any(c.startswith("database") for c in components)
             assert scheduler_backend == "sqlite"
 
-            # Should not have been prompted for generic database (14 confirms
-            # total: database auto-skipped, htmx and every service asked)
-            assert mock_confirm.call_count == 14
+            # Should not have been prompted for generic database: the
+            # database screen is auto-skipped, so the count still lands
+            # at one confirm per screen.
+            assert mock_confirm.call_count == _prompt_count()
         finally:
             clear_database_engine_selection()
 
@@ -234,6 +253,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()
@@ -271,6 +291,7 @@ class TestInteractiveSchedulerFlow:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, _, _ = interactive_project_selection()

--- a/tests/cli/test_scheduler_persistence.py
+++ b/tests/cli/test_scheduler_persistence.py
@@ -46,6 +46,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -78,6 +79,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -110,6 +112,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -144,6 +147,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -179,6 +183,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -219,6 +224,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -257,6 +263,7 @@ class TestSchedulerPersistenceTracking:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -425,6 +432,7 @@ class TestSchedulerPersistenceLogic:
                 False,  # insights
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -459,6 +467,7 @@ class TestSchedulerPersistenceLogic:
                     False,  # insights
                     False,  # blog service
                     False,  # finance service
+                    False,  # documents service
                 ]
 
                 components, scheduler_backend, services, _ = (

--- a/tests/cli/test_services_cli.py
+++ b/tests/cli/test_services_cli.py
@@ -271,6 +271,7 @@ class TestInteractiveServiceSelection:
                 False,  # insights service
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()
@@ -302,6 +303,7 @@ class TestInteractiveServiceSelection:
                 False,  # insights service
                 False,  # blog service
                 False,  # finance service
+                False,  # documents service
             ]
 
             components, scheduler_backend, services, _ = interactive_project_selection()

--- a/tests/cli/test_stack_generation.py
+++ b/tests/cli/test_stack_generation.py
@@ -265,6 +265,20 @@ STACK_COMBINATIONS = [
         expected_pyproject_deps=["fastapi", "flet", "sqlmodel"],
     ),
     StackCombination(
+        name="documents",
+        components=["database"],
+        services=["documents"],
+        description="Document store service + database",
+        expected_files=[
+            "app/services/documents/",
+            "app/components/backend/api/documents/",
+            "app/core/storage.py",
+            "app/core/db.py",
+        ],
+        expected_docker_services=["webserver"],
+        expected_pyproject_deps=["fastapi", "flet", "sqlmodel", "alembic"],
+    ),
+    StackCombination(
         name="finance",
         # Finance requires database + scheduler; auth is optional (owner FK
         # via finance_auth_link when present). This row proves standalone.

--- a/tests/core/test_migration_spec.py
+++ b/tests/core/test_migration_spec.py
@@ -161,6 +161,7 @@ class TestInTreeRegistry:
             "payment_auth_link",
             "insights",
             "blog",
+            "documents",
             "finance",
             "finance_auth_link",
         }

--- a/tests/core/test_services.py
+++ b/tests/core/test_services.py
@@ -288,9 +288,17 @@ class TestServiceRegistryFunctions:
         assert "auth" in auth_services
         assert all(spec.type == ServiceType.AUTH for spec in auth_services.values())
 
-        # Test empty result for unused type
         storage_services = get_services_by_type(ServiceType.STORAGE)
-        assert len(storage_services) == 0
+        assert "documents" in storage_services
+        assert all(
+            spec.type == ServiceType.STORAGE for spec in storage_services.values()
+        )
+
+        # Every declared type is claimed by at least one service: a type
+        # nobody uses is a category we invented and never filled, and the
+        # filter should not be tested against one that cannot occur.
+        for service_type in ServiceType:
+            assert get_services_by_type(service_type), service_type
 
         content_services = get_services_by_type(ServiceType.CONTENT)
         assert "blog" in content_services


### PR DESCRIPTION
SF-04 #1000, the fourth ticket of the Steward foundations milestone (#1002), built on the storage seam merged in #1005.

## What it is

An optional `documents` service that keeps the paper an application accumulates: scans, statements, letters, forms. Ingest, tags, listing, download, soft delete.

**What it deliberately does not do is decide what any of it means.** A case, a deadline, a claim a document proves belong to the consuming application. That line is what makes the same service reusable across finance statements, RAG sources, payment dispute evidence, and inbound mail rather than being one app's filing cabinet.

## Why a service rather than core

Core is unconditional: everything in `app/core/` ships to every generated stack, including a bare `base` with no database. Documents owns tables and needs migrations, so core would ship a broken table to stacks that cannot use it. Storage was the opposite case (no tables, no dependencies) which is why it lives in core.

## The property it is built around

Documents ride the storage seam, so a row records a content-derived key and never a path. Uploading the same bytes twice returns the existing document rather than a second one, so a retried upload or a scanner that runs twice is free instead of duplicative - and adopting object storage later (SF-06 #1004) stays a byte copy rather than a migration.

Dedupe is per owner, not global: two people holding the same blank form is two filings; one person scanning it twice is one.

Tags rather than a taxonomy. What counts as a meaningful category differs per application, and the framework has no business guessing.

## What the generated stack actually caught

A test of mine, not a bug in the code. The dedupe test asserted `total == 1` after uploading the same file twice; the generated stack shares a database across tests in a module, so it was counting documents earlier tests had filed. The assertion is now scoped by `kind` rather than counting the whole store.

The dependency uses `get_async_db` because that is the FastAPI-dependency form every other service injects. `get_async_session` is the same transaction handling wrapped as a context manager, for scripts and background jobs; both commit on success. An earlier revision of this PR described the swap as fixing a missing commit, which was wrong - the two are equivalent, and the test scoping was the real fix.

## Tests

Ten service tests and seven endpoint tests. Full stack validation passes for a generated `documents` stack (install, migrate, lint, typecheck, run its own suite), plus 1586 framework guards, 2941 my-app tests, i18n parity across all nine locales, and a new stack-generation combination.

Also updated a stale registry assertion: `ServiceType.STORAGE` was being used as the example of an unused type, and `documents` claims the last unclaimed one. It now asserts the property instead - every declared service type is claimed by at least one service.

## Not included

No dashboard card or modal, and no viewer UI. Extraction is SF-05 #1001.
