### PR TITLE
Read documents once, per page, and keep what was read

### DIFF
--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -1568,6 +1568,36 @@ DOCUMENTS_MIGRATION = ServiceMigrationSpec(
                 ),
             ],
         ),
+        # One row per page as extraction read it: the method that produced
+        # the text (text layer, vision, none) rides along so any later
+        # claim can cite both the page and the way it was read.
+        TableSpec(
+            name="document_page",
+            columns=[
+                ColumnSpec("id", "sa.Integer()", nullable=False, primary_key=True),
+                ColumnSpec("document_id", "sa.Integer()", nullable=False),
+                ColumnSpec("page_number", "sa.Integer()", nullable=False),
+                ColumnSpec(
+                    "status", "sa.String(16)", nullable=False, default="'unread'"
+                ),
+                ColumnSpec("method", "sa.String(16)", nullable=False, default="'none'"),
+                ColumnSpec("text", "sa.String()", nullable=True),
+                ColumnSpec("image_key", "sa.String(128)", nullable=True),
+                ColumnSpec("model", "sa.String(128)", nullable=True),
+                ColumnSpec("detail", "sa.String()", nullable=True),
+                ColumnSpec("created_at", "sa.DateTime()", nullable=False),
+                ColumnSpec("updated_at", "sa.DateTime()", nullable=True),
+            ],
+            foreign_keys=[
+                ForeignKeySpec(["document_id"], "document", ["id"], ondelete="CASCADE"),
+            ],
+            indexes=[
+                IndexSpec("ix_document_page_document", ["document_id"]),
+                IndexSpec(
+                    "uq_document_page", ["document_id", "page_number"], unique=True
+                ),
+            ],
+        ),
         # Free-form labels rather than a fixed taxonomy: the framework
         # stores paper, it does not decide what kinds of paper exist.
         TableSpec(

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -1130,6 +1130,8 @@ SERVICES: dict[str, ServiceSpec] = {
         migrations=[DOCUMENTS_MIGRATION],
         pyproject_deps=[
             "alembic==1.16.5",
+            # PDFium: the text layer and page rendering behind extraction.
+            "pypdfium2>=5.0,<6",
         ],
         template_files=[
             "app/services/documents/",
@@ -1140,11 +1142,15 @@ SERVICES: dict[str, ServiceSpec] = {
                 "app/components/backend/api/documents",
                 "app/services/documents",
                 "tests/services/test_documents_service.py",
+                "tests/services/test_document_extraction.py",
                 "tests/api/test_documents_endpoints.py",
+                "tests/api/test_document_pages.py",
+                "tests/_pdf.py",
                 "tests/components/frontend/test_documents_ui.py",
                 "app/components/frontend/dashboard/cards/documents_card.py",
                 "app/components/frontend/dashboard/modals/documents_modal.py",
                 "app/components/frontend/dashboard/modals/documents_detail_pane.py",
+                "app/components/frontend/dashboard/modals/documents_pages.py",
             ],
         ),
     ),

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/pages.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/pages.py
@@ -1,0 +1,179 @@
+"""Extraction and the pages it produces.
+
+``POST /{id}/extract`` reads the document (synchronously by default, as a
+background job with ``?background=true`` so a 40-page statement can
+stream progress over the jobs SSE endpoint). The page routes read back
+what extraction stored: status per page, one page's text, its image.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel
+
+from app.core.db import get_async_session
+from app.core.storage import get_storage
+from app.services.documents.deps import get_document_service, get_owner_user_id
+from app.services.documents.extraction import (
+    DocumentContentMissingError,
+    DocumentNotFoundError,
+    ExtractionResult,
+    extract_document,
+)
+from app.services.documents.models import DocumentPage
+from app.services.documents.queries import page_for, pages_for
+from app.services.documents.service import DocumentService
+from app.services.documents.vision import vision_reader
+from app.services.system.jobs import JobHandle, get_job_runner
+
+router = APIRouter()
+
+_NOT_FOUND = "Document not found"
+_PAGE_NOT_FOUND = "Page not found"
+
+
+class PageSummary(BaseModel):
+    page_number: int
+    status: str
+    method: str
+    has_image: bool
+    model: str | None
+    detail: str | None
+
+    @classmethod
+    def from_row(cls, row: DocumentPage) -> PageSummary:
+        return cls(
+            page_number=row.page_number,
+            status=row.status,
+            method=row.method,
+            has_image=bool(row.image_key),
+            model=row.model,
+            detail=row.detail,
+        )
+
+
+class PageDetail(PageSummary):
+    text: str | None
+
+    @classmethod
+    def from_row(cls, row: DocumentPage) -> PageDetail:
+        return cls(**PageSummary.from_row(row).model_dump(), text=row.text)
+
+
+@router.post("/{document_id}/extract")
+async def extract(
+    document_id: int,
+    background: bool = False,
+    force: bool = False,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> Response:
+    """Read every page not yet read. Returns the counts, or a job id."""
+    if await service.get(document_id, owner_user_id=owner_user_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    if not background:
+        try:
+            result = await extract_document(
+                service.db,
+                document_id,
+                owner_user_id=owner_user_id,
+                vision=vision_reader(),
+                force=force,
+            )
+        except DocumentNotFoundError:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND
+            ) from None
+        except DocumentContentMissingError as exc:
+            # The row outlived its object: the store lost it, not the client.
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY, detail=str(exc)
+            ) from None
+        return JSONResponse(result.as_dict())
+
+    async def work(handle: JobHandle) -> dict[str, int]:
+        def progress(page: int, total: int) -> None:
+            handle.set_label(f"Reading page {page} of {total}...")
+
+        async with get_async_session() as session:
+            result: ExtractionResult = await extract_document(
+                session,
+                document_id,
+                owner_user_id=owner_user_id,
+                vision=vision_reader(),
+                force=force,
+                progress=progress,
+            )
+            await session.commit()
+        return result.as_dict()
+
+    job_id = get_job_runner().start(
+        f"documents-extract:{document_id}", work, label="Opening the document..."
+    )
+    return JSONResponse({"job_id": job_id}, status_code=status.HTTP_202_ACCEPTED)
+
+
+@router.get("/{document_id}/pages", response_model=list[PageSummary])
+async def list_pages(
+    document_id: int,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> list[PageSummary]:
+    if await service.get(document_id, owner_user_id=owner_user_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    return [
+        PageSummary.from_row(row) for row in await pages_for(service.db, document_id)
+    ]
+
+
+@router.get("/{document_id}/pages/{page_number}", response_model=PageDetail)
+async def get_page(
+    document_id: int,
+    page_number: int,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> PageDetail:
+    row = await _page(service, document_id, page_number, owner_user_id)
+    return PageDetail.from_row(row)
+
+
+@router.get("/{document_id}/pages/{page_number}/image")
+async def get_page_image(
+    document_id: int,
+    page_number: int,
+    service: DocumentService = Depends(get_document_service),
+    owner_user_id: int | None = Depends(get_owner_user_id),
+) -> Response:
+    row = await _page(service, document_id, page_number, owner_user_id)
+    if not row.image_key:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="No page image"
+        )
+    data = await get_storage().get(row.image_key)
+    if data is None:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Page image is not retrievable from storage",
+        )
+    document = await service.get(document_id, owner_user_id=owner_user_id)
+    media_type = "image/png"
+    if document is not None and row.image_key == document.storage_key:
+        media_type = document.media_type or media_type
+    return Response(content=data, media_type=media_type)
+
+
+async def _page(
+    service: DocumentService,
+    document_id: int,
+    page_number: int,
+    owner_user_id: int | None,
+) -> DocumentPage:
+    if await service.get(document_id, owner_user_id=owner_user_id) is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
+    row = await page_for(service.db, document_id, page_number)
+    if row is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail=_PAGE_NOT_FOUND
+        )
+    return row

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/documents/router.py
@@ -22,6 +22,7 @@ from fastapi import (
 )
 from pydantic import BaseModel, Field
 
+from app.components.backend.api.documents.pages import router as pages_router
 from app.services.documents.deps import get_document_service, get_owner_user_id
 from app.services.documents.models import Document
 from app.services.documents.service import DocumentService, ProtectedDocumentError
@@ -306,3 +307,7 @@ async def delete_document(
     if not retired:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=_NOT_FOUND)
     return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# Extraction and page routes live in their own module; same prefix.
+router.include_router(pages_router)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_detail_pane.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_detail_pane.py
@@ -18,31 +18,52 @@ from app.components.frontend.controls import (
     FormDropdown,
     FormTextField,
     H3Text,
+    LabelText,
+    PrimaryText,
     SecondaryText,
     ThemedSwitch,
 )
 from app.components.frontend.controls.buttons import PulseButton
 from app.components.frontend.controls.dialog import StyledAlertDialog
 from app.components.frontend.controls.form_fields import FormDateField
+from app.components.frontend.controls.loading_overlay import LoadingOverlay
 from app.components.frontend.controls.snack_bar import ErrorSnackBar, SuccessSnackBar
 from app.components.frontend.theme import AegisTheme as Theme
 from app.core.formatting import format_bytes, format_date
 from app.core.log import logger
 from app.services.documents.models import DOCUMENT_KINDS
 
+from .documents_pages import PagesStrip, extraction_summary
 from .modal_sections import EmptyStatePlaceholder
 
 API = "/api/v1/documents"
 KIND_OPTIONS = [(kind, kind.title()) for kind in DOCUMENT_KINDS]
 # How paper tends to arrive. Free text on the row; these are the offers.
 CHANNELS = ("mail", "download", "scan", "email", "upload")
+# Flet's dropdown reports an option with an EMPTY key by its text, so
+# "no value" needs a real key or "Nothing" arrives as a value.
+NONE = "none"
+
+
+def _chosen(value: str | None) -> str | None:
+    """A dropdown value, with the placeholder read as no value."""
+    return None if value in (None, "", NONE) else value
+
+
+def _pair(left: ft.Control, right: ft.Control) -> ft.Row:
+    """Two fields on one line, equal width."""
+    return ft.Row(
+        [ft.Container(left, expand=True), ft.Container(right, expand=True)],
+        spacing=Theme.Spacing.SM,
+        vertical_alignment=ft.CrossAxisAlignment.START,
+    )
 
 
 def replaces_options(
     docs: list[dict[str, Any]], *, current_id: int | None
 ) -> list[tuple[str, str]]:
     """Dropdown options for "this replaces": nothing, or any other document."""
-    return [("", "Nothing")] + [
+    return [(NONE, "Nothing")] + [
         (str(doc["id"]), str(doc.get("title") or "Untitled"))
         for doc in docs
         if doc.get("id") != current_id
@@ -68,7 +89,10 @@ class DocumentDetailPane(ft.Container):
         self._on_change = on_change
         self._doc: dict[str, Any] | None = None
         self._others: list[dict[str, Any]] = []
-        self.width = 380
+        self.width = 400
+        self.padding = ft.padding.all(Theme.Spacing.MD)
+        self.border = ft.border.all(1, ft.Colors.OUTLINE_VARIANT)
+        self.border_radius = Theme.Components.CARD_RADIUS
         self.content = EmptyStatePlaceholder("Select a document")
 
     def _api(self) -> Any:
@@ -104,38 +128,71 @@ class DocumentDetailPane(ft.Container):
         )
         self._channel = FormDropdown(
             label="Received via",
-            value=str(doc.get("channel") or ""),
-            options=[("", "Unknown"), *[(c, c.title()) for c in CHANNELS]],
+            value=str(doc.get("channel") or NONE),
+            options=[(NONE, "Unknown"), *[(c, c.title()) for c in CHANNELS]],
         )
         self._replaces = FormDropdown(
             label="Replaces",
-            value=str(doc.get("supersedes_id") or ""),
+            value=str(doc.get("supersedes_id") or NONE),
             options=replaces_options(self._others, current_id=doc.get("id")),
         )
         self._protected = ThemedSwitch(value=bool(doc.get("protected")))
+        self._pages = PagesStrip(
+            page=self.page, api=self._api, document_id=int(doc["id"])
+        )
         self._tag_input = FormTextField(
             label="Add tag", hint="Enter to add", on_submit=self._add_tag
         )
-        self.content = ft.Column(
+        hairline = ft.Divider(height=1, color=ft.Colors.OUTLINE_VARIANT)
+        header = ft.Column(
             [
-                H3Text(str(doc.get("title") or "Untitled")),
-                SecondaryText(_facts(doc), size=Theme.Typography.BODY_SMALL),
-                self._title,
-                self._kind,
-                self._date,
-                self._channel,
-                self._replaces,
                 ft.Row(
                     [
-                        SecondaryText(
-                            "Protected: delete asks for the title, never auto-purged",
-                            size=Theme.Typography.BODY_SMALL,
+                        ft.Container(
+                            H3Text(str(doc.get("title") or "Untitled")), expand=True
                         ),
-                        self._protected,
+                        ft.Icon(
+                            ft.Icons.LOCK_OUTLINE,
+                            size=16,
+                            color=ft.Colors.ON_SURFACE_VARIANT,
+                            visible=bool(doc.get("protected")),
+                            tooltip="Protected",
+                        ),
                     ],
-                    alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                    vertical_alignment=ft.CrossAxisAlignment.START,
+                ),
+                SecondaryText(
+                    _facts(doc),
+                    size=Theme.Typography.BODY_SMALL,
+                    tooltip=str(doc.get("storage_key") or ""),
+                ),
+                self._pages,
+            ],
+            spacing=Theme.Spacing.XS,
+            tight=True,
+        )
+        body = ft.Column(
+            [
+                self._title,
+                _pair(self._kind, self._date),
+                _pair(self._channel, self._replaces),
+                ft.Column(
+                    [
+                        ft.Row(
+                            [PrimaryText("Protected"), self._protected],
+                            alignment=ft.MainAxisAlignment.SPACE_BETWEEN,
+                            vertical_alignment=ft.CrossAxisAlignment.CENTER,
+                        ),
+                        SecondaryText(
+                            "Delete asks for the title. Never auto-purged.",
+                            size=Theme.Typography.CAPTION,
+                        ),
+                    ],
+                    spacing=0,
+                    tight=True,
                 ),
                 self._note,
+                LabelText("Tags"),
                 ft.Row(self._tag_chips(), wrap=True, spacing=Theme.Spacing.XS),
                 ft.Row(
                     [
@@ -150,37 +207,65 @@ class DocumentDetailPane(ft.Container):
                     spacing=Theme.Spacing.SM,
                     vertical_alignment=ft.CrossAxisAlignment.END,
                 ),
-                SecondaryText(
-                    str(doc.get("storage_key") or ""),
-                    size=Theme.Typography.CAPTION,
-                    selectable=True,
-                ),
-                ft.Row(
-                    [
-                        PulseButton(
-                            on_click_callable=self._save, text="Save", compact=True
-                        ),
-                        PulseButton(
-                            on_click_callable=self._download,
-                            text="Download",
-                            variant="muted",
-                            compact=True,
-                        ),
-                        PulseButton(
-                            on_click_callable=self._confirm_delete,
-                            text="Delete",
-                            variant="stop",
-                            compact=True,
-                        ),
-                    ],
-                    spacing=Theme.Spacing.SM,
-                ),
             ],
             spacing=Theme.Spacing.SM,
             scroll=ft.ScrollMode.AUTO,
+            expand=True,
+        )
+        footer = ft.Row(
+            [
+                PulseButton(on_click_callable=self._save, text="Save", compact=True),
+                ft.Container(expand=True),
+                PulseButton(
+                    on_click_callable=self._extract,
+                    text="Extract",
+                    variant="muted",
+                    compact=True,
+                ),
+                PulseButton(
+                    on_click_callable=self._download,
+                    text="Download",
+                    variant="muted",
+                    compact=True,
+                ),
+                PulseButton(
+                    on_click_callable=self._confirm_delete,
+                    text="Delete",
+                    variant="stop",
+                    compact=True,
+                ),
+            ],
+            spacing=Theme.Spacing.SM,
+        )
+        self.content = ft.Column(
+            [header, hairline, body, hairline, footer],
+            spacing=Theme.Spacing.SM,
+            expand=True,
         )
         if self.page:
             self.update()
+            self.page.run_task(self._pages.load)
+
+    async def _extract(self) -> None:
+        """Read every page not yet read; progress rides the jobs stream."""
+        if self._doc is None:
+            return
+        overlay = LoadingOverlay(self.page)
+        overlay.show("Opening the document...")
+        started = await self._api().post(
+            f"{API}/{self._doc['id']}/extract?background=true"
+        )
+        if not isinstance(started, dict) or not started.get("job_id"):
+            overlay.fail("Extraction could not start.", title="Extraction failed")
+            return
+        result = await overlay.run_job(
+            self._api(), str(started["job_id"]), title="Extraction failed"
+        )
+        if result is None:
+            return
+        SuccessSnackBar(extraction_summary(result)).launch(self.page)
+        await self._pages.load()
+        await self._on_change()
 
     def _tag_chips(self) -> list[ft.Control]:
         tags = self._doc.get("tags", []) if self._doc else []
@@ -201,15 +286,14 @@ class DocumentDetailPane(ft.Container):
     async def _save(self) -> None:
         if self._doc is None:
             return
+        replaces = _chosen(self._replaces.value)
         payload = {
             "title": self._title.value,
             "kind": self._kind.value,
             "document_date": self._date.value or None,
             "note": self._note.value or None,
-            "channel": self._channel.value or None,
-            "supersedes_id": int(self._replaces.value)
-            if self._replaces.value
-            else None,
+            "channel": _chosen(self._channel.value),
+            "supersedes_id": int(replaces) if replaces else None,
             "protected": bool(self._protected.value),
         }
         code, body = await self._api().request_with_status(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_modal.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_modal.py
@@ -16,7 +16,7 @@ import flet as ft
 from app.components.frontend.controls import (
     DataTable,
     DataTableColumn,
-    FormDropdown,
+    NativeDropdown,
     PrimaryText,
     SecondaryText,
     ThemedSwitch,
@@ -54,6 +54,27 @@ def matching_documents(docs: list[dict[str, Any]], query: str) -> list[dict[str,
     ]
 
 
+def _filter_dropdown(
+    everything: str,
+    options: list[tuple[str, str]],
+    *,
+    width: int,
+    on_change: Any,
+) -> NativeDropdown:
+    """A toolbar filter: dense, unlabeled, first entry means no filter."""
+    return NativeDropdown(
+        value=ALL,
+        options=[
+            ft.dropdown.Option(key=ALL, text=everything),
+            *[ft.dropdown.Option(key=k, text=t) for k, t in options],
+        ],
+        width=width,
+        enable_filter=False,
+        enable_search=False,
+        on_change=on_change,
+    )
+
+
 def _title_cell(doc: dict[str, Any]) -> Any:
     """The title, with a lock beside it when the document is protected."""
     title = str(doc.get("title") or "-")
@@ -77,32 +98,32 @@ class DocumentsTab(ft.Container):
         self.page = page
         self._docs: list[dict[str, Any]] = []
         self._query = ""
-        self._kind = FormDropdown(
-            label="Kind",
-            value=ALL,
+        self._kind = _filter_dropdown(
+            "All kinds",
+            [(k, k.title()) for k in DOCUMENT_KINDS],
             width=150,
-            options=[(ALL, "All"), *[(k, k.title()) for k in DOCUMENT_KINDS]],
             on_change=lambda _: page.run_task(self._load),
         )
-        self._tag = FormDropdown(
-            label="Tag",
-            value=ALL,
-            width=180,
-            options=[(ALL, "All")],
+        self._channel = _filter_dropdown(
+            "Any channel",
+            [(c, c.title()) for c in CHANNELS],
+            width=150,
             on_change=lambda _: page.run_task(self._load),
         )
-        self._channel = FormDropdown(
-            label="Via",
-            value=ALL,
-            width=140,
-            options=[(ALL, "All"), *[(c, c.title()) for c in CHANNELS]],
-            on_change=lambda _: page.run_task(self._load),
+        self._tag = _filter_dropdown(
+            "Any tag", [], width=170, on_change=lambda _: page.run_task(self._load)
         )
         self._replaced = ThemedSwitch(
             value=False, on_change=lambda _: page.run_task(self._load)
         )
+        # The search takes whatever width the fixed filters leave, so the
+        # row can never overrun the pane beside it.
         self._search = StyledTextField(
-            compact=True, hint_text="Search", width=220, on_change=self._on_search
+            compact=True,
+            hint_text="Search title or tag",
+            prefix_icon=ft.Icons.SEARCH,
+            expand=True,
+            on_change=self._on_search,
         )
         self._table = ft.Container(
             content=EmptyStatePlaceholder("Loading documents..."), expand=True
@@ -110,23 +131,21 @@ class DocumentsTab(ft.Container):
         self._pane = DocumentDetailPane(page, on_change=self._load)
         self._uploads = BrowserUploads(on_file=self._file)
         self._uploads.mount(page)
+        # One line: search, the three filters, then the switch and the one
+        # primary action pushed to the right edge.
         toolbar = ft.Row(
             [
-                PulseButton(on_click_callable=self._pick, text="Upload", compact=True),
-                self._kind,
-                self._tag,
-                self._channel,
                 self._search,
-                ft.Row(
-                    [
-                        SecondaryText("Replaced too", size=Theme.Typography.BODY_SMALL),
-                        self._replaced,
-                    ],
-                    spacing=Theme.Spacing.XS,
-                ),
+                self._kind,
+                self._channel,
+                self._tag,
+                ft.Container(width=Theme.Spacing.SM),
+                SecondaryText("Replaced", size=Theme.Typography.BODY_SMALL),
+                self._replaced,
+                PulseButton(on_click_callable=self._pick, text="Upload", compact=True),
             ],
-            spacing=Theme.Spacing.MD,
-            vertical_alignment=ft.CrossAxisAlignment.END,
+            spacing=Theme.Spacing.SM,
+            vertical_alignment=ft.CrossAxisAlignment.CENTER,
         )
         # The pane sits beside toolbar AND table, so it starts at the top of
         # the tab and has the full height to show a document without scrolling.
@@ -138,7 +157,7 @@ class DocumentsTab(ft.Container):
                 self._pane,
             ],
             spacing=Theme.Spacing.MD,
-            vertical_alignment=ft.CrossAxisAlignment.START,
+            vertical_alignment=ft.CrossAxisAlignment.STRETCH,
             expand=True,
         )
         self.padding = ft.padding.all(Theme.Spacing.MD)
@@ -168,7 +187,14 @@ class DocumentsTab(ft.Container):
         self._docs = items if isinstance(items, list) else []
         tags = await api.get(f"{API}/tags")
         labels = [str(t["label"]) for t in tags] if isinstance(tags, list) else []
-        self._tag.set_options([(ALL, "All"), *[(t, t) for t in labels]])
+        self._tag.options = [
+            ft.dropdown.Option(key=ALL, text="Any tag"),
+            *[ft.dropdown.Option(key=t, text=t) for t in labels],
+        ]
+        if self._tag.value not in {ALL, *labels}:
+            self._tag.value = ALL
+        if self._tag.page is not None:
+            self._tag.update()
         self._render()
 
     def _on_search(self, e: ft.ControlEvent) -> None:
@@ -290,7 +316,7 @@ class DocumentsDetailDialog(BaseDetailPopup):
             ),
             sections=[tabs],
             scrollable=False,
-            width=1280,
-            height=840,
+            width=1600,
+            height=900,
             status_detail=get_status_detail(component_data),
         )

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_pages.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/documents_pages.py
@@ -1,0 +1,126 @@
+"""The pages of a document, as extraction left them.
+
+A strip of thumbnails from the stored renders (a page number where there
+is no image), unread pages dimmed with their reason on hover, and a
+click-through to the page at full size with its text beside it.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable
+from typing import Any
+
+import flet as ft
+
+from app.components.frontend.controls import SecondaryText
+from app.components.frontend.controls.dialog import StyledAlertDialog
+from app.components.frontend.theme import AegisTheme as Theme
+
+API = "/api/v1/documents"
+
+
+def extraction_summary(result: dict[str, Any]) -> str:
+    """What the snackbar says when a run lands."""
+    read = int(result.get("read") or 0)
+    unread = int(result.get("unread") or 0)
+    if read == 0 and unread == 0:
+        return "Already read"
+    if unread == 0:
+        return f"{read} pages read" if read != 1 else "1 page read"
+    return f"{read} read, {unread} unread"
+
+
+class PagesStrip(ft.Row):
+    """One tile per extracted page; empty until extraction has run."""
+
+    def __init__(
+        self, *, page: ft.Page, api: Callable[[], Any], document_id: int
+    ) -> None:
+        super().__init__([], wrap=True, spacing=Theme.Spacing.XS)
+        self._page = page
+        self._api = api
+        self._document_id = document_id
+
+    async def load(self) -> None:
+        api = self._api()
+        rows = await api.get(f"{API}/{self._document_id}/pages")
+        tiles: list[ft.Control] = []
+        for row in rows if isinstance(rows, list) else []:
+            number = int(row.get("page_number") or 0)
+            png = None
+            if row.get("has_image"):
+                png = await api.get_bytes(
+                    f"{API}/{self._document_id}/pages/{number}/image"
+                )
+            tiles.append(self._tile(number, png, row))
+        self.controls = tiles
+        if self.page is not None:
+            self.update()
+
+    def _tile(self, number: int, png: bytes | None, row: dict[str, Any]) -> ft.Control:
+        unread = row.get("status") != "read"
+        face: ft.Control = (
+            ft.Image(
+                src_base64=base64.b64encode(png).decode(),
+                width=48,
+                height=64,
+                fit=ft.ImageFit.COVER,
+            )
+            if png
+            else SecondaryText(str(number), size=Theme.Typography.BODY_SMALL)
+        )
+        return ft.Container(
+            content=face,
+            width=48,
+            height=64,
+            alignment=ft.alignment.center,
+            border=ft.border.all(1, ft.Colors.OUTLINE_VARIANT),
+            border_radius=4,
+            opacity=0.45 if unread else 1.0,
+            tooltip=(row.get("detail") or f"Page {number}")
+            if unread
+            else f"Page {number}",
+            ink=True,
+            on_click=lambda _e, n=number, p=png: self._page.run_task(self._open, n, p),
+        )
+
+    async def _open(self, number: int, png: bytes | None) -> None:
+        """A page at full size with its text beside it."""
+        fetched = await self._api().get(f"{API}/{self._document_id}/pages/{number}")
+        detail: dict[str, Any] = fetched if isinstance(fetched, dict) else {}
+        text = detail.get("text")
+        dialog: StyledAlertDialog | None = None
+
+        async def _close() -> None:
+            if dialog is not None:
+                dialog.open = False
+                self._page.update()
+
+        image: ft.Control = (
+            ft.Image(src_base64=base64.b64encode(png).decode(), fit=ft.ImageFit.CONTAIN)
+            if png
+            else SecondaryText("No image for this page")
+        )
+        dialog = StyledAlertDialog(
+            title=f"Page {number}",
+            body=ft.Row(
+                [
+                    ft.Container(image, width=460, height=600),
+                    ft.Container(
+                        SecondaryText(
+                            text or detail.get("detail") or "Not read yet",
+                            selectable=True,
+                        ),
+                        width=380,
+                        height=600,
+                    ),
+                ],
+                spacing=Theme.Spacing.MD,
+                vertical_alignment=ft.CrossAxisAlignment.START,
+                scroll=ft.ScrollMode.AUTO,
+            ),
+            width=900,
+            on_close=_close,
+        )
+        self._page.open(dialog)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/client.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/client.py
@@ -203,6 +203,11 @@ class APIClient:
             "POST", endpoint, files=files, params=params, timeout=timeout
         )
 
