### PR TITLE
Give documents a lifecycle: supersession, protection, channel

### DIFF
--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -1522,14 +1522,28 @@ DOCUMENTS_MIGRATION = ServiceMigrationSpec(
                 ColumnSpec(
                     "source", "sa.String(32)", nullable=False, default="'upload'"
                 ),
+                # How the paper reached you, as opposed to ``source``, which
+                # is the mechanism that stored the bytes.
+                ColumnSpec("channel", "sa.String(32)", nullable=True),
+                # A newer version points at the one it replaces; the head of
+                # the chain is the copy to cite.
+                ColumnSpec("supersedes_id", "sa.Integer()", nullable=True),
+                # One more gate on delete, never auto-purged.
+                ColumnSpec(
+                    "protected", "sa.Boolean()", nullable=False, default="False"
+                ),
                 ColumnSpec("note", "sa.String()", nullable=True),
                 ColumnSpec("meta_data", "sa.JSON()", nullable=False, default="{}"),
                 ColumnSpec("created_at", "sa.DateTime()", nullable=False),
                 ColumnSpec("updated_at", "sa.DateTime()", nullable=True),
                 ColumnSpec("deleted_at", "sa.DateTime()", nullable=True),
             ],
+            foreign_keys=[
+                ForeignKeySpec(["supersedes_id"], "document", ["id"]),
+            ],
             indexes=[
                 IndexSpec("ix_document_owner", ["owner_user_id"]),
+                IndexSpec("ix_document_supersedes", ["supersedes_id"]),
                 # The dedupe lookup: same bytes, same owner, same row.
                 # The dedupe rule, enforced rather than merely checked:
                 # ingest reads before it writes, and two concurrent

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
@@ -24,7 +24,7 @@ from pydantic import BaseModel, Field
 
 from app.services.documents.deps import get_document_service, get_owner_user_id
 from app.services.documents.models import Document
-from app.services.documents.service import DocumentService
+from app.services.documents.service import DocumentService, ProtectedDocumentError
 
 router = APIRouter(prefix="/documents", tags=["documents"])
 
@@ -58,6 +58,9 @@ class DocumentResponse(BaseModel):
     source: str
     storage_key: str
     storage_backend: str
+    channel: str | None
+    supersedes_id: int | None
+    protected: bool
     note: str | None
     tags: list[str] = Field(default_factory=list)
 
@@ -75,6 +78,9 @@ class DocumentResponse(BaseModel):
             source=row.source,
             storage_key=row.storage_key,
             storage_backend=row.storage_backend,
+            channel=row.channel,
+            supersedes_id=row.supersedes_id,
+            protected=row.protected,
             note=row.note,
             tags=tags or [],
         )
@@ -103,6 +109,9 @@ class DocumentUpdate(BaseModel):
     kind: str | None = None
     document_date: date | None = None
     note: str | None = None
+    channel: str | None = None
+    supersedes_id: int | None = None
+    protected: bool | None = None
 
 
 @router.post("", response_model=DocumentResponse, status_code=status.HTTP_201_CREATED)
@@ -112,6 +121,7 @@ async def upload_document(
     title: str | None = Form(None),
     kind: str = Form("other"),
     note: str | None = Form(None),
+    channel: str | None = Form(None),
     service: DocumentService = Depends(get_document_service),
     owner_user_id: int | None = Depends(get_owner_user_id),
 ) -> DocumentResponse:
