### PR TITLE
Let the docs server pick a port, like every other host publish

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,9 @@ clean: ## Clean up cache files
 	@find . -type f -name "*.pyc" -delete
 
 # Serve documentation locally
-docs-serve: ## Serve documentation locally on port 8001 (no live reload, avoids dev server starvation on image-heavy pages)
-	@uv run mkdocs serve --dev-addr 0.0.0.0:8001 --no-livereload
+docs-serve: ## Serve documentation locally (port resolved, no live reload: avoids dev server starvation on image-heavy pages)
+	@port=$$(uv run python scripts/docs_port.py); \
+	uv run mkdocs serve --dev-addr 0.0.0.0:$$port --no-livereload
 
 # Build documentation
 docs-build: ## Build the static documentation site

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/Makefile.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/Makefile.jinja
@@ -203,9 +203,8 @@ clean-cache: ## Clean Python cache files
 # DOCUMENTATION
 #=============================================================================
 
-docs-serve: ## Serve documentation locally (http://localhost:8001)
-	@echo "Serving documentation on http://localhost:8001"
-	@uv run mkdocs serve --dev-addr 0.0.0.0:8001
+docs-serve: ## Serve documentation locally (port resolved like make serve)
+	@uv run python scripts/dev_tasks.py docs
 
 docs-build: ## Build static documentation
 	@echo "Building documentation..."

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
@@ -512,8 +512,8 @@ help = "Clean Python cache files"
 script = "scripts.dev_tasks:clean_cache"
 
 [tool.poe.tasks.docs-serve]
-help = "Serve documentation locally (http://localhost:8001)"
-cmd = "uv run mkdocs serve --dev-addr 0.0.0.0:8001"
+help = "Serve documentation locally (port resolved like serve)"
+script = "scripts.dev_tasks:docs"
 
 [tool.poe.tasks.docs-build]
 help = "Build static documentation"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/dev_tasks.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/dev_tasks.py.jinja
@@ -15,7 +15,7 @@ import subprocess
 import sys
 from pathlib import Path
 