+    async def get_bytes(self, endpoint: str) -> bytes | None:
+        """A binary body (a page image); the standard path, body undecoded."""
+        result = await self._request("GET", endpoint, raw=True)
+        return result if isinstance(result, bytes) else None
+
     async def put(
         self, endpoint: str, json: dict[str, Any] | None = None
     ) -> dict | list | None:
@@ -357,8 +362,9 @@ class APIClient:
         form_data: dict[str, str] | None = None,
         files: dict[str, tuple[str, bytes, str]] | None = None,
         timeout: float | None = None,
+        raw: bool = False,
         _retry_on_401: bool = True,
-    ) -> dict | list | None:
+    ) -> Any:
         if method == "GET":
             return await self._perform_request(
                 method,
@@ -368,6 +374,7 @@ class APIClient:
                 form_data=form_data,
                 files=files,
                 timeout=timeout,
+                raw=raw,
                 _retry_on_401=_retry_on_401,
             )
         try:
@@ -379,6 +386,7 @@ class APIClient:
                 form_data=form_data,
                 files=files,
                 timeout=timeout,
+                raw=raw,
                 _retry_on_401=_retry_on_401,
             )
         finally:
@@ -395,8 +403,9 @@ class APIClient:
         form_data: dict[str, str] | None = None,
         files: dict[str, tuple[str, bytes, str]] | None = None,
         timeout: float | None = None,