@@ -136,6 +146,8 @@ async def upload_document(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from None
+    if created and channel:
+        await service.update(document.id or 0, {"channel": channel})
     if not created:
         response.status_code = status.HTTP_200_OK
     return DocumentResponse.from_row(document)
@@ -145,6 +157,8 @@ async def upload_document(
 async def list_documents(
     kind: str | None = None,
     tag: str | None = None,
+    channel: str | None = None,
+    include_superseded: bool = False,
     page: int = 1,
     page_size: int = 50,
     service: DocumentService = Depends(get_document_service),
@@ -153,6 +167,8 @@ async def list_documents(
     rows, total = await service.list_documents(
         kind=kind,
         tag=tag,
+        channel=channel,
+        include_superseded=include_superseded,
         page=page,
         page_size=page_size,
         owner_user_id=owner_user_id,
@@ -273,11 +289,21 @@ async def untag_document(
 @router.delete("/{document_id}", status_code=status.HTTP_204_NO_CONTENT)
 async def delete_document(
     document_id: int,
+    confirm: str | None = None,
     service: DocumentService = Depends(get_document_service),
     owner_user_id: int | None = Depends(get_owner_user_id),
 ) -> Response:
     """Retire a document. The bytes stay: another document may hold the
-    same content, and the audit trail should not lose its subject."""
-    if not await service.soft_delete(document_id, owner_user_id=owner_user_id):
+    same content, and the audit trail should not lose its subject. A
+    protected document needs ``?confirm=<its exact title>``."""
+    try:
+        retired = await service.soft_delete(
+            document_id, owner_user_id=owner_user_id, confirm=confirm
+        )
+    except ProtectedDocumentError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT, detail=str(exc)
+        ) from None
+    if not retired:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
     return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
@@ -140,14 +140,13 @@ async def upload_document(
             media_type=file.content_type,
             source="upload",
             note=note,
+            channel=channel,
             owner_user_id=owner_user_id,
         )
     except ValueError as exc:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail=str(exc)
         ) from None
-    if created and channel:
-        await service.update(document.id or 0, {"channel": channel})
     if not created:
         response.status_code = status.HTTP_200_OK
     return DocumentResponse.from_row(document)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_detail_pane.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_detail_pane.py
@@ -19,8 +19,10 @@ from app.components.frontend.controls import (
     FormTextField,
     H3Text,
     SecondaryText,
+    ThemedSwitch,
 )
 from app.components.frontend.controls.buttons import PulseButton
+from app.components.frontend.controls.dialog import StyledAlertDialog
 from app.components.frontend.controls.form_fields import FormDateField
 from app.components.frontend.controls.snack_bar import ErrorSnackBar, SuccessSnackBar
 from app.components.frontend.theme import AegisTheme as Theme
@@ -32,6 +34,19 @@ from .modal_sections import EmptyStatePlaceholder
 
 API = "/api/v1/documents"
 KIND_OPTIONS = [(kind, kind.title()) for kind in DOCUMENT_KINDS]
+# How paper tends to arrive. Free text on the row; these are the offers.
+CHANNELS = ("mail", "download", "scan", "email", "upload")
+
+
+def replaces_options(
+    docs: list[dict[str, Any]], *, current_id: int | None
+) -> list[tuple[str, str]]:
+    """Dropdown options for "this replaces": nothing, or any other document."""
+    return [("", "Nothing")] + [
+        (str(doc["id"]), str(doc.get("title") or "Untitled"))
+        for doc in docs
+        if doc.get("id") != current_id
+    ]
 
 
 def _facts(doc: dict[str, Any]) -> str:
@@ -52,6 +67,7 @@ class DocumentDetailPane(ft.Container):
         self.page = page
         self._on_change = on_change
         self._doc: dict[str, Any] | None = None
+        self._others: list[dict[str, Any]] = []
         self.width = 380
         self.content = EmptyStatePlaceholder("Select a document")
 
@@ -66,8 +82,12 @@ class DocumentDetailPane(ft.Container):
         if self.page:
             self.update()
 
-    def show(self, doc: dict[str, Any]) -> None:
+    def show(
+        self, doc: dict[str, Any], others: list[dict[str, Any]] | None = None
+    ) -> None:
         self._doc = doc
+        if others is not None:
+            self._others = others
         self._title = FormTextField(label="Title", value=str(doc.get("title") or ""))
         self._kind = FormDropdown(
             label="Kind", value=str(doc.get("kind") or "other"), options=KIND_OPTIONS
@@ -82,6 +102,17 @@ class DocumentDetailPane(ft.Container):
             min_lines=2,
             max_lines=4,
         )
+        self._channel = FormDropdown(
+            label="Received via",
+            value=str(doc.get("channel") or ""),
+            options=[("", "Unknown"), *[(c, c.title()) for c in CHANNELS]],
+        )
+        self._replaces = FormDropdown(
+            label="Replaces",
+            value=str(doc.get("supersedes_id") or ""),
+            options=replaces_options(self._others, current_id=doc.get("id")),
+        )
+        self._protected = ThemedSwitch(value=bool(doc.get("protected")))
         self._tag_input = FormTextField(
             label="Add tag", hint="Enter to add", on_submit=self._add_tag
         )
@@ -92,6 +123,18 @@ class DocumentDetailPane(ft.Container):
                 self._title,
                 self._kind,
                 self._date,
+                self._channel,
+                self._replaces,
+                ft.Row(
+                    [
+                        SecondaryText(
+                            "Protected: delete asks for the title, never auto-purged",
+                            size=Theme.Typography.BODY_SMALL,
+                        ),
+                        self._protected,
+                    ],
+                    alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                ),
                 self._note,
                 ft.Row(self._tag_chips(), wrap=True, spacing=Theme.Spacing.XS),
                 ft.Row(
@@ -163,6 +206,11 @@ class DocumentDetailPane(ft.Container):
             "kind": self._kind.value,
             "document_date": self._date.value or None,
             "note": self._note.value or None,
+            "channel": self._channel.value or None,
+            "supersedes_id": int(self._replaces.value)
+            if self._replaces.value
+            else None,
+            "protected": bool(self._protected.value),
         }
         code, body = await self._api().request_with_status(
             "PATCH", f"{API}/{self._doc['id']}", json=payload
@@ -206,6 +254,9 @@ class DocumentDetailPane(ft.Container):
         if self._doc is None:
             return
         title = str(self._doc.get("title") or "this document")
+        if self._doc.get("protected"):
+            self._confirm_protected_delete(title)
+            return
 
         async def _do_delete() -> None:
             if self._doc is None:
@@ -224,3 +275,51 @@ class DocumentDetailPane(ft.Container):
             destructive=True,
             on_confirm=_do_delete,
         ).show()
+
+    def _confirm_protected_delete(self, title: str) -> None:
+        """One more gate: the title, typed back, is the confirmation the
+        API requires too."""
+        typed = FormTextField(label="Title", hint=title)
+        dialog: StyledAlertDialog | None = None
+
+        async def _do_delete() -> None:
+            if self._doc is None:
+                return
+            code, body = await self._api().request_with_status(
+                "DELETE", f"{API}/{self._doc['id']}", params={"confirm": typed.value}
+            )
+            if code != 204:
+                detail = body.get("detail") if isinstance(body, dict) else None
+                ErrorSnackBar(str(detail or "The title did not match.")).launch(
+                    self.page
+                )
+                return
+            if dialog is not None:
+                dialog.open = False
+            self.clear()
+            await self._on_change()
+
+        dialog = StyledAlertDialog(
+            title="Delete protected document?",
+            body=ft.Column(
+                [
+                    SecondaryText(
+                        f'Type "{title}" to retire it. The stored file is kept.',
+                        size=Theme.Typography.BODY_SMALL,
+                    ),
+                    typed,
+                ],
+                spacing=Theme.Spacing.SM,
+                tight=True,
+            ),
+            actions=[
+                PulseButton(
+                    on_click_callable=_do_delete,
+                    text="Delete",
+                    variant="stop",
+                    compact=True,
+                )
+            ],
+            width=420,
+        )
+        self.page.open(dialog)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_modal.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_modal.py
@@ -13,7 +13,14 @@ from typing import Any
 
 import flet as ft
 
-from app.components.frontend.controls import DataTable, DataTableColumn, FormDropdown
+from app.components.frontend.controls import (
+    DataTable,
+    DataTableColumn,
+    FormDropdown,
+    PrimaryText,
+    SecondaryText,
+    ThemedSwitch,
+)
 from app.components.frontend.controls.buttons import PulseButton
 from app.components.frontend.controls.inputs import StyledTextField
 from app.components.frontend.controls.snack_bar import ErrorSnackBar, SuccessSnackBar
@@ -27,7 +34,7 @@ from app.services.system.ui import get_component_subtitle, get_component_title
 
 from ..cards.card_utils import get_status_detail
 from .base_detail_popup import BaseDetailPopup
-from .documents_detail_pane import API, DocumentDetailPane
+from .documents_detail_pane import API, CHANNELS, DocumentDetailPane
 from .modal_sections import EmptyStatePlaceholder, row_matches
 
 ALL = "all"
@@ -45,6 +52,21 @@ def matching_documents(docs: list[dict[str, Any]], query: str) -> list[dict[str,
         for doc in docs
         if row_matches(query, [doc.get("title"), *doc.get("tags", [])])
     ]
+
+
+def _title_cell(doc: dict[str, Any]) -> Any:
+    """The title, with a lock beside it when the document is protected."""
+    title = str(doc.get("title") or "-")
+    if not doc.get("protected"):
+        return title
+    return ft.Row(
+        [
+            PrimaryText(title),
+            ft.Icon(ft.Icons.LOCK_OUTLINE, size=14, color=ft.Colors.ON_SURFACE_VARIANT),
+        ],
+        tight=True,
+        spacing=Theme.Spacing.XS,
+    )
 
 
 class DocumentsTab(ft.Container):
@@ -69,6 +91,16 @@ class DocumentsTab(ft.Container):
             options=[(ALL, "All")],
             on_change=lambda _: page.run_task(self._load),
         )
+        self._channel = FormDropdown(
+            label="Via",
+            value=ALL,
+            width=140,
+            options=[(ALL, "All"), *[(c, c.title()) for c in CHANNELS]],
+            on_change=lambda _: page.run_task(self._load),
+        )
+        self._replaced = ThemedSwitch(
+            value=False, on_change=lambda _: page.run_task(self._load)
+        )
         self._search = StyledTextField(
             compact=True, hint_text="Search", width=220, on_change=self._on_search
         )
@@ -83,7 +115,15 @@ class DocumentsTab(ft.Container):
                 PulseButton(on_click_callable=self._pick, text="Upload", compact=True),
                 self._kind,
                 self._tag,
+                self._channel,
                 self._search,
+                ft.Row(
+                    [
+                        SecondaryText("Replaced too", size=Theme.Typography.BODY_SMALL),
+                        self._replaced,
+                    ],
+                    spacing=Theme.Spacing.XS,
+                ),
             ],
             spacing=Theme.Spacing.MD,
             vertical_alignment=ft.CrossAxisAlignment.END,
@@ -119,6 +159,10 @@ class DocumentsTab(ft.Container):
             params["kind"] = self._kind.value
         if self._tag.value != ALL:
             params["tag"] = self._tag.value
+        if self._channel.value != ALL:
+            params["channel"] = self._channel.value
+        if self._replaced.value:
+            params["include_superseded"] = "true"
         data = await api.get(API, params=params)
         items = data.get("items") if isinstance(data, dict) else None
         self._docs = items if isinstance(items, list) else []
@@ -142,7 +186,7 @@ class DocumentsTab(ft.Container):
         ]
         rows = [
             [
-                str(doc.get("title") or "-"),
+                _title_cell(doc),
                 str(doc.get("kind") or "-").title(),
                 display_date(doc) or "-",
                 format_bytes(int(doc.get("byte_size") or 0)),
@@ -155,7 +199,7 @@ class DocumentsTab(ft.Container):
             rows=rows,
             scroll_height=600,
             empty_message="No documents yet",
-            on_row_click=lambda i: self._pane.show(docs[i]),
+            on_row_click=lambda i: self._pane.show(docs[i], others=self._docs),
         )
         if self.page:
             self._table.update()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/models.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/models.py
@@ -62,6 +62,7 @@ class Document(SQLModel, table=True):
             postgresql_where=Column("deleted_at").is_(None),
         ),
         Index("ix_document_kind", "kind"),
+        Index("ix_document_supersedes", "supersedes_id"),
         CheckConstraint(
             "kind IN ('letter', 'statement', 'form', 'identification', "
             "'receipt', 'other')",
@@ -88,6 +89,15 @@ class Document(SQLModel, table=True):
     document_date: date | None = None
     received_at: datetime | None = None
     source: str = Field(default="upload", max_length=32)
+    # How the paper reached you (mail, download, scan, email), as opposed
+    # to ``source``, which is the mechanism that stored the bytes.
+    channel: str | None = Field(default=None, max_length=32)
+    # A newer version points at the one it replaces. The head of a chain
+    # is the copy to cite; the rest stay reachable beneath it. Supersede,
+    # never overwrite: the same rule facts follow.
+    supersedes_id: int | None = Field(default=None, foreign_key="document.id")
+    # One more gate on delete, and never auto-purged. Not an access tier.
+    protected: bool = Field(default=False)
     note: str | None = None
     meta_data: dict[str, Any] = Field(
         default_factory=dict, sa_column=Column("meta_data", JSON, nullable=False)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/queries.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/queries.py
@@ -1,0 +1,177 @@
+"""Reads for the document store: one document, a page of them, and the
+labels and totals over them. Writes stay in ``service.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sqlalchemy import func
+from sqlmodel import select
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.documents.models import Document, DocumentTag, utcnow
+
+
+async def document_by_content(
+    db: AsyncSession, key: str, *, owner_user_id: int | None = None
+) -> Document | None:
+    """The live document holding these bytes, if there is one."""
+    digest = key.rsplit("/", 1)[-1]
+    query = select(Document).where(
+        Document.content_hash == digest, Document.deleted_at.is_(None)
+    )
+    if owner_user_id is not None:
+        query = query.where(Document.owner_user_id == owner_user_id)
+    return (await db.exec(query)).first()
+
+
+async def document_by_id(
+    db: AsyncSession, document_id: int, *, owner_user_id: int | None = None
+) -> Document | None:
+    query = select(Document).where(
+        Document.id == document_id, Document.deleted_at.is_(None)
+    )
+    if owner_user_id is not None:
+        query = query.where(Document.owner_user_id == owner_user_id)
+    return (await db.exec(query)).first()
+
+
+async def documents_page(
+    db: AsyncSession,
+    *,
+    owner_user_id: int | None = None,
+    kind: str | None = None,
+    tag: str | None = None,
+    channel: str | None = None,
+    include_superseded: bool = False,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[Document], int]:
+    """A page of live documents, newest first, plus the total.
+
+    By default only the head of each version chain is listed: a
+    document another live document supersedes is reachable through
+    that one, not beside it.
+    """
+    query = select(Document).where(Document.deleted_at.is_(None))
+    count_query = (
+        select(func.count()).select_from(Document).where(Document.deleted_at.is_(None))
+    )
+    if owner_user_id is not None:
+        query = query.where(Document.owner_user_id == owner_user_id)
+        count_query = count_query.where(Document.owner_user_id == owner_user_id)
+    if kind is not None:
+        query = query.where(Document.kind == kind)
+        count_query = count_query.where(Document.kind == kind)
+    if tag is not None:
+        tagged = select(DocumentTag.document_id).where(DocumentTag.label == tag)
+        query = query.where(Document.id.in_(tagged))
+        count_query = count_query.where(Document.id.in_(tagged))
+    if channel is not None:
+        query = query.where(Document.channel == channel)
+        count_query = count_query.where(Document.channel == channel)
+    if not include_superseded:
+        replaced = select(Document.supersedes_id).where(
+            Document.supersedes_id.is_not(None), Document.deleted_at.is_(None)
+        )
+        query = query.where(Document.id.not_in(replaced))
+        count_query = count_query.where(Document.id.not_in(replaced))
+    total = (await db.exec(count_query)).one()
+    rows = (
+        await db.exec(
+            query.order_by(Document.created_at.desc(), Document.id.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+        )
+    ).all()
+    return list(rows), int(total)
+
+
+async def store_summary(
+    db: AsyncSession, *, owner_user_id: int | None = None
+) -> dict[str, Any]:
+    """What the card shows: how much paper, how recent, how heavy."""
+    live = Document.deleted_at.is_(None)
+    if owner_user_id is not None:
+        live = live & (Document.owner_user_id == owner_user_id)
+    by_kind = (
+        await db.exec(
+            select(
+                Document.kind,
+                func.count(),
+                func.coalesce(func.sum(Document.byte_size), 0),
+            )
+            .where(live)
+            .group_by(Document.kind)
+        )
+    ).all()
+    month_start = utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    this_month = (
+        await db.exec(
+            select(func.count())
+            .select_from(Document)
+            .where(live, Document.received_at >= month_start)
+        )
+    ).one()
+    return {
+        "total": sum(int(n) for _, n, _ in by_kind),
+        "this_month": int(this_month),
+        "bytes": sum(int(b) for _, _, b in by_kind),
+        "by_kind": {kind: int(n) for kind, n, _ in by_kind},
+    }
+
+
+async def tag_counts(
+    db: AsyncSession, *, owner_user_id: int | None = None
+) -> list[tuple[str, int]]:
+    """Every label in use on live documents, most used first."""
+    query = (
+        select(DocumentTag.label, func.count())
+        .join(Document, Document.id == DocumentTag.document_id)
+        .where(Document.deleted_at.is_(None))
+    )
+    if owner_user_id is not None:
+        query = query.where(Document.owner_user_id == owner_user_id)
+    rows = (
+        await db.exec(
+            query.group_by(DocumentTag.label).order_by(
+                func.count().desc(), DocumentTag.label
+            )
+        )
+    ).all()
+    return [(str(label), int(n)) for label, n in rows]
+
+
+async def tags_for_many(
+    db: AsyncSession, document_ids: list[int]
+) -> dict[int, list[str]]:
+    """Tags for a page of documents in ONE query.
+
+    A per-row lookup is the N+1 the house rules forbid, and a listing
+    endpoint is exactly where it bites.
+    """
+    if not document_ids:
+        return {}
+    rows = (
+        await db.exec(
+            select(DocumentTag)
+            .where(DocumentTag.document_id.in_(document_ids))
+            .order_by(DocumentTag.document_id, DocumentTag.label)
+        )
+    ).all()
+    grouped: dict[int, list[str]] = {}
+    for row in rows:
+        grouped.setdefault(row.document_id, []).append(row.label)
+    return grouped
+
+
+async def tags_for(db: AsyncSession, document_id: int) -> list[str]:
+    rows = (
+        await db.exec(
+            select(DocumentTag)
+            .where(DocumentTag.document_id == document_id)
+            .order_by(DocumentTag.label)
+        )
+    ).all()
+    return [row.label for row in rows]

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/service.py
@@ -48,6 +48,7 @@ class DocumentService:
         source: str = "upload",
         note: str | None = None,
         page_count: int | None = None,
+        channel: str | None = None,
     ) -> Document:
         """Store bytes and record the document, or return the one that
         already holds these exact bytes. See ``store`` for the version
@@ -62,6 +63,7 @@ class DocumentService:
             source=source,
             note=note,
             page_count=page_count,
+            channel=channel,
         )
         return document
 
@@ -77,6 +79,7 @@ class DocumentService:
         source: str = "upload",
         note: str | None = None,
         page_count: int | None = None,
+        channel: str | None = None,
     ) -> tuple[Document, bool]:
         """Store bytes and record the document, or return the one that
         already holds these exact bytes, plus whether a row was created.
@@ -118,6 +121,7 @@ class DocumentService:
             received_at=utcnow(),
             source=source,
             note=note,
+            channel=channel,
         )
         self.db.add(document)
         await self.db.flush()
@@ -193,6 +197,8 @@ class DocumentService:
             )
         if "title" in fields and not (fields["title"] or "").strip():
             raise ValueError("A document needs a title.")
+        if "protected" in fields and not isinstance(fields["protected"], bool):
+            raise ValueError("protected must be true or false.")
         document = await self.get(document_id, owner_user_id=owner_user_id)
         if document is None:
             return None

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/service.py
@@ -12,16 +12,22 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
-from sqlalchemy import func
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.storage import content_key, get_storage
+from app.services.documents import queries
 from app.services.documents.models import DOCUMENT_KINDS, Document, DocumentTag, utcnow
 
 # The columns a client may change after the fact. Storage, hash, size and
 # provenance describe the bytes and are fixed by them.
-_EDITABLE = frozenset({"title", "kind", "document_date", "note"})
+_EDITABLE = frozenset(
+    {"title", "kind", "document_date", "note", "channel", "supersedes_id", "protected"}
+)
+
+
+class ProtectedDocumentError(PermissionError):
+    """Retiring a protected document needs its title typed back."""
 
 
 class DocumentService:
@@ -121,23 +127,16 @@ class DocumentService:
         self, key: str, *, owner_user_id: int | None = None
     ) -> Document | None:
         """The live document holding these bytes, if there is one."""
-        digest = key.rsplit("/", 1)[-1]
-        query = select(Document).where(
-            Document.content_hash == digest, Document.deleted_at.is_(None)
+        return await queries.document_by_content(
+            self.db, key, owner_user_id=owner_user_id
         )
-        if owner_user_id is not None:
-            query = query.where(Document.owner_user_id == owner_user_id)
-        return (await self.db.exec(query)).first()
 
     async def get(
         self, document_id: int, *, owner_user_id: int | None = None
     ) -> Document | None:
-        query = select(Document).where(
-            Document.id == document_id, Document.deleted_at.is_(None)
+        return await queries.document_by_id(
+            self.db, document_id, owner_user_id=owner_user_id
         )
-        if owner_user_id is not None:
-            query = query.where(Document.owner_user_id == owner_user_id)
-        return (await self.db.exec(query)).first()
 
     async def content(
         self, document_id: int, *, owner_user_id: int | None = None
@@ -155,35 +154,23 @@ class DocumentService:
         owner_user_id: int | None = None,
         kind: str | None = None,
         tag: str | None = None,
+        channel: str | None = None,
+        include_superseded: bool = False,
         page: int = 1,
         page_size: int = 50,
     ) -> tuple[list[Document], int]:
-        """A page of live documents, newest first, plus the total."""
-        query = select(Document).where(Document.deleted_at.is_(None))
-        count_query = (
-            select(func.count())
-            .select_from(Document)
-            .where(Document.deleted_at.is_(None))
+        """A page of live documents, newest first, plus the total. Heads of
+        version chains only unless ``include_superseded``."""
+        return await queries.documents_page(
+            self.db,
+            owner_user_id=owner_user_id,
+            kind=kind,
+            tag=tag,
+            channel=channel,
+            include_superseded=include_superseded,
+            page=page,
+            page_size=page_size,
         )
-        if owner_user_id is not None:
-            query = query.where(Document.owner_user_id == owner_user_id)
-            count_query = count_query.where(Document.owner_user_id == owner_user_id)
-        if kind is not None:
-            query = query.where(Document.kind == kind)
-            count_query = count_query.where(Document.kind == kind)
-        if tag is not None:
-            tagged = select(DocumentTag.document_id).where(DocumentTag.label == tag)
-            query = query.where(Document.id.in_(tagged))
-            count_query = count_query.where(Document.id.in_(tagged))
-        total = (await self.db.exec(count_query)).one()
-        rows = (
-            await self.db.exec(
-                query.order_by(Document.created_at.desc(), Document.id.desc())
-                .offset((page - 1) * page_size)
-                .limit(page_size)
-            )
-        ).all()
-        return list(rows), int(total)
 
     async def update(
         self,
@@ -209,6 +196,10 @@ class DocumentService:
         document = await self.get(document_id, owner_user_id=owner_user_id)
         if document is None:
             return None
+        if fields.get("supersedes_id") is not None:
+            await self._check_supersedes(
+                document_id, int(fields["supersedes_id"]), owner_user_id=owner_user_id
+            )
         for name, value in fields.items():
             setattr(document, name, value.strip() if name == "title" else value)
         document.updated_at = utcnow()
@@ -216,56 +207,32 @@ class DocumentService:
         await self.db.flush()
         return document
 
+    async def _check_supersedes(
+        self, document_id: int, target_id: int, *, owner_user_id: int | None
+    ) -> None:
+        """The target must exist, be someone else's version, and not
+        already descend from this document, or the chain would loop."""
+        if target_id == document_id:
+            raise ValueError("A document cannot replace itself.")
+        target = await self.get(target_id, owner_user_id=owner_user_id)
+        if target is None:
+            raise ValueError("Unknown document to replace.")
+        seen: set[int] = set()
+        while target is not None and target.supersedes_id is not None:
+            if target.supersedes_id == document_id or target.id in seen:
+                raise ValueError("That would make the version chain loop.")
+            seen.add(target.id or 0)
+            target = await self.get(target.supersedes_id, owner_user_id=owner_user_id)
+
     async def summary(self, *, owner_user_id: int | None = None) -> dict[str, Any]:
         """What the card shows: how much paper, how recent, how heavy."""
-        live = Document.deleted_at.is_(None)
-        if owner_user_id is not None:
-            live = live & (Document.owner_user_id == owner_user_id)
-        by_kind = (
-            await self.db.exec(
-                select(
-                    Document.kind,
-                    func.count(),
-                    func.coalesce(func.sum(Document.byte_size), 0),
-                )
-                .where(live)
-                .group_by(Document.kind)
-            )
-        ).all()
-        month_start = utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        this_month = (
-            await self.db.exec(
-                select(func.count())
-                .select_from(Document)
-                .where(live, Document.received_at >= month_start)
-            )
-        ).one()
-        return {
-            "total": sum(int(n) for _, n, _ in by_kind),
-            "this_month": int(this_month),
-            "bytes": sum(int(b) for _, _, b in by_kind),
-            "by_kind": {kind: int(n) for kind, n, _ in by_kind},
-        }
+        return await queries.store_summary(self.db, owner_user_id=owner_user_id)
 
     async def tag_counts(
         self, *, owner_user_id: int | None = None
     ) -> list[tuple[str, int]]:
         """Every label in use on live documents, most used first."""
-        query = (
-            select(DocumentTag.label, func.count())
-            .join(Document, Document.id == DocumentTag.document_id)
-            .where(Document.deleted_at.is_(None))
-        )
-        if owner_user_id is not None:
-            query = query.where(Document.owner_user_id == owner_user_id)
-        rows = (
-            await self.db.exec(
-                query.group_by(DocumentTag.label).order_by(
-                    func.count().desc(), DocumentTag.label
-                )
-            )
-        ).all()
-        return [(str(label), int(n)) for label, n in rows]
+        return await queries.tag_counts(self.db, owner_user_id=owner_user_id)
 
     async def untag(self, document_id: int, label: str) -> bool:
         """Take a label off; False when it was not there."""
@@ -307,46 +274,32 @@ class DocumentService:
         return row
 
     async def tags_for_many(self, document_ids: list[int]) -> dict[int, list[str]]:
-        """Tags for a page of documents in ONE query.
-
-        A per-row lookup is the N+1 the house rules forbid, and a listing
-        endpoint is exactly where it bites.
-        """
-        if not document_ids:
-            return {}
-        rows = (
-            await self.db.exec(
-                select(DocumentTag)
-                .where(DocumentTag.document_id.in_(document_ids))
-                .order_by(DocumentTag.document_id, DocumentTag.label)
-            )
-        ).all()
-        grouped: dict[int, list[str]] = {}
-        for row in rows:
-            grouped.setdefault(row.document_id, []).append(row.label)
-        return grouped
+        """Tags for a page of documents in one query, never one per row."""
+        return await queries.tags_for_many(self.db, document_ids)
 
     async def tags_for(self, document_id: int) -> list[str]:
-        rows = (
-            await self.db.exec(
-                select(DocumentTag)
-                .where(DocumentTag.document_id == document_id)
-                .order_by(DocumentTag.label)
-            )
-        ).all()
-        return [row.label for row in rows]
+        return await queries.tags_for(self.db, document_id)
 
     async def soft_delete(
-        self, document_id: int, *, owner_user_id: int | None = None
+        self,
+        document_id: int,
+        *,
+        owner_user_id: int | None = None,
+        confirm: str | None = None,
     ) -> bool:
         """Retire a document without touching storage.
 
         The bytes stay: another document may hold the same content hash,
         and an audit trail that loses its subject is not an audit trail.
+        A protected document goes only when ``confirm`` is its exact title.
         """
         document = await self.get(document_id, owner_user_id=owner_user_id)
         if document is None:
             return False
+        if document.protected and confirm != document.title:
+            raise ProtectedDocumentError(
+                "This document is protected; confirm by sending its exact title."
+            )
         document.deleted_at = utcnow()
         self.db.add(document)
         await self.db.flush()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_documents_endpoints.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_documents_endpoints.py
@@ -5,8 +5,8 @@ the property a retrying client depends on: the same file twice is one
 document, not two.
 """
 
-import pytest
 from fastapi.testclient import TestClient
+import pytest
 
 from app.core.storage import FilesystemStorage, set_storage
 
@@ -203,3 +203,72 @@ class TestDocumentEndpoints:
             client.delete(f"/api/v1/documents/{created['id']}/tags/tmp").status_code
             == 404
         )
+
+    def test_a_protected_document_refuses_a_bare_delete(
+        self, client: TestClient
+    ) -> None:
+        created = client.post(
+            "/api/v1/documents",
+            files={"file": ("poa.pdf", b"executed poa bytes", "application/pdf")},
+            data={"title": "Executed POA"},
+        ).json()
+        client.patch(f"/api/v1/documents/{created['id']}", json={"protected": True})
+
+        assert client.delete(f"/api/v1/documents/{created['id']}").status_code == 409
+        assert (
+            client.delete(
+                f"/api/v1/documents/{created['id']}", params={"confirm": "wrong"}
+            ).status_code
+            == 409
+        )
+        assert (
+            client.delete(
+                f"/api/v1/documents/{created['id']}",
+                params={"confirm": "Executed POA"},
+            ).status_code
+            == 204
+        )
+
+    def test_superseded_documents_leave_the_default_listing(
+        self, client: TestClient
+    ) -> None:
+        draft = client.post(
+            "/api/v1/documents",
+            files={"file": ("d.pdf", b"draft bytes", "application/pdf")},
+            data={"title": "Draft", "kind": "form"},
+        ).json()
+        final = client.post(
+            "/api/v1/documents",
+            files={"file": ("f.pdf", b"final bytes", "application/pdf")},
+            data={"title": "Final", "kind": "form"},
+        ).json()
+
+        patched = client.patch(
+            f"/api/v1/documents/{final['id']}", json={"supersedes_id": draft["id"]}
+        )
+
+        assert patched.status_code == 200
+        assert patched.json()["supersedes_id"] == draft["id"]
+        titles = [
+            d["title"]
+            for d in client.get("/api/v1/documents", params={"kind": "form"}).json()[
+                "items"
+            ]
+        ]
+        assert titles == ["Final"]
+        both = client.get(
+            "/api/v1/documents", params={"kind": "form", "include_superseded": True}
+        ).json()
+        assert both["total"] == 2
+
+    def test_channel_is_filed_and_filterable(self, client: TestClient) -> None:
+        client.post(
+            "/api/v1/documents",
+            files={"file": ("m.pdf", b"mailed bytes", "application/pdf")},
+            data={"title": "Mailed", "channel": "mail"},
+        )
+
+        listed = client.get("/api/v1/documents", params={"channel": "mail"}).json()
+
+        assert listed["total"] == 1
+        assert listed["items"][0]["channel"] == "mail"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_documents_endpoints.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_documents_endpoints.py
@@ -261,6 +261,23 @@ class TestDocumentEndpoints:
         ).json()
         assert both["total"] == 2
 
+    def test_protected_cannot_be_unset_to_null(self, client: TestClient) -> None:
+        created = client.post(
+            "/api/v1/documents",
+            files={"file": ("n.pdf", b"null protected", "application/pdf")},
+            data={"title": "N"},
+        ).json()
+
+        response = client.patch(
+            f"/api/v1/documents/{created['id']}", json={"protected": None}
+        )
+
+        assert response.status_code == 400
+        assert (
+            client.get(f"/api/v1/documents/{created['id']}").json()["protected"]
+            is False
+        )
+
     def test_channel_is_filed_and_filterable(self, client: TestClient) -> None:
         client.post(
             "/api/v1/documents",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_documents_ui.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_documents_ui.py
@@ -5,6 +5,9 @@ matches, and that the card renders the counts the health check hands it.
 """
 
 from app.components.frontend.dashboard.cards.documents_card import DocumentsCard
+from app.components.frontend.dashboard.modals.documents_detail_pane import (
+    replaces_options,
+)
 from app.components.frontend.dashboard.modals.documents_modal import (
     display_date,
     matching_documents,
@@ -52,3 +55,17 @@ def test_card_shows_the_counts_the_health_check_reports() -> None:
     assert "47" in shown
     assert "6" in shown
     assert "212.0 MB" in shown
+
+
+def test_replaces_options_offer_every_other_document_and_nothing() -> None:
+    docs = [
+        {"id": 1, "title": "POA draft"},
+        {"id": 2, "title": "POA executed"},
+        {"id": 3, "title": "Statement"},
+    ]
+
+    options = replaces_options(docs, current_id=2)
+
+    assert options[0] == ("", "Nothing")
+    assert [label for _, label in options[1:]] == ["POA draft", "Statement"]
+    assert all(key != "2" for key, _ in options)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_documents_service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_documents_service.py
@@ -273,3 +273,61 @@ class TestSummary:
         summary = await svc.summary(owner_user_id=99)
 
         assert summary == {"total": 0, "this_month": 0, "bytes": 0, "by_kind": {}}
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_a_newer_version_hides_the_one_it_replaces(self, svc) -> None:
+        draft = await svc.ingest(b"poa draft", title="POA draft", owner_user_id=1)
+        executed = await svc.ingest(
+            b"poa signed", title="POA executed", owner_user_id=1
+        )
+
+        await svc.update(executed.id, {"supersedes_id": draft.id}, owner_user_id=1)
+
+        heads, total = await svc.list_documents(owner_user_id=1)
+        assert [d.id for d in heads] == [executed.id] and total == 1
+        everything, _ = await svc.list_documents(
+            owner_user_id=1, include_superseded=True
+        )
+        assert {d.id for d in everything} == {draft.id, executed.id}
+
+    @pytest.mark.asyncio
+    async def test_a_chain_cannot_loop_or_point_at_itself(self, svc) -> None:
+        a = await svc.ingest(b"v1", title="v1", owner_user_id=1)
+        b = await svc.ingest(b"v2", title="v2", owner_user_id=1)
+        await svc.update(b.id, {"supersedes_id": a.id}, owner_user_id=1)
+
+        with pytest.raises(ValueError, match="itself"):
+            await svc.update(a.id, {"supersedes_id": a.id}, owner_user_id=1)
+        with pytest.raises(ValueError, match="loop"):
+            await svc.update(a.id, {"supersedes_id": b.id}, owner_user_id=1)
+        with pytest.raises(ValueError, match="Unknown"):
+            await svc.update(a.id, {"supersedes_id": 9999}, owner_user_id=1)
+
+    @pytest.mark.asyncio
+    async def test_a_protected_document_needs_its_title_to_be_retired(
+        self, svc
+    ) -> None:
+        from app.services.documents.service import ProtectedDocumentError
+
+        poa = await svc.ingest(b"executed poa", title="Executed POA", owner_user_id=1)
+        await svc.update(poa.id, {"protected": True}, owner_user_id=1)
+
+        with pytest.raises(ProtectedDocumentError):
+            await svc.soft_delete(poa.id, owner_user_id=1)
+        with pytest.raises(ProtectedDocumentError):
+            await svc.soft_delete(poa.id, owner_user_id=1, confirm="executed poa")
+        assert await svc.get(poa.id, owner_user_id=1) is not None
+
+        assert await svc.soft_delete(poa.id, owner_user_id=1, confirm="Executed POA")
+
+    @pytest.mark.asyncio
+    async def test_channel_records_how_the_paper_arrived(self, svc) -> None:
+        letter = await svc.ingest(b"county letter", title="Letter", owner_user_id=1)
+        await svc.ingest(b"chase pdf", title="Statement", owner_user_id=1)
+
+        await svc.update(letter.id, {"channel": "mail"}, owner_user_id=1)
+
+        rows, total = await svc.list_documents(owner_user_id=1, channel="mail")
+        assert total == 1 and rows[0].channel == "mail"

--- a/tests/core/test_migration_generator.py
+++ b/tests/core/test_migration_generator.py
@@ -511,6 +511,10 @@ class TestGenerateMigration:
         content = result.read_text()
         assert "'document'" in content
         assert "'document_tag'" in content
+        # SF-07 lifecycle columns ship in the squashed migration too.
+        assert "'supersedes_id'" in content
+        assert "'protected'" in content
+        assert "'channel'" in content
 
     def test_creates_versions_directory(self, tmp_path: Path) -> None:
         """Test creates versions directory if it doesn't exist."""


### PR DESCRIPTION
SF-07 #1009. Three columns on the document row, each cheap now and unrecoverable later, all properties of the paper rather than of what it means.

## Supersession

`supersedes_id` points a newer version at the one it replaces: draft, executed, recorded copy of the same POA. The head of a chain is the copy to cite. The listing shows heads by default; `?include_superseded=true` (and a "Replaced too" switch in the modal) shows the rest. The service refuses a self-reference, an unknown target, and any link that would make the chain loop. Same rule facts follow in ST-06: supersede, never overwrite.

## Protection

`protected` is one more gate on the one destructive action. `DELETE` without `?confirm=<exact title>` is a 409; the pane replaces the yes/no with the title typed back. A lock marks the row in the listing. Not an access tier: when a purge job exists, it skips these rows, and that is all it means.

## Channel

`channel` records how the paper reached you (mail, download, scan, email, upload), distinct from `source`, which is the mechanism that stored the bytes. Set on upload, editable in the pane, filterable in the listing and API.

## Migrations

The squashed documents migration carries the columns for fresh stacks, with the self-referential FK and an index on `supersedes_id`. An existing database moves forward with an ordinary incremental migration; the dev stack ran its 007 on reload and the columns are live.

## Shape

The read side of the document service moved into `queries.py`, the same seam finance uses, because `service.py` had crossed the "one file wearing a folder" line the size-budget guard enforces.

## Verified

Documents-only and everything stack full validations pass. Framework guards pass, including the migration generator asserting the new columns. Live on the dev stack: filter by channel, mark protected, refuse the bare delete, accept the typed title.

Closes #1009
