### PR TITLE
Storage follow-ups from the first live run

### DIFF
--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/modal_sections.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/modal_sections.py
@@ -346,7 +346,7 @@ class StatRowsSection(ft.Container):
     def __init__(
         self,
         title: str,
-        stats: dict[str, str],
+        stats: dict[str, str | ft.Control],
         label_width: int = 150,
     ) -> None:
         """
@@ -369,7 +369,7 @@ class StatRowsSection(ft.Container):
                             weight=Theme.Typography.WEIGHT_SEMIBOLD,
                             width=label_width,
                         ),
-                        BodyText(value),
+                        value if isinstance(value, ft.Control) else BodyText(value),
                     ],
                     spacing=Theme.Spacing.MD,
                 )

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/storage_modal.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/modals/storage_modal.py
@@ -1,39 +1,92 @@
-"""Storage component detail modal: the bucket as the app sees it."""
+"""Storage component detail modal: the bucket as the app sees it.
+
+Same shape as the other component modals: a row of metric cards for the
+numbers that matter at a glance, then the connection details as labeled
+rows. Nothing here talks to the store; it renders what the health check
+already gathered.
+"""
 
 import flet as ft
 
+from app.components.frontend.theme import AegisTheme as Theme
 from app.core.formatting import format_bytes
-from app.services.system.models import ComponentStatus
+from app.services.system.models import ComponentStatus, ComponentStatusType
 from app.services.system.ui import get_component_subtitle, get_component_title
 
 from ..cards.card_utils import get_status_detail
 from .base_detail_popup import BaseDetailPopup
-from .modal_sections import InfoCard, SectionHeader
+from .modal_sections import MetricCard, StatRowsSection, status_dot
+
+
+class OverviewSection(ft.Container):
+    """Backend, bucket and how much it holds, at a glance."""
+
+    def __init__(self, component_data: ComponentStatus) -> None:
+        super().__init__()
+        self.padding = Theme.Spacing.MD
+        metadata = component_data.metadata or {}
+        reachable = component_data.status == ComponentStatusType.HEALTHY
+        cards: list[ft.Control] = [
+            MetricCard(
+                "Backend",
+                str(metadata.get("backend") or "-"),
+                Theme.Colors.INFO,
+            ),
+            MetricCard(
+                "Bucket",
+                str(metadata.get("bucket") or "-"),
+                Theme.Colors.SUCCESS if reachable else Theme.Colors.ERROR,
+            ),
+        ]
+        if "objects" in metadata:
+            cards.append(
+                MetricCard(
+                    "Objects",
+                    str(metadata.get("objects", 0)),
+                    Theme.Colors.INFO,
+                )
+            )
+            cards.append(
+                MetricCard(
+                    "Stored",
+                    format_bytes(int(metadata.get("bytes") or 0)),
+                    Theme.Colors.INFO,
+                )
+            )
+        self.content = ft.Row(cards, spacing=Theme.Spacing.MD)
 
 
 class StorageDetailDialog(BaseDetailPopup):
-    """Where objects live, how the app reaches them, and how many there are."""
+    """Where objects live and how the app reaches them."""
 
     def __init__(self, component_data: ComponentStatus, page: ft.Page) -> None:
         metadata = component_data.metadata or {}
-        cards: list[ft.Control] = [
-            InfoCard("Backend", str(metadata.get("backend") or "-")),
-            InfoCard("Endpoint", str(metadata.get("endpoint") or "-")),
-            InfoCard("Bucket", str(metadata.get("bucket") or "-")),
-            InfoCard("Region", str(metadata.get("region") or "-")),
-        ]
-        if "objects" in metadata:
-            cards.append(InfoCard("Objects", str(metadata.get("objects", 0))))
-            cards.append(InfoCard("Stored", format_bytes(int(metadata.get("bytes") or 0))))
-        sections: list[ft.Control] = [
-            SectionHeader("Connection"),
-            ft.Row(cards, wrap=True, spacing=12, run_spacing=12),
-        ]
+        connection = StatRowsSection(
+            "Connection",
+            {
+                "Endpoint": str(metadata.get("endpoint") or "AWS S3"),
+                "Bucket": str(metadata.get("bucket") or "-"),
+                "Region": str(metadata.get("region") or "-"),
+                "Status": status_dot(
+                    component_data.message,
+                    Theme.Colors.ACCENT
+                    if component_data.status == ComponentStatusType.HEALTHY
+                    else Theme.Colors.ERROR,
+                    str(metadata.get("endpoint") or ""),
+                ),
+            },
+        )
         super().__init__(
             page=page,
             component_data=component_data,
             title_text=get_component_title("storage"),
             subtitle_text=get_component_subtitle("storage", metadata),
-            sections=sections,
+            sections=[
+                OverviewSection(component_data),
+                ft.Divider(height=1, color=ft.Colors.OUTLINE_VARIANT),
+                connection,
+            ],
+            width=900,
+            height=520,
             status_detail=get_status_detail(component_data),
         )

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/storage/s3.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/storage/s3.py
@@ -94,9 +94,11 @@ class S3Storage:
         )
 
     async def reachable(self) -> bool:
-        """One HEAD on the bucket: the health check's whole question."""
+        """Can we reach the bucket? A bucket that does not exist yet is
+        created here, the same as on first put: an empty store is healthy,
+        not unreachable."""
         try:
-            await asyncio.to_thread(self._client.head_bucket, Bucket=self.bucket)
+            await asyncio.to_thread(self._ensure_bucket)
         except Exception:  # noqa: BLE001 - any failure is "not reachable"
             return False
         return True

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_storage_s3.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_storage_s3.py
@@ -106,6 +106,13 @@ class TestS3Storage:
         assert asyncio.run(store.delete(key)) is True
         assert asyncio.run(store.exists(key)) is False
 
+    def test_an_empty_store_is_reachable_and_gets_its_bucket(self, store) -> None:
+        """Before the first upload there is no bucket; that is not an outage."""
+        assert asyncio.run(store.reachable()) is True
+        # The bucket itself now answers a HEAD; an object in it still does not.
+        store._client.head_bucket(Bucket=store.bucket)
+        assert asyncio.run(store.exists(content_key(b"anything"))) is False
+
     def test_a_presigned_url_names_the_key(self, store) -> None:
         key = asyncio.run(store.put(b"shareable"))
 


### PR DESCRIPTION
Two things the first run on the dev stack showed, after #1025.

**An empty bucket read as unreachable.** The health check did a bare `HeadBucket`, and until the first upload there is no bucket, so a freshly added component showed UNHEALTHY with "not reachable" while SeaweedFS was up and answering. The check now ensures the bucket the same way first put does; an empty store is healthy. Test added.

**The modal painted one blank block.** `InfoCard` expands to share a row, and I had put the cards in a wrapping row, which gives them no width to share. Plain rows now, four to a line.

Also exercised for real: the twelve existing objects were copied from the filesystem into the SeaweedFS bucket under their content keys, and downloads and page images serve from the bucket unchanged.