+        raw: bool = False,
         _retry_on_401: bool = True,
-    ) -> dict | list | None:
+    ) -> Any:
         url = f"{self.base_url}{endpoint}"
         headers: dict[str, str] = {}
         if form_data is not None:
@@ -421,7 +430,7 @@ class APIClient:
             self.last_error = None
             if response.status_code == 204:
                 return None
-            return response.json()
+            return response.content if raw else response.json()
         except httpx.TimeoutException:
             budget = timeout if timeout is not None else self.timeout
             self.last_error = f"{method} {endpoint} timed out after {budget:g}s"
@@ -451,6 +460,7 @@ class APIClient:
                         form_data=form_data,
                         files=files,
                         timeout=timeout,
+                        raw=raw,
                         _retry_on_401=False,
                     )
                 await self._emit_unauthorized()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/__init__.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/__init__.py
@@ -1,6 +1,17 @@
 """Document store: keep the paper, deduped and findable."""
 
-from app.services.documents.models import DOCUMENT_KINDS, Document, DocumentTag
+from app.services.documents.models import (
+    DOCUMENT_KINDS,
+    Document,
+    DocumentPage,
+    DocumentTag,
+)
 from app.services.documents.service import DocumentService
 
-__all__ = ["DOCUMENT_KINDS", "Document", "DocumentTag", "DocumentService"]
+__all__ = [
+    "DOCUMENT_KINDS",
+    "Document",
+    "DocumentPage",
+    "DocumentTag",
+    "DocumentService",
+]

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/extraction.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/extraction.py
@@ -1,0 +1,232 @@
+"""Reading a stored document once, per page, and keeping the result.
+
+Two read paths, one shape. A PDF page with a text layer is read for free;
+a page without one (a scan) is rendered and handed to a vision reader,
+which is the same model call the chat surface makes on a pasted
+screenshot. Either way the result is a ``DocumentPage`` row that names
+its method, so anything built on it later can say where it came from.
+
+A page is read exactly once. Re-running touches only pages still
+``unread`` and calls no model for the rest; ``force`` is the one way to
+spend model time again. What cannot be read is a row too, with the
+reason, never a silent blank.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.log import logger
+from app.core.storage import get_storage
+from app.services.documents.models import Document, DocumentPage, utcnow
+from app.services.documents.pdf import PNG_MEDIA_TYPE, PdfPages
+from app.services.documents.queries import document_by_id, pages_for
+
+# Reads one page image and returns (text, model name). None when the
+# stack has no vision model to offer.
+VisionReader = Callable[[bytes, str], Awaitable[tuple[str, str]]]
+Progress = Callable[[int, int], None]
+
+IMAGE_TYPES = frozenset({"image/png", "image/jpeg", "image/webp", "image/gif"})
+
+# ponytail: a scanned PDF often carries a junk text layer of a few glyphs
+# per page, so "has text" is a threshold, not a boolean. Raise it if
+# real scans slip through as text; lower it if short pages get sent to
+# the model needlessly.
+MIN_TEXT_CHARS = 10
+
+NO_VISION = "No vision model is available to read a page without a text layer."
+
+
+@dataclass
+class ExtractionResult:
+    read: int = 0
+    unread: int = 0
+    skipped: int = 0
+    pages: list[DocumentPage] = field(default_factory=list)
+
+    def as_dict(self) -> dict[str, int]:
+        return {"read": self.read, "unread": self.unread, "skipped": self.skipped}
+
+
+class DocumentNotFoundError(LookupError):
+    """No such document for this owner."""
+
+
+class DocumentContentMissingError(LookupError):
+    """The row exists but storage no longer holds its bytes."""
+
+
+async def extract_document(
+    db: AsyncSession,
+    document_id: int,
+    *,
+    owner_user_id: int | None = None,
+    vision: VisionReader | None,
+    force: bool = False,
+    progress: Progress | None = None,
+) -> ExtractionResult:
+    """Read every page not yet read (or every page, when forced)."""
+    document = await document_by_id(db, document_id, owner_user_id=owner_user_id)
+    if document is None:
+        raise DocumentNotFoundError(f"Document {document_id} not found")
+    data = await get_storage().get(document.storage_key)
+    if data is None:
+        raise DocumentContentMissingError(
+            f"Document {document_id} has no content in storage"
+        )
+
+    existing = {p.page_number: p for p in await pages_for(db, document_id)}
+    result = ExtractionResult()
+    media_type = (document.media_type or "").lower()
+    if media_type == "application/pdf":
+        await _extract_pdf(
+            db, document, document_id, data, existing, result, vision, force, progress
+        )
+    elif media_type in IMAGE_TYPES:
+        await _extract_image(db, document, document_id, existing, result, vision, force)
+    else:
+        await _unsupported(db, document, document_id, existing, result, force)
+    await db.flush()
+    return result
+
+
+async def _extract_pdf(
+    db: AsyncSession,
+    document: Document,
+    document_id: int,
+    data: bytes,
+    existing: dict[int, DocumentPage],
+    result: ExtractionResult,
+    vision: VisionReader | None,
+    force: bool,
+    progress: Progress | None,
+) -> None:
+    pdf = PdfPages(data)
+    try:
+        total = len(pdf)
+        if document.page_count != total:
+            document.page_count = total
+            db.add(document)
+        for number in range(1, total + 1):
+            page = existing.get(number)
+            if page is not None and page.status == "read" and not force:
+                result.skipped += 1
+                continue
+            page = page or DocumentPage(document_id=document_id, page_number=number)
+            if not page.image_key:
+                page.image_key = await get_storage().put(
+                    pdf.render_png(number), content_type=PNG_MEDIA_TYPE
+                )
+            text = pdf.text(number)
+            if len(text) >= MIN_TEXT_CHARS:
+                _mark_read(page, text, method="text_layer", model=None)
+            else:
+                await _read_with_vision(page, page.image_key, PNG_MEDIA_TYPE, vision)
+            _finish(db, page, result)
+            if progress is not None:
+                progress(number, total)
+    finally:
+        pdf.close()
+
+
+async def _extract_image(
+    db: AsyncSession,
+    document: Document,
+    document_id: int,
+    existing: dict[int, DocumentPage],
+    result: ExtractionResult,
+    vision: VisionReader | None,
+    force: bool,
+) -> None:
+    """An uploaded photo or screenshot is a one-page document whose
+    render is the image itself."""
+    page = existing.get(1)
+    if page is not None and page.status == "read" and not force:
+        result.skipped += 1
+        return
+    page = page or DocumentPage(document_id=document_id, page_number=1)
+    page.image_key = document.storage_key
+    if document.page_count != 1:
+        document.page_count = 1
+        db.add(document)
+    await _read_with_vision(page, page.image_key, document.media_type or "", vision)
+    _finish(db, page, result)
+
+
+async def _unsupported(
+    db: AsyncSession,
+    document: Document,
+    document_id: int,
+    existing: dict[int, DocumentPage],
+    result: ExtractionResult,
+    force: bool,
+) -> None:
+    page = existing.get(1)
+    if page is not None and not force:
+        result.skipped += 1
+        return
+    page = page or DocumentPage(document_id=document_id, page_number=1)
+    _mark_unread(
+        page,
+        f"Unsupported media type {document.media_type or 'unknown'}: only PDF and "
+        "images are read.",
+    )
+    _finish(db, page, result)
+
+
+async def _read_with_vision(
+    page: DocumentPage, image_key: str, media_type: str, vision: VisionReader | None
+) -> None:
+    if vision is None:
+        _mark_unread(page, NO_VISION)
+        return
+    image = await get_storage().get(image_key)
+    if image is None:
+        _mark_unread(page, "The page image is missing from storage.")
+        return
+    try:
+        text, model = await vision(image, media_type)
+    except Exception as exc:  # noqa: BLE001 - one bad page must not sink the run
+        logger.warning("documents.vision_failed", page=page.page_number, error=str(exc))
+        _mark_unread(page, f"Vision read failed: {exc}")
+        return
+    if not text.strip():
+        _mark_unread(page, f"{model} returned no text for this page.")
+        return
+    _mark_read(page, text.strip(), method="vision", model=model)
+
+
+def _mark_read(
+    page: DocumentPage, text: str, *, method: str, model: str | None
+) -> None:
+    page.status, page.method, page.text, page.model, page.detail = (
+        "read",
+        method,
+        text,
+        model,
+        None,
+    )
+
+
+def _mark_unread(page: DocumentPage, detail: str) -> None:
+    page.status, page.method, page.text, page.model, page.detail = (
+        "unread",
+        "none",
+        None,
+        None,
+        detail,
+    )
+
+
+def _finish(db: AsyncSession, page: DocumentPage, result: ExtractionResult) -> None:
+    page.updated_at = utcnow()
+    db.add(page)
+    result.pages.append(page)
+    if page.status == "read":
+        result.read += 1
+    else:
+        result.unread += 1

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/models.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/models.py
@@ -126,3 +126,33 @@ class DocumentTag(SQLModel, table=True):
     id: int | None = Field(default=None, primary_key=True)
     document_id: int = Field(foreign_key="document.id")
     label: str = Field(max_length=64)
+
+
+class DocumentPage(SQLModel, table=True):
+    """One page of a document as extraction read it.
+
+    ``method`` says how the text was obtained (the PDF's own text layer,
+    a vision model over the rendered page, or none), so any claim built
+    on it later can cite both the page and the way it was read. A page
+    that could not be read is a row with ``status='unread'`` and the
+    reason in ``detail``, never an absence.
+    """
+
+    __tablename__ = "document_page"
+    __table_args__ = (
+        Index("ix_document_page_document", "document_id"),
+        Index("uq_document_page", "document_id", "page_number", unique=True),
+    )
+
+    id: int | None = Field(default=None, primary_key=True)
+    document_id: int = Field(foreign_key="document.id")
+    page_number: int
+    status: str = Field(default="unread", max_length=16)
+    method: str = Field(default="none", max_length=16)
+    text: str | None = None
+    # The rendered page in object storage, what the thumbnail strip shows.
+    image_key: str | None = Field(default=None, max_length=128)
+    model: str | None = Field(default=None, max_length=128)
+    detail: str | None = None
+    created_at: datetime = Field(default_factory=utcnow)
+    updated_at: datetime | None = None

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/pdf.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/pdf.py
@@ -1,0 +1,87 @@
+"""The PDF engine behind extraction, and a PNG encoder for its pages.
+
+pypdfium2 (Google's PDFium) does both jobs this needs: the text layer
+where a PDF has one, and rendering a page to pixels where it does not.
+The import is lazy so the service boots in an image built before the
+dependency landed; only extraction itself needs it.
+
+The PNG encoder is the standard library: pypdfium2 hands back a raw
+RGBA bitmap and would otherwise need Pillow just to write it out.
+"""
+
+from __future__ import annotations
+
+import struct
+from typing import Any
+import zlib
+
+# Rendering scale over 72 dpi: 2.0 gives 144 dpi, enough for a vision
+# model to read body text and for a thumbnail to be crisp.
+RENDER_SCALE = 2.0
+
+PNG_MEDIA_TYPE = "image/png"
+
+
+class PdfPages:
+    """One opened PDF: how many pages, the text layer of each, a render."""
+
+    def __init__(self, data: bytes) -> None:
+        import pypdfium2 as pdfium  # lazy: see module docstring
+
+        self._doc = pdfium.PdfDocument(data)
+
+    def __len__(self) -> int:
+        return len(self._doc)
+
+    def text(self, page_number: int) -> str:
+        """The page's own text layer, blank for a scan."""
+        page = self._doc[page_number - 1]
+        try:
+            return page.get_textpage().get_text_range().strip()
+        finally:
+            page.close()
+
+    def render_png(self, page_number: int, *, scale: float = RENDER_SCALE) -> bytes:
+        page = self._doc[page_number - 1]
+        try:
+            bitmap: Any = page.render(scale=scale, rev_byteorder=True, prefer_bgrx=True)
+        finally:
+            page.close()
+        return encode_png(
+            bitmap.width,
+            bitmap.height,
+            bytes(bitmap.buffer),
+            bitmap.stride,
+            bitmap.n_channels,
+        )
+
+    def close(self) -> None:
+        self._doc.close()
+
+
+def encode_png(
+    width: int, height: int, pixels: bytes, stride: int, channels: int
+) -> bytes:
+    """A PNG from a packed RGB or RGBA buffer, no filtering, stdlib only."""
+    if channels not in (3, 4):
+        raise ValueError(
+            f"encode_png takes RGB or RGBA pixels, not {channels} channels"
+        )
+    row_bytes = width * channels
+    raw = bytearray()
+    for y in range(height):
+        start = y * stride
+        raw += b"\x00" + pixels[start : start + row_bytes]
+
+    def chunk(kind: bytes, payload: bytes) -> bytes:
+        crc = zlib.crc32(kind + payload) & 0xFFFFFFFF
+        return struct.pack(">I", len(payload)) + kind + payload + struct.pack(">I", crc)
+
+    color_type = 6 if channels == 4 else 2
+    header = struct.pack(">IIBBBBB", width, height, 8, color_type, 0, 0, 0)
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", header)
+        + chunk(b"IDAT", zlib.compress(bytes(raw), 6))
+        + chunk(b"IEND", b"")
+    )

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/queries.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/queries.py
@@ -10,7 +10,7 @@ from sqlalchemy import func
 from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
