### PR TITLE
Point the add-service ai tests at the tables and files that exist

### DIFF
--- a/docs/services/ai/llm-catalog.md
+++ b/docs/services/ai/llm-catalog.md
@@ -308,19 +308,35 @@ Current active LLM configuration enriched with catalog data.
 
 ## Database Schema
 
-The catalog uses five tables:
+### LLMOrg
 
-### LLMVendor
+An organization in the model economy. One table, because a maker and a
+server are one kind of thing wearing different hats: OpenAI both builds
+weights and serves them, Meta builds and serves nothing, DeepInfra serves
+and builds nothing. Modelling those as separate tables duplicated every
+org that does both.
 
 | Column | Type | Description |
 |--------|------|-------------|
-| `name` | string, unique | Vendor name (e.g., "OpenAI") |
-| `description` | string | Vendor description |
+| `slug` | string, unique | Stable identifier (`meta-models`, `fireworks`) |
+| `name` | string, indexed | Display name (e.g., "OpenAI") |
+| `description` | string | Org description |
+| `homepage` | string | Where to read more |
 | `color` | string | UI color code |
-| `api_base` | string | API base URL |
+| `api_base` | string | API base URL; null for an org that only publishes weights |
 | `auth_method` | string | Authentication method |
 
-20+ vendors pre-configured with metadata (OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, etc.).
+20+ orgs pre-configured with metadata (OpenAI, Anthropic, Google, Groq, Mistral, DeepSeek, xAI, etc.).
+
+### LLMOrgRole
+
+Which hats an org wears. An org that both builds and serves has two rows,
+which is the whole reason this is a link table.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `org_id` | FK | The org, cascading on delete |
+| `role` | string | `maker` or `server`; unique per `(org_id, role)` |
 
 ### LargeLanguageModel
 
@@ -333,7 +349,8 @@ The catalog uses five tables:
 | `enabled` | boolean | Available for use |
 | `released_on` | string | Release date |
 | `family` | string | Model family |
-| `llm_vendor_id` | FK | Reference to vendor |
+| `served_by_org_id` | FK | The org serving this model |
+| `made_by_org_id` | FK | The org that built it |
 
 ### LLMModality
 

--- a/tests/cli/test_add_service_migrations.py
+++ b/tests/cli/test_add_service_migrations.py
@@ -123,9 +123,9 @@ class TestAddServiceSeedsAgents:
         assert db_path.exists(), "add-service should have created the database"
         with sqlite3.connect(db_path) as conn:
             agents = conn.execute("SELECT slug FROM agent").fetchall()
-            vendors = conn.execute("SELECT COUNT(*) FROM llm_vendor").fetchone()
+            orgs = conn.execute("SELECT COUNT(*) FROM llm_org").fetchone()
         assert ("assistant",) in agents, "default agent should be seeded"
-        assert vendors[0] > 0, "LLM catalog should be seeded"
+        assert orgs[0] > 0, "LLM catalog should be seeded"
 
 
 class TestAddServiceNoMigrationNeeded:
@@ -207,22 +207,25 @@ class TestAddServiceSharedFileReRendering:
     """Test that add-service re-renders shared template files."""
 
     @pytest.mark.slow
-    def test_add_ai_service_updates_card_utils(
+    def test_add_ai_service_updates_the_modal_registry(
         self, project_factory: ProjectFactory
     ) -> None:
-        """Test that adding AI service updates card_utils.py with AI modal mapping."""
+        """The dashboard has to know how to open the modal a new service
+        brought with it. The map lives in ``modal_registry.py``, a shared
+        file gated on ``include_ai`` - if the add path does not re-render
+        it, the card is there and clicking it does nothing."""
         # Get cached base project copy
         project_path = project_factory("base")
 
-        card_utils_path = (
-            project_path / "app/components/frontend/dashboard/cards/card_utils.py"
+        registry_path = (
+            project_path / "app/components/frontend/dashboard/modal_registry.py"
         )
 
         # Verify base project doesn't have AI in modal_map
-        assert card_utils_path.exists(), "card_utils.py should exist"
-        base_content = card_utils_path.read_text()
+        assert registry_path.exists(), "modal_registry.py should exist"
+        base_content = registry_path.read_text()
         assert "AIDetailDialog" not in base_content, (
-            "Base project should not have AIDetailDialog in card_utils.py"
+            "Base project should not have AIDetailDialog in modal_registry.py"
         )
 
         # Add ai service with bracket syntax to skip interactive prompts
@@ -236,13 +239,13 @@ class TestAddServiceSharedFileReRendering:
         )
         assert result.returncode == 0, f"Add-service failed: {result.stderr}"
 
-        # Verify card_utils.py now has AI modal mapping
-        updated_content = card_utils_path.read_text()
+        # Verify modal_registry.py now has AI modal mapping
+        updated_content = registry_path.read_text()
         assert "AIDetailDialog" in updated_content, (
-            "card_utils.py should have AIDetailDialog after add-service ai"
+            "modal_registry.py should have AIDetailDialog after add-service ai"
         )
-        assert '"ai": AIDetailDialog' in updated_content, (
-            "modal_map should include 'ai': AIDetailDialog"
+        assert '"service_ai": AIDetailDialog' in updated_content, (
+            "modal_map should include 'service_ai': AIDetailDialog"
         )
 
 


### PR DESCRIPTION
Closes #1047.

Both failures on `main` turned out to be the tests, not the add path. Each named something a merged refactor had renamed, and neither was noticed because CI runs `-m "not slow"` and both are `@pytest.mark.slow`.

| Test | Named | Now called |
|---|---|---|
| `test_add_ai_seeds_default_agent` | `llm_vendor` table | `llm_org` (an org wears maker/server roles rather than being one or the other) |
| `test_add_ai_service_updates_card_utils` | `card_utils.py`, key `"ai"` | `modal_registry.py`, key `"service_ai"` |

Pointed at what exists, both pass: `add-service ai` on an existing project seeds the catalog and teaches the dashboard the new modal. The add path was working the whole time.

The same rename had also left `docs/services/ai/llm-catalog.md` describing an `LLMVendor` table with an `llm_vendor_id` foreign key. That section now describes `LLMOrg` and `LLMOrgRole`, and the `served_by_org_id` / `made_by_org_id` columns a model actually carries.

## Worth a follow-up

The add-service suite does not run in CI. That is why two tests could sit red on `main` across several merges. Making them a scheduled or pre-release job would catch the next rename at the time it happens rather than weeks later; happy to file that separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0186vU37JizSSuJepPDNjWF3