### PR TITLE
Release 0.11.0rc2: updates drop moved modules cleanly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -283,6 +283,18 @@
 
 ### Fixed
 
+- **`aegis update` left stale modules behind when the template moved
+  them**: the removal pass compared each dropped file byte-for-byte with
+  the old render, but init's post-gen step ruff-formats every file, so
+  any module the formatter had touched read as "customized" and was kept.
+  A 0.10.1 project updated to this release kept importable copies of the
+  finance and AI packages at their old paths. Removal now looks through
+  formatting the same way the sync loop does; a real edit is still kept
+  and reported.
+  The sync loop also compared against the unpruned template render, so
+  an update from a local template checkout re-created storage, documents,
+  and blog files in a project that selected none of them; both renders
+  are now pruned the way init prunes before anything is compared.
 - **Re-importing a statement counted every row as an edit**: an empty
   memo cell was treated as a change against a missing memo, and the demo
   seed left `original_description` empty, which no bank import does.

--- a/aegis/__init__.py
+++ b/aegis/__init__.py
@@ -2,4 +2,4 @@
 Aegis Stack CLI - Component generation and project management tools.
 """
 
-__version__ = "0.11.0rc1"
+__version__ = "0.11.0rc2"

--- a/aegis/core/template_cleanup.py
+++ b/aegis/core/template_cleanup.py
@@ -12,6 +12,7 @@ import tempfile
 import time
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -426,6 +427,7 @@ def sync_template_changes(
         new_rendered_dir = new_render / project_slug
         if not new_rendered_dir.exists():
             return SyncResult()
+        _prune_render(new_rendered_dir, answers)
 
         # Render the OLD template version (for 3-way merge base)
         old_rendered_dir: Path | None = None
@@ -443,6 +445,7 @@ def sync_template_changes(
                 )
                 candidate = old_render / project_slug
                 if candidate.exists():
+                    _prune_render(candidate, answers)
                     old_rendered_dir = candidate
             except Exception as e:
                 verbose_print(
@@ -567,6 +570,21 @@ def sync_template_changes(
     return result
 
 
+def _prune_render(rendered_dir: Path, answers: dict[str, Any]) -> None:
+    """Make a raw render look like init's output for this stack.
+
+    The template carries every component; ``aegis init`` prunes what the
+    answers did not select. Comparing against the unpruned render made the
+    create-missing-file backstop resurrect storage, documents, and blog
+    files in a project that has none of them, moments after component
+    cleanup had removed them. Pruning both renders keeps every comparison
+    on the file set this stack actually owns.
+    """
+    from aegis.core.post_gen_tasks import cleanup_components  # circular at module load
+
+    cleanup_components(rendered_dir, answers)
+
+
 def _remove_dropped_files(
     project_path: Path,
     old_rendered_dir: Path | None,
@@ -606,7 +624,7 @@ def _remove_dropped_files(
         if not project_file.exists():
             continue
         try:
-            if project_file.read_bytes() != old_file.read_bytes():
+            if not _unedited(project_file, old_file, relative, project_path):
                 result.stale.append(str(relative))
                 verbose_print(
                     f"   Kept customized file no longer in template: {relative}"
@@ -621,22 +639,59 @@ def _remove_dropped_files(
         verbose_print(f"   Removed file no longer in template: {relative}")
 
     # Prune directories the deletions emptied, deepest first so a nested tree
-    # collapses in one pass.
+    # collapses in one pass. Stale bytecode does not count as content: init
+    # imports what it generates, so every package carries a ``__pycache__``,
+    # and a moved package kept alive by its .pyc files is still a package.
     for parent in sorted(
         {p.parent for p in removed_paths}, key=lambda p: len(p.parts), reverse=True
     ):
         current = parent
         while current != project_path and current.is_relative_to(project_path):
             try:
-                if not current.exists() or any(current.iterdir()):
+                if not current.exists() or not _only_bytecode(current):
                     break
-                current.rmdir()
+                shutil.rmtree(current)
                 verbose_print(
                     f"   Removed empty directory: {current.relative_to(project_path)}"
                 )
             except OSError:
                 break
             current = current.parent
+
+
+def _only_bytecode(directory: Path) -> bool:
+    """True when nothing but ``__pycache__`` trees remain under ``directory``."""
+    return all(
+        entry.is_dir() and entry.name == "__pycache__" for entry in directory.iterdir()
+    )
+
+
+def _unedited(
+    project_file: Path, old_file: Path, relative: Path, project_path: Path
+) -> bool:
+    """Is the project file the old render, give or take formatting?
+
+    ``aegis init`` post-gen ruff-formats every file, so a byte comparison
+    against the raw render calls every formatted module "customized". For
+    Python that is the same look-through-formatting test the sync loop
+    applies; anything else is compared byte-wise. Ruff unavailable means
+    the conservative answer: treat as edited.
+    """
+    project_bytes, old_bytes = project_file.read_bytes(), old_file.read_bytes()
+    if project_bytes == old_bytes:
+        return True
+    if relative.suffix != ".py":
+        return False
+    rel = relative.as_posix()
+    project_norm = run_ruff_on_text(
+        project_bytes.decode("utf-8"), project_path, "", rel_path=rel
+    )
+    old_norm = run_ruff_on_text(
+        old_bytes.decode("utf-8"), project_path, "", rel_path=rel
+    )
+    if project_norm is None or old_norm is None:
+        return False
+    return normalize_for_compare(project_norm) == normalize_for_compare(old_norm)
 
 
 def _warn_raw_merge_fallback(relative: Path) -> None:

--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@
 # - Update support
 
 _min_copier_version: "9.0.0"
-_version: "0.11.0rc1"
+_version: "0.11.0rc2"
 
 # IMPORTANT: Template content is in subdirectory
 # This allows the template to be recognized as git-tracked (aegis-stack repo root has .git)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-stack"
-version = "0.11.0rc1"
+version = "0.11.0rc2"
 description = "A production-ready FastAPI platform with modular components and a built-in control plane. Try: uvx aegis-stack init my-project"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/tests/core/test_template_cleanup.py
+++ b/tests/core/test_template_cleanup.py
@@ -1309,6 +1309,95 @@ class TestSyncRemovesFilesTheTemplateDropped:
         assert not stale.exists()
         assert "app/models.py" in result.removed
 
+    def test_a_formatted_but_unedited_file_dropped_by_the_template_is_deleted(
+        self, tmp_path: Path
+    ) -> None:
+        """init's post-gen ruff-formats every file, so a pristine project file
+        differs from the raw old render byte-wise. That is not an edit: the
+        module the template moved elsewhere must still go, or a stale copy
+        stays importable at the old path."""
+        answers = {"project_slug": "my-project"}
+        raw_render = "import os\nimport sys\n\n\n\n\nVALUE = os.sep + sys.platform\n"
+        formatted = "import os\nimport sys\n\n\nVALUE = os.sep + sys.platform\n"
+        stale = tmp_path / "app" / "old_module.py"
+        stale.parent.mkdir(parents=True)
+        stale.write_text(formatted)
+
+        with patch(
+            "copier.run_copy",
+            side_effect=self._renders(
+                "my-project",
+                old={"app/old_module.py": raw_render},
+                new={"app/new_home/module.py": raw_render},
+            ),
+        ):
+            result = sync_template_changes(
+                tmp_path, answers, "gh:test/repo", "v1.0.0", old_commit="abc123"
+            )
+
+        assert not stale.exists()
+        assert "app/old_module.py" in result.removed
+        assert "app/old_module.py" not in result.stale
+
+    def test_a_dropped_package_goes_even_with_its_pycache(self, tmp_path: Path) -> None:
+        """Init imports the modules it generates, so every package carries
+        a ``__pycache__``. A moved package whose directory survives on the
+        strength of stale bytecode is still a package to Python: an empty
+        `app/services/finance/importers/` shadows nothing but still fails
+        a layout check and confuses a reader. Bytecode is not content."""
+        answers = {"project_slug": "my-project"}
+        package = tmp_path / "app" / "old_pkg"
+        (package / "__pycache__").mkdir(parents=True)
+        (package / "__pycache__" / "mod.cpython-313.pyc").write_bytes(b"\x00")
+        (package / "mod.py").write_text("# mod")
+
+        with patch(
+            "copier.run_copy",
+            side_effect=self._renders(
+                "my-project",
+                old={"app/old_pkg/mod.py": "# mod"},
+                new={"app/new_pkg/mod.py": "# mod"},
+            ),
+        ):
+            sync_template_changes(
+                tmp_path, answers, "gh:test/repo", "v1.0.0", old_commit="abc123"
+            )
+
+        assert not package.exists()
+
+    def test_sync_never_creates_files_of_an_unselected_component(
+        self, tmp_path: Path
+    ) -> None:
+        """The raw render carries every component; init prunes what the
+        stack did not select. The sync loop's create-missing-file backstop
+        read the raw render, so a local-template update re-created storage,
+        documents, and blog files in a project that has none of them, right
+        after component cleanup had removed them. Renders are pruned the
+        way init prunes."""
+        answers = {"project_slug": "my-project", "include_storage": False}
+        card = "app/components/frontend/dashboard/cards/storage_card.py"
+        (tmp_path / "app").mkdir()
+
+        with patch(
+            "copier.run_copy",
+            side_effect=self._renders(
+                "my-project",
+                old={"app/keep.py": "# keep"},
+                new={"app/keep.py": "# keep", card: "# storage card"},
+            ),
+        ):
+            result = sync_template_changes(
+                tmp_path,
+                answers,
+                "gh:test/repo",
+                "v1.0.0",
+                template_changed_files={card, "app/keep.py"},
+                old_commit="abc123",
+            )
+
+        assert not (tmp_path / card).exists()
+        assert card not in result.synced
+
     def test_customized_file_dropped_by_the_template_is_kept_and_reported(
         self, tmp_path: Path
     ) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { editable = "tests/fixtures/aegis_plugin_test" }
 
 [[package]]
 name = "aegis-stack"
-version = "0.11.0rc1"
+version = "0.11.0rc2"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
Second candidate. Verifying rc1 from TestPyPI on a full 0.10.1 stack (database, redis, worker, scheduler, auth, finance, AI, plus local edits) left stale copies of the finance and AI packages at their old paths, and the layout test caught it.

**Cause.** The update's removal pass compared each dropped file byte-for-byte with the raw old render. Init's post-gen step ruff-formats every file, so any module the formatter had touched read as customized and was kept. Directories then survived on their `__pycache__` alone.

**Fix.** Removal looks through formatting the same way the sync loop does (a real edit is still kept and reported), and a directory holding only bytecode is pruned. Both renders are also pruned the way init prunes, so the sync loop's create-missing-file backstop cannot resurrect files of unselected components (seen on the local-template path).

**Verified** with the fixed CLI on the same 0.10.1 full stack: all five old packages gone, no unselected component files, both local edits kept, no conflict markers, no `.rej`, 3202 tests passed. Three new unit tests, each failing without its fix.

Carries the fix, its tests, the changelog entry, and the bump to `0.11.0rc2`.