-from app.services.documents.models import Document, DocumentTag, utcnow
+from app.services.documents.models import Document, DocumentPage, DocumentTag, utcnow
 
 
 async def document_by_content(
@@ -175,3 +175,28 @@ async def tags_for(db: AsyncSession, document_id: int) -> list[str]:
         )
     ).all()
     return [row.label for row in rows]
+
+
+async def pages_for(db: AsyncSession, document_id: int) -> list[DocumentPage]:
+    """Every extracted page of a document, in page order."""
+    rows = (
+        await db.exec(
+            select(DocumentPage)
+            .where(DocumentPage.document_id == document_id)
+            .order_by(DocumentPage.page_number)
+        )
+    ).all()
+    return list(rows)
+
+
+async def page_for(
+    db: AsyncSession, document_id: int, page_number: int
+) -> DocumentPage | None:
+    return (
+        await db.exec(
+            select(DocumentPage).where(
+                DocumentPage.document_id == document_id,
+                DocumentPage.page_number == page_number,
+            )
+        )
+    ).first()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/vision.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/documents/vision.py.jinja
@@ -1,0 +1,65 @@
+{%- if include_ai and ai_framework == "pydantic-ai" %}
+"""The vision reader extraction hands a rendered page to.
+
+The same model the chat surface reads a pasted screenshot with, called
+headlessly: a page image in, its transcription out. Usage is recorded
+under its own surface so the cost of reading paper is visible.
+"""
+
+from __future__ import annotations
+
+from app.core.config import settings
+from app.services.ai.config import AIServiceConfig
+from app.services.ai.domains.llm.providers import ProviderError, model_for
+from app.services.ai.usage_recording import extract_usage, record_usage
+from app.services.documents.extraction import VisionReader
+
+SURFACE = "documents:extract"
+INSTRUCTIONS = (
+    "You transcribe one page of a scanned document. Return the page's text "
+    "faithfully in reading order, keeping headings, labels, amounts, dates "
+    "and account numbers exactly as printed. Render tables one row per "
+    "line with cells separated by ' | '. Do not summarize, interpret, or add "
+    "anything that is not on the page."
+)
+
+
+async def read_page(image: bytes, media_type: str) -> tuple[str, str]:
+    """Transcribe one page image; returns (text, model name)."""
+    from pydantic_ai import Agent as PydanticAgent
+    from pydantic_ai.messages import BinaryContent
+
+    model, model_name = model_for(AIServiceConfig.from_settings(settings), settings)
+    agent: PydanticAgent[None, str] = PydanticAgent(model, instructions=INSTRUCTIONS)
+    result = await agent.run(
+        ["Transcribe this page.", BinaryContent(data=image, media_type=media_type)]
+    )
+    record_usage(
+        action=SURFACE, model_name=model_name, usage=extract_usage(result), user_id=None
+    )
+    return str(result.output), model_name
+
+
+def vision_reader() -> VisionReader | None:
+    """The reader, or None when the configured provider cannot hand out
+    a bare model (the keyless public endpoints build their own client)."""
+    try:
+        model_for(AIServiceConfig.from_settings(settings), settings)
+    except ProviderError:
+        return None
+    return read_page
+{%- else %}
+"""No vision reader in this stack: scans stay unread with a reason.
+
+The AI service with the pydantic-ai framework supplies one; without it,
+extraction still reads every text layer and records the rest as unread.
+"""
+
+from __future__ import annotations
+
+from app.services.documents.extraction import VisionReader
+
+
+def vision_reader() -> VisionReader | None:
+    return None
+{%- endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
@@ -82,6 +82,11 @@ dependencies = [
 {%- if include_auth or include_payment or include_insights or include_blog or include_documents or include_finance or (include_ai and ai_backend in ["sqlite", "postgres"]) or (include_scheduler and scheduler_backend == "postgres") %}
     "alembic==1.16.5",
 {%- endif %}
+{%- if include_documents %}
+{#- PDFium: the text layer and page rendering behind document extraction.
+    Binary wheels, no system packages; the PNG encoder is the stdlib. #}
+    "pypdfium2>=5.0,<6",
+{%- endif %}
 {%- if include_ai %}
 {%- if ai_framework == "pydantic-ai" %}
 {# Map provider names to pydantic-ai-slim extras. Every provider routed

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/_pdf.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/_pdf.py
@@ -1,0 +1,45 @@
+"""Hand-built PDFs for tests: one page per entry, blank where the text is empty.
+
+Generated rather than checked in, so the suite carries no binary fixtures
+and a "scan" (a page with no text layer) is just an empty string.
+"""
+
+
+def pdf_bytes(texts: list[str]) -> bytes:
+    pages = [(3 + 2 * i, 4 + 2 * i) for i in range(len(texts))]
+    font = 3 + 2 * len(texts)
+    body = b"%PDF-1.4\n"
+    offsets: list[int] = []
+
+    def add(obj: bytes) -> None:
+        nonlocal body
+        offsets.append(len(body))
+        body += obj
+
+    kids = " ".join(f"{p} 0 R" for p, _ in pages)
+    add(b"1 0 obj << /Type /Catalog /Pages 2 0 R >> endobj\n")
+    add(
+        f"2 0 obj << /Type /Pages /Kids [{kids}] /Count {len(pages)} >> endobj\n".encode()
+    )
+    for (page, content), text in zip(pages, texts, strict=True):
+        stream = f"BT /F1 24 Tf 72 700 Td ({text}) Tj ET".encode() if text else b""
+        add(
+            f"{page} 0 obj << /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+            f"/Contents {content} 0 R /Resources << /Font << /F1 {font} 0 R >> >> >> "
+            "endobj\n".encode()
+        )
+        add(
+            f"{content} 0 obj << /Length {len(stream)} >> stream\n".encode()
+            + stream
+            + b"\nendstream endobj\n"
+        )
+    add(
+        f"{font} 0 obj << /Type /Font /Subtype /Type1 /BaseFont /Helvetica >> endobj\n".encode()
+    )
+    xref = len(body)
+    body += f"xref\n0 {font + 1}\n0000000000 65535 f \n".encode()
+    body += b"".join(f"{o:010d} 00000 n \n".encode() for o in offsets)
+    body += (
+        f"trailer << /Size {font + 1} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF".encode()
+    )
+    return body

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_document_pages.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_document_pages.py
@@ -1,0 +1,88 @@
+"""The extraction surface: kick it off, then read pages back."""
+
+from fastapi.testclient import TestClient
+import pytest
+
+from app.components.backend.api.documents import pages
+from app.core.storage import FilesystemStorage, set_storage
+from tests._pdf import pdf_bytes
+
+
+@pytest.fixture(autouse=True)
+def _storage(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    set_storage(FilesystemStorage(tmp_path))
+    # No model in the test process: scans come back unread, deterministically.
+    monkeypatch.setattr(pages, "vision_reader", lambda: None)
+    yield
+    set_storage(None)
+
+
+def _upload(client: TestClient, texts: list[str], title: str) -> int:
+    # The title rides in the text so two tests never dedupe onto one row.
+    texts = [f"{text} for {title}" if text else "" for text in texts]
+    created = client.post(
+        "/api/v1/documents",
+        files={"file": (f"{title}.pdf", pdf_bytes(texts), "application/pdf")},
+        data={"title": title, "kind": "letter"},
+    )
+    assert created.status_code in (200, 201)
+    return int(created.json()["id"])
+
+
+class TestExtraction:
+    def test_extract_reads_the_text_layer_and_reports(self, client: TestClient) -> None:
+        doc_id = _upload(
+            client, ["Renewal request received", "Page two of the same"], "Renewal"
+        )
+
+        response = client.post(f"/api/v1/documents/{doc_id}/extract")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["read"] == 2 and body["unread"] == 0
+
+    def test_pages_list_carries_status_not_text(self, client: TestClient) -> None:
+        doc_id = _upload(client, ["Alpha page with text", ""], "Mixed")
+        client.post(f"/api/v1/documents/{doc_id}/extract")
+
+        pages = client.get(f"/api/v1/documents/{doc_id}/pages").json()
+
+        assert [p["page_number"] for p in pages] == [1, 2]
+        assert pages[0]["status"] == "read" and pages[1]["status"] == "unread"
+        assert "text" not in pages[0]
+        assert pages[0]["has_image"] is True
+
+    def test_one_page_carries_its_text_and_image(self, client: TestClient) -> None:
+        doc_id = _upload(client, ["Alpha page with text"], "Single")
+        client.post(f"/api/v1/documents/{doc_id}/extract")
+
+        page = client.get(f"/api/v1/documents/{doc_id}/pages/1")
+        image = client.get(f"/api/v1/documents/{doc_id}/pages/1/image")
+
+        assert page.status_code == 200 and "Alpha" in page.json()["text"]
+        assert image.status_code == 200
+        assert image.headers["content-type"] == "image/png"
+        assert image.content[:8] == b"\x89PNG\r\n\x1a\n"
+
+    def test_a_missing_page_is_a_404(self, client: TestClient) -> None:
+        doc_id = _upload(client, ["Alpha page with text"], "Short")
+        client.post(f"/api/v1/documents/{doc_id}/extract")
+
+        assert client.get(f"/api/v1/documents/{doc_id}/pages/7").status_code == 404
+
+    def test_background_returns_a_job(self, client: TestClient) -> None:
+        doc_id = _upload(client, ["Alpha page with text"], "Job")
+
+        response = client.post(f"/api/v1/documents/{doc_id}/extract?background=true")
+
+        assert response.status_code == 202
+        job_id = response.json()["job_id"]
+        # Drive the job to its end here: the runner's task only advances
+        # while the test client is inside a request, and a job left
+        # running would hold the shared test database into the next test.
+        for _ in range(50):
+            body = client.get(f"/api/v1/jobs/{job_id}").json()
+            if body["status"] != "running":
+                break
+        assert body["status"] == "done", body
+        assert body["result"]["read"] == 1

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_documents_ui.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_documents_ui.py
@@ -12,6 +12,9 @@ from app.components.frontend.dashboard.modals.documents_modal import (
     display_date,
     matching_documents,
 )
+from app.components.frontend.dashboard.modals.documents_pages import (
+    extraction_summary,
+)
 from app.services.documents.health import DOCUMENTS_MODAL_ID
 from app.services.system.models import ComponentStatus, ComponentStatusType
 from tests.components.frontend._tree import texts
@@ -66,6 +69,21 @@ def test_replaces_options_offer_every_other_document_and_nothing() -> None:
 
     options = replaces_options(docs, current_id=2)
 
-    assert options[0] == ("", "Nothing")
+    assert options[0] == ("none", "Nothing")
     assert [label for _, label in options[1:]] == ["POA draft", "Statement"]
     assert all(key != "2" for key, _ in options)
+
+
+def test_extraction_summary_reads_like_a_sentence() -> None:
+    assert extraction_summary({"read": 7, "unread": 0, "skipped": 0}) == "7 pages read"
+    assert (
+        extraction_summary({"read": 5, "unread": 2, "skipped": 0}) == "5 read, 2 unread"
+    )
+    assert extraction_summary({"read": 0, "unread": 0, "skipped": 3}) == "Already read"
+
+
+def test_placeholders_save_as_no_value() -> None:
+    from app.components.frontend.dashboard.modals.documents_detail_pane import _chosen
+
+    assert _chosen("none") is None and _chosen("") is None and _chosen(None) is None
+    assert _chosen("mail") == "mail"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_document_extraction.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_document_extraction.py
@@ -1,0 +1,214 @@
+"""Reading a stored document once, per page, and keeping the result.
+
+The property under test: a page is read exactly once. Text layers are
+read for free; scans go to a vision reader; a re-run touches nothing and
+calls no model unless forced; what cannot be read is recorded as unread,
+with the reason, never as an empty string.
+"""
+
+import pytest
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.core.storage import FilesystemStorage, get_storage, set_storage
+from app.services.documents import DocumentService
+from app.services.documents.extraction import extract_document
+from app.services.documents.queries import pages_for
+from tests._pdf import pdf_bytes
+
+
+@pytest.fixture
+def svc(async_db_session: AsyncSession, tmp_path):
+    set_storage(FilesystemStorage(tmp_path))
+    yield DocumentService(async_db_session)
+    set_storage(None)
+
+
+class FakeVision:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def __call__(self, image: bytes, media_type: str) -> tuple[str, str]:
+        self.calls += 1
+        assert image[:8] == b"\x89PNG\r\n\x1a\n" or media_type != "image/png"
+        return f"transcribed page {self.calls}", "fake-vision"
+
+
+class TestTextLayer:
+    @pytest.mark.asyncio
+    async def test_pages_with_text_are_read_without_a_model(self, svc) -> None:
+        doc = await svc.ingest(
+            pdf_bytes(["Hello renewal request", "Second page of the letter"]),
+            title="Letter",
+            media_type="application/pdf",
+            owner_user_id=1,
+        )
+        vision = FakeVision()
+
+        result = await extract_document(svc.db, doc.id, owner_user_id=1, vision=vision)
+
+        assert (result.read, result.unread) == (2, 0)
+        assert vision.calls == 0
+        pages = await pages_for(svc.db, doc.id)
+        assert [p.page_number for p in pages] == [1, 2]
+        assert all(p.method == "text_layer" and p.status == "read" for p in pages)
+        assert "Hello renewal" in (pages[0].text or "")
+        assert (await svc.get(doc.id, owner_user_id=1)).page_count == 2
+
+    @pytest.mark.asyncio
+    async def test_every_page_gets_a_stored_image_for_the_strip(self, svc) -> None:
+        doc = await svc.ingest(
+            pdf_bytes(["The only page of this one"]),
+            title="L",
+            media_type="application/pdf",
+            owner_user_id=1,
+        )
+
+        await extract_document(svc.db, doc.id, owner_user_id=1, vision=None)
+
+        (page,) = await pages_for(svc.db, doc.id)
+        assert page.image_key
+        png = await get_storage().get(page.image_key)
+        assert png is not None and png[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+class TestScans:
+    @pytest.mark.asyncio
+    async def test_blank_text_layers_go_to_vision(self, svc) -> None:
+        doc = await svc.ingest(
+            pdf_bytes(["", ""]),
+            title="Scan",
+            media_type="application/pdf",
+            owner_user_id=1,
+        )
+        vision = FakeVision()
+
+        result = await extract_document(svc.db, doc.id, owner_user_id=1, vision=vision)
+
+        assert (result.read, result.unread) == (2, 0)
+        assert vision.calls == 2
+        pages = await pages_for(svc.db, doc.id)
+        assert all(p.method == "vision" and p.model == "fake-vision" for p in pages)
+        assert pages[1].text == "transcribed page 2"
+
+    @pytest.mark.asyncio
+    async def test_a_rerun_reads_nothing_and_calls_no_model(self, svc) -> None:
+        doc = await svc.ingest(
+            pdf_bytes([""]), title="Scan", media_type="application/pdf", owner_user_id=1
+        )
+        vision = FakeVision()
+        await extract_document(svc.db, doc.id, owner_user_id=1, vision=vision)
+
+        again = await extract_document(svc.db, doc.id, owner_user_id=1, vision=vision)
+
+        assert vision.calls == 1
+        assert (again.read, again.unread, again.skipped) == (0, 0, 1)
+
+    @pytest.mark.asyncio
+    async def test_force_reads_again(self, svc) -> None:
+        doc = await svc.ingest(
+            pdf_bytes([""]), title="Scan", media_type="application/pdf", owner_user_id=1
+        )
+        vision = FakeVision()
+        await extract_document(svc.db, doc.id, owner_user_id=1, vision=vision)
+
+        await extract_document(
+            svc.db, doc.id, owner_user_id=1, vision=vision, force=True
+        )
+
+        assert vision.calls == 2
+        (page,) = await pages_for(svc.db, doc.id)
+        assert page.text == "transcribed page 2"
+
+    @pytest.mark.asyncio
+    async def test_without_a_vision_reader_a_scan_is_unread_with_a_reason(
+        self, svc
+    ) -> None:
+        doc = await svc.ingest(
+            pdf_bytes([""]), title="Scan", media_type="application/pdf", owner_user_id=1
+        )
+
+        result = await extract_document(svc.db, doc.id, owner_user_id=1, vision=None)
+
+        assert (result.read, result.unread) == (0, 1)
+        (page,) = await pages_for(svc.db, doc.id)
+        assert page.status == "unread" and page.method == "none"
+        assert page.text is None
+        assert "vision" in (page.detail or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_a_rerun_retries_only_the_unread_pages(self, svc) -> None:
+        doc = await svc.ingest(
+            pdf_bytes(["A page with a text layer", ""]),
+            title="Mixed",
+            media_type="application/pdf",
+            owner_user_id=1,
+        )
+        await extract_document(svc.db, doc.id, owner_user_id=1, vision=None)
+        vision = FakeVision()
+
+        result = await extract_document(svc.db, doc.id, owner_user_id=1, vision=vision)
+
+        assert vision.calls == 1
+        assert (result.read, result.skipped) == (1, 1)
+
+
+class TestFailures:
+    @pytest.mark.asyncio
+    async def test_a_model_error_leaves_the_page_unread_with_the_reason(
+        self, svc
+    ) -> None:
+        async def broken(image: bytes, media_type: str) -> tuple[str, str]:
+            raise RuntimeError("model 'llama3.2:3b' not found")
+
+        doc = await svc.ingest(
+            pdf_bytes(["", "A second page with real text on it"]),
+            title="Scan",
+            media_type="application/pdf",
+            owner_user_id=1,
+        )
+
+        result = await extract_document(svc.db, doc.id, owner_user_id=1, vision=broken)
+
+        assert (result.read, result.unread) == (1, 1)
+        pages = await pages_for(svc.db, doc.id)
+        assert pages[0].status == "unread" and "not found" in (pages[0].detail or "")
+        assert pages[1].status == "read"
+
+
+class TestPng:
+    def test_only_rgb_and_rgba_buffers_are_encoded(self) -> None:
+        from app.services.documents.pdf import encode_png
+
+        assert encode_png(1, 1, b"\x00\x00\x00\xff", 4, 4)[:8] == b"\x89PNG\r\n\x1a\n"
+        with pytest.raises(ValueError, match="channels"):
+            encode_png(1, 1, b"\x00", 1, 1)
+
+
+class TestOtherMedia:
+    @pytest.mark.asyncio
+    async def test_an_image_document_is_one_page_read_by_vision(self, svc) -> None:
+        png = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+        doc = await svc.ingest(
+            png, title="Photo", media_type="image/png", owner_user_id=1
+        )
+        vision = FakeVision()
+
+        result = await extract_document(svc.db, doc.id, owner_user_id=1, vision=vision)
+
+        assert (result.read, result.unread) == (1, 0)
+        (page,) = await pages_for(svc.db, doc.id)
+        assert page.method == "vision" and page.image_key == doc.storage_key
+
+    @pytest.mark.asyncio
+    async def test_an_unsupported_type_is_one_unread_page(self, svc) -> None:
+        doc = await svc.ingest(
+            b"hello", title="Note", media_type="text/plain", owner_user_id=1
+        )
+
+        result = await extract_document(
+            svc.db, doc.id, owner_user_id=1, vision=FakeVision()
+        )
+
+        assert (result.read, result.unread) == (0, 1)
+        (page,) = await pages_for(svc.db, doc.id)
+        assert "unsupported" in (page.detail or "").lower()

--- a/tests/core/test_migration_generator.py
+++ b/tests/core/test_migration_generator.py
@@ -515,6 +515,9 @@ class TestGenerateMigration:
         assert "'supersedes_id'" in content
         assert "'protected'" in content
         assert "'channel'" in content
+        # SF-05: the per-page readings table rides the same migration.
+        assert "'document_page'" in content
+        assert "uq_document_page" in content
 
     def test_creates_versions_directory(self, tmp_path: Path) -> None:
         """Test creates versions directory if it doesn't exist."""


### PR DESCRIPTION
SF-05 #1001. Extraction over a stored document: page-addressed readings, stored once, so no later consumer re-reads the pixels and every claim can cite its page.

## Decisions

**One library, pypdfium2.** Google's PDF engine, permissive license, binary wheels, no system packages. It does both jobs: the text layer where a PDF has one, and rendering a page to pixels where it does not. The PNG encoder is the standard library; pypdfium2 would otherwise pull Pillow in only to write a file out, and nothing in any stack uses Pillow today. Kreuzberg (#569) stays the answer for table structure and non-PDF inputs, if either turns out to matter on real paper.

**Scans go through the existing vision path.** The same model the chat surface reads a pasted screenshot with, called headlessly on a rendered page, usage recorded under `documents:extract`. Stacks without the AI service, or on a provider that cannot hand out a bare model, still read every text layer and record scans as unread with the reason.

**Runs as a job, not on the scheduler.** `POST /documents/{id}/extract` is synchronous by default and a background job with `?background=true`, the same shape file imports use, so a 40-page statement streams "page 12 of 40" over the jobs SSE endpoint. Extraction happens because someone asked; the button is the trigger. Extract-on-upload can become a setting once the cost per page is known.

## Data

`document_page`: document, page number, status (read, unread), method (text_layer, vision, none), text, image key, model, and a reason when unread. A page is read exactly once: a re-run touches only unread pages and calls no model for the rest; `force` is the one way to spend model time again. A vision failure marks its page unread with the error and the run continues.

Page images ride the storage seam like any other bytes, so SF-06 changes nothing here.

## API

`POST /{id}/extract`, `GET /{id}/pages` (status per page, no text), `GET /{id}/pages/{n}` (with text), `GET /{id}/pages/{n}/image`. Owner-scoped like the rest.

## Pane

An Extract button with job progress, then a page strip: thumbnails from the stored renders, a page at full size with its text beside it, unread pages dimmed with their reason on hover. This is where SF-04's deferred thumbnails land.

## Migrations

The squashed documents migration carries the table for fresh stacks. The dev stack moved forward with an incremental 008 on reload. The container needs a rebuild to pick up pypdfium2; the import is lazy so the app boots without it and only extraction waits.

## Tests

PDFs are generated in the tests by a small hand-rolled builder (one page per string, blank for a scan), so nothing binary is checked in. Service: text layer without a model, scans through a fake vision reader, re-run is a no-op and the fake is never called, force re-reads, no reader means unread with a reason, a failing model leaves one page unread and the rest read, images are one page, unsupported types are one unread page. API: extract counts, pages list carries status not text, one page carries text and a PNG, missing page 404, background job driven to done. Migration generator asserts the table.

Documents-only and everything stack validations pass.

Closes #1001
