### PR TITLE
Service structure follow-ups: stale doc paths, dead comms fixture, unused imports

### DIFF
--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
@@ -513,7 +513,7 @@ class Settings(
 {% endif %}
 
     # Editorial metadata for the Overview project hero — read by
-    # `view_service._project_info()`. All optional; the project hero is
+    # `views.overview.project_info()`. All optional; the project hero is
     # hidden when no GitHub repo and no project name are set. Lives
     # outside the source-specific blocks because it's project-level
     # metadata, not tied to any particular collector.

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/blog/service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/blog/service.py
@@ -1,6 +1,5 @@
 """Blog service business logic."""
 
-import re
 from datetime import datetime, timedelta
 
 from sqlalchemy import func

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/payment/demo_seed.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/payment/demo_seed.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import string
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 
 from sqlalchemy import delete
 from sqlmodel import select

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/services/comms/index.md
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/services/comms/index.md
@@ -106,7 +106,7 @@ print(response.json())
 ```python
 from app.services.comms.email import send_email_simple
 from app.services.comms.sms import send_sms_simple
-from app.services.comms.call import make_call_simple
+from app.services.comms.calls import make_call_simple
 
 # Send email
 result = await send_email_simple(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/etl/test_lab_resolver.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/etl/test_lab_resolver.py
@@ -9,8 +9,6 @@ repository IS the lab.
 
 from typing import Any
 
-import pytest
-
 from app.services.ai.domains.llm.etl.lab_resolver import (
     pick_repo,
     strip_local_tag,
@@ -36,14 +34,20 @@ class TestPickRepo:
         """The most-downloaded hit is often a re-quantizer's upload; it
         names its origin, so the origin is the answer."""
         candidates = [
-            _repo("unsloth/Muse-Glimmer-30B-GGUF", base=["meta-models/Muse-Glimmer-30B"], downloads=982_083),
+            _repo(
+                "unsloth/Muse-Glimmer-30B-GGUF",
+                base=["meta-models/Muse-Glimmer-30B"],
+                downloads=982_083,
+            ),
             _repo("meta-models/Muse-Glimmer-30B", downloads=600_273),
         ]
         assert pick_repo(candidates, "muse-glimmer") == "meta-models/Muse-Glimmer-30B"
 
     def test_an_original_wins_on_name_affinity_not_popularity(self) -> None:
         candidates = [
-            _repo("Blackfrost-AI/Muse-Glimmer-30B-Abliterated-GGUF", downloads=9_000_000),
+            _repo(
+                "Blackfrost-AI/Muse-Glimmer-30B-Abliterated-GGUF", downloads=9_000_000
+            ),
             _repo("meta-models/Muse-Glimmer-30B", downloads=1),
         ]
         assert pick_repo(candidates, "muse-glimmer") == "meta-models/Muse-Glimmer-30B"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/comms/conftest.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/comms/conftest.py
@@ -6,6 +6,7 @@ from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
+
 from app.services.comms.models import (
     CallResponse,
     CallStatus,
@@ -105,7 +106,7 @@ def mock_resend():
 @pytest.fixture
 def mock_twilio_client():
     """Mock the Twilio Client."""
-    with patch("app.services.comms.sms.Client") as mock_client_class:
+    with patch("app.services.comms.twilio.Client") as mock_client_class:
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
 

--- a/docs/services/auth/integration.md
+++ b/docs/services/auth/integration.md
@@ -89,7 +89,7 @@ class UserService:
 
 ```python
 from app.components.backend.api.deps import get_user_service
-from app.services.auth.user_service import UserService
+from app.services.auth.users import UserService
 from app.models.user import UserCreate
 
 @router.post("/register", response_model=UserResponse)
@@ -164,7 +164,7 @@ class OrgService:
 
 ```python
 from app.components.backend.api.deps import get_org_service
-from app.services.auth.org_service import OrgService
+from app.services.auth.orgs import OrgService
 from app.models.org import OrgCreate, OrgResponse
 
 @router.post("/orgs", response_model=OrgResponse)
@@ -209,7 +209,7 @@ class MembershipService:
 
 ```python
 from app.components.backend.api.deps import get_membership_service
-from app.services.auth.membership_service import MembershipService
+from app.services.auth.memberships import MembershipService
 
 @router.post("/orgs/{org_id}/members/bulk")
 async def bulk_add(
@@ -288,7 +288,7 @@ create_invite()
 
 ```python
 from app.components.backend.api.deps import get_invite_service
-from app.services.auth.invite_service import InviteService
+from app.services.auth.invites import InviteService
 
 @router.post("/orgs/{org_id}/invites", response_model=InviteResponse)
 async def invite_member(
@@ -405,10 +405,10 @@ async def create_org_with_owner(
 
 ### Role-based access control
 
-`require_role()` is a dependency factory from `app.services.auth.auth_service`. It validates the JWT, loads the user, and checks their system-level role.
+`require_role()` is a dependency factory from `app.services.auth.service`. It validates the JWT, loads the user, and checks their system-level role.
 
 ```python
-from app.services.auth.auth_service import require_role
+from app.services.auth.service import require_role
 
 # Single role
 @router.delete("/users/{user_id}")

--- a/docs/services/auth/levels.md
+++ b/docs/services/auth/levels.md
@@ -240,7 +240,7 @@ class UserBase(SQLModel):
 The `require_role()` function is a FastAPI dependency that checks the authenticated user's role:
 
 ```python
-from app.services.auth.auth_service import require_role
+from app.services.auth.service import require_role
 from fastapi import Depends
 
 @router.get("/admin/dashboard")
@@ -341,8 +341,8 @@ Organization slugs are validated to be **lowercase alphanumeric with hyphens onl
 ### Membership Management
 
 ```python
-from app.services.auth.membership_service import MembershipService
-from app.services.auth.org_service import OrgService
+from app.services.auth.memberships import MembershipService
+from app.services.auth.orgs import OrgService
 
 # Create an organization
 org_service = OrgService(db)
@@ -535,7 +535,7 @@ aegis add-service auth[rbac]
 **What changes:**
 
 - `role` field added to the User model
-- `require_role()` dependency available in `auth_service.py`
+- `require_role()` dependency available in `service.py`
 - Role constants (`ROLE_ADMIN`, `ROLE_MODERATOR`, `ROLE_USER`) added to `security.py`
 - Admin-protected user management endpoints (list, activate, deactivate, delete)
 - Moderator can list users

--- a/docs/services/payment/examples.md
+++ b/docs/services/payment/examples.md
@@ -178,7 +178,7 @@ The standard play is to refund proactively before the chargeback lands. Fighting
 
 ```python
 from app.services.payment.constants import DisputeStatus
-from app.services.payment.payment_service import PaymentService
+from app.services.payment.service import PaymentService
 
 class FraudAwarePaymentService(PaymentService):
     async def _handle_early_fraud_warning(self, event) -> None:


### PR DESCRIPTION
## Summary

Review pass on #1073 after it merged. No behaviour changes.

- Docs still named the pre-rename auth, payment and comms module paths; they now point at `service`, `users`, `orgs`, `memberships`, `invites` and `calls`.
- The comms test fixture patched `Client` on `sms`, which no longer imports it; it now patches `comms.twilio.Client` where the symbol lives. Nothing consumed the fixture, so it was latent.
- Drops imports left behind by the slugify and utcnow moves, and a stale `view_service` reference in a config comment.

## Verification

- Generated comms stack: comms tests pass after the fixture change
- Blog and payment templates F-clean; lab resolver test passes in my-app
- Repo guards (size budget, render parity, blog render) pass