### PR TITLE
Release 0.11.0

### DIFF
--- a/aegis/__init__.py
+++ b/aegis/__init__.py
@@ -2,4 +2,4 @@
 Aegis Stack CLI - Component generation and project management tools.
 """
 
-__version__ = "0.11.0rc2"
+__version__ = "0.11.0"

--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@
 # - Update support
 
 _min_copier_version: "9.0.0"
-_version: "0.11.0rc2"
+_version: "0.11.0"
 
 # IMPORTANT: Template content is in subdirectory
 # This allows the template to be recognized as git-tracked (aegis-stack repo root has .git)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-stack"
-version = "0.11.0rc2"
+version = "0.11.0"
 description = "A production-ready FastAPI platform with modular components and a built-in control plane. Try: uvx aegis-stack init my-project"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { editable = "tests/fixtures/aegis_plugin_test" }
 
 [[package]]
 name = "aegis-stack"
-version = "0.11.0rc2"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
Final version bump. `0.11.0rc2` survived the full TestPyPI test unchanged:

| | Full stack (database, redis, worker, scheduler, auth, finance, AI) | Base stack |
|---|---|---|
| Old packages | all gone | AI modal gone |
| Unselected components | none present | n/a |
| Local edits | kept | kept |
| Conflicts, .rej | none | none |
| Suite | 3202 passed | 596 passed |

Carries only the version files (package init, `pyproject.toml`, `copier.yml`, `uv.lock`). After merge: delete this branch, then tag the merge commit `v0.11.0` to publish to PyPI.