-from scripts.resolve_ports import resolve_ports
+from scripts.resolve_ports import docs_port, resolve_ports
 
 _COMPOSE_DEV = [
     "docker",
@@ -73,6 +73,15 @@ def serve_prod() -> None:
     subprocess.run(
         [*_COMPOSE_PROD, "--profile", "prod", "up", "--remove-orphans"],
         env=env,
+        check=True,
+    )
+
+
+def docs() -> None:
+    """Serve the documentation on a port that is actually free."""
+    port = docs_port()
+    subprocess.run(
+        ["uv", "run", "mkdocs", "serve", "--dev-addr", f"0.0.0.0:{port}"],
         check=True,
     )
 
@@ -157,6 +166,7 @@ def main(argv: list[str] | None = None) -> None:
             "serve",
             "serve-bg",
             "serve-prod",
+            "docs",
             {%- if include_database %}
             "migrate-reset",
             {%- endif %}
@@ -171,6 +181,8 @@ def main(argv: list[str] | None = None) -> None:
             serve_bg()
         elif args.action == "serve-prod":
             serve_prod()
+        elif args.action == "docs":
+            docs()
         {%- if include_database %}
         else:
             migrate_reset()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/resolve_ports.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/resolve_ports.py
@@ -78,6 +78,19 @@ def _resolve_one(base: int, label: str, scheme: str = "http://") -> int:
     return port
 
 
+def docs_port(base: int | None = None) -> int:
+    """The host port ``make docs-serve`` should bind.
+
+    Same rule as every other host publish: take the base if it is free,
+    otherwise the next one that is. 8001 was hardcoded, which is exactly
+    the port a second stack's webserver resolves to, so previewing docs
+    beside a running app failed to bind.
+    """
+    if base is None:
+        base = int(os.environ.get("DOCS_PORT_BASE", "8001"))
+    return _resolve_one(base, "docs")
+
+
 def resolve_ports(
     *,
     ingress: bool,

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_resolve_ports.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_resolve_ports.py
@@ -20,7 +20,12 @@ from pathlib import Path
 import pytest
 
 from scripts import resolve_ports as resolve_ports_module
-from scripts.resolve_ports import _find_free_port, _is_free, resolve_ports
+from scripts.resolve_ports import (
+    _find_free_port,
+    _is_free,
+    docs_port,
+    resolve_ports,
+)
 
 
 def _listen_free() -> socket.socket:
@@ -215,3 +220,37 @@ class TestResolvePorts:
         )
 
         assert "STALE_KEY" not in ports_file.read_text()
+
+
+class TestDocsPort:
+    """``make docs-serve`` picks a port the way ``make serve`` does.
+
+    A hardcoded 8001 is the port a second stack's webserver lands on and
+    the port this project's own compose publishes, so the docs server
+    failed to bind whenever anything else was already up. Nothing about
+    a docs preview needs a fixed port.
+    """
+
+    def test_it_takes_the_base_port_when_free(self) -> None:
+        base = _free_port()
+        assert docs_port(base) == base
+
+    def test_it_steps_past_a_busy_port(self) -> None:
+        blocker = _listen_free()
+        try:
+            taken = blocker.getsockname()[1]
+            assert docs_port(taken) > taken
+        finally:
+            blocker.close()
+
+    def test_it_says_where_the_docs_landed(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """A resolved port is useless if the user cannot see it."""
+        blocker = _listen_free()
+        try:
+            taken = blocker.getsockname()[1]
+            chosen = docs_port(taken)
+        finally:
+            blocker.close()
+        assert str(chosen) in capsys.readouterr().err

--- a/scripts/docs_port.py
+++ b/scripts/docs_port.py
@@ -1,0 +1,70 @@
+"""Pick a host port for ``make docs-serve``.
+
+The docs server used to insist on 8001, which is exactly where a
+generated project's webserver lands when 8000 is taken. Previewing the
+docs beside a running stack then failed to bind, and the error reads as
+"a docs server is already running" rather than as a collision.
+
+Deliberately a probe rather than a bind: connecting needs no privileges,
+so a low base port does not require root.
+"""
+
+from __future__ import annotations
+
+import errno
+import os
+import socket
+import sys
+
+_DEFAULT_BASE = 8001
+
+
+def _attempt(port: int) -> int:
+    """0 = free, 1 = busy, -1 = ambiguous.
+
+    macOS answers a self-connect straight after a recent bind with
+    EINVAL, which is not a real "in use" signal, so the caller retries
+    instead of trusting it.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.settimeout(1.0)
+    try:
+        sock.connect(("127.0.0.1", port))
+    except ConnectionRefusedError:
+        return 0
+    except OSError as exc:
+        return -1 if exc.errno == errno.EINVAL else 1
+    else:
+        return 1
+    finally:
+        sock.close()
+
+
+def _is_free(port: int) -> bool:
+    for _ in range(3):
+        verdict = _attempt(port)
+        if verdict >= 0:
+            return verdict == 0
+    return False  # persistent EINVAL: do not hand it out
+
+
+def docs_port(base: int | None = None, max_attempts: int = 20) -> int:
+    """The base port if it is free, else the next one that is."""
+    start = (
+        base
+        if base is not None
+        else int(os.environ.get("DOCS_PORT_BASE", _DEFAULT_BASE))
+    )
+    for port in range(start, start + max_attempts):
+        if _is_free(port):
+            if port != start:
+                print(f">> port {start} in use", file=sys.stderr)
+            print(f">> docs: http://127.0.0.1:{port}", file=sys.stderr)
+            return port
+    raise RuntimeError(
+        f"docs_port: no free port in {start}..{start + max_attempts - 1}"
+    )
+
+
+if __name__ == "__main__":
+    print(docs_port())

--- a/tests/core/test_docs_port.py
+++ b/tests/core/test_docs_port.py
@@ -1,0 +1,65 @@
+"""``make docs-serve`` must not insist on a port something else holds.
+
+8001 was hardcoded, and 8001 is exactly where a generated project's
+webserver lands when 8000 is taken. Previewing the docs beside a running
+stack failed to bind, which reads as "a docs server is already running"
+rather than as a port collision.
+"""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from scripts import docs_port as docs_port_module
+from scripts.docs_port import docs_port
+
+
+def _listen_free() -> socket.socket:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(1)
+    return sock
+
+
+def _free_port() -> int:
+    sock = _listen_free()
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+def test_it_takes_the_base_port_when_free() -> None:
+    base = _free_port()
+    assert docs_port(base) == base
+
+
+def test_it_steps_past_a_busy_port() -> None:
+    blocker = _listen_free()
+    try:
+        taken = blocker.getsockname()[1]
+        assert docs_port(taken) > taken
+    finally:
+        blocker.close()
+
+
+def test_it_says_where_the_docs_landed(capsys: pytest.CaptureFixture[str]) -> None:
+    """A resolved port is useless if the user cannot see it."""
+    blocker = _listen_free()
+    try:
+        taken = blocker.getsockname()[1]
+        chosen = docs_port(taken)
+    finally:
+        blocker.close()
+    assert str(chosen) in capsys.readouterr().err
+
+
+def test_it_gives_up_rather_than_scanning_forever(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Better a clear error than a silent scan up the port range."""
+    monkeypatch.setattr(docs_port_module, "_is_free", lambda port: False)
+    with pytest.raises(RuntimeError):
+        docs_port(9999, max_attempts=3)


### PR DESCRIPTION
`make docs-serve` insisted on 8001, and 8001 is exactly where a webserver lands when 8000 is taken. Previewing docs beside a running stack fails to bind, and mkdocs surfaces that as an `OSError: [Errno 48] Address already in use` at the bottom of a traceback, which reads as "a docs server is already running" rather than as a collision with something else.

Generated projects already solve this for every other host publish: `scripts/resolve_ports.py` takes the base port if it is free and the next one if not, then prints where it landed. Docs now go through the same path.

## Changes

**Template** (the shipped product):

- `resolve_ports.py` gains `docs_port()`, honouring `DOCS_PORT_BASE`
- `dev_tasks.py` gains a `docs` action, so `make docs-serve` and `poe docs-serve` share one implementation rather than each carrying a literal port
- both call sites updated

**Framework repo** (its own docs):

- `scripts/docs_port.py`, a small resolver of its own, and `make docs-serve` uses it

The probe logic is duplicated rather than imported. The template copy ships to users as project source; reaching into it from the tool's own scripts would couple the two deliverables through a path containing `{{ project_slug }}`.

## Why not mkdocs' own `--dev-addr :0`

`wsgiref` would accept it, but `LiveReloadServer.__init__` computes `self.url` from the requested port and never re-derives it after `server_bind()`. An OS-assigned port would be served at an address the log never prints.

## Tests

Failing-first, in both repos: takes the base when free, steps past a busy one, says where it landed, and raises rather than scanning forever.

Verified live: with my-app holding 8001, the resolver reports `>> port 8001 in use` and hands back 8002.
