### PR TITLE
aegis add <plugin> writes and runs the plugin's migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,13 @@
   `make lint-frontend` fail.
 - **Generated `test_app_js_is_loaded` no longer fails once assets are
   built**: it accepts the fingerprinted path as well as the source path.
+- **`aegis add <plugin>` creates the plugin's tables.** A third-party
+  plugin's `migrations` were never written: `add_plugin` skipped the
+  migration tail in-tree services get, and the generator only resolved
+  names from the static registry. The plugin's revisions are now rendered
+  straight from its spec (`generate_plugin_migrations`), with alembic
+  bootstrapped when missing, schema dropped on SQLite, and re-adding the
+  plugin never stacking a duplicate revision.
 
 ## [0.11.0] - 2026-09-06
 

--- a/aegis/core/manual_updater.py
+++ b/aegis/core/manual_updater.py
@@ -1441,6 +1441,13 @@ class ManualUpdater:
                     )
                 )
 
+            # Migration tail, the same one ``add_service`` gives in-tree
+            # services: a plugin that declares tables needs alembic
+            # bootstrapped, its revisions written, and applied. Without
+            # it the router mounts over tables nobody created.
+            if getattr(spec, "migrations", None):
+                self._run_plugin_migrations(spec)
+
             # Post-gen — uv sync picks up the plugin's pyproject deps,
             # make fix re-formats anything we touched. Skipped when the
             # caller (resolver flow) is batching installs and will run
@@ -1463,6 +1470,20 @@ class ManualUpdater:
                 success=False,
                 error_message=str(e),
             )
+
+    def _run_plugin_migrations(self, spec: Any) -> None:
+        """Bootstrap alembic if missing, write the plugin's migrations, run
+        them. ``run_migrations`` failure is non-fatal, as in ``add_service``:
+        the user can ``alembic upgrade head`` later."""
+        from .migration_generator import bootstrap_alembic, generate_plugin_migrations
+        from .post_gen_tasks import run_migrations
+
+        if not (self.project_path / "alembic").exists():
+            bootstrap_alembic(self.project_path, self.jinja_env, self.answers)
+        # Answers carry the database engine, which decides whether a
+        # spec's Postgres schema survives; SQLite has none.
+        generate_plugin_migrations(self.project_path, spec, self.answers)
+        run_migrations(self.project_path, include_migrations=True)
 
     def _save_answers(self, answers: dict[str, Any]) -> None:
         """

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -4522,13 +4522,20 @@ def _resolve_spec(
             schema=DatabaseSchemas.FINANCE, user_ref_schema=DatabaseSchemas.PUBLIC
         )
 
-    spec = migration_specs[service_name]
+    return _gate_schema(migration_specs[service_name], context)
 
-    # Engines without schema support drop the qualifier entirely; the tables
-    # still get created, just in the single unscoped namespace.
+
+def _gate_schema(
+    spec: ServiceMigrationSpec, context: dict[str, Any] | None
+) -> ServiceMigrationSpec:
+    """Drop a spec's schema qualifier on engines without schema support.
+
+    The tables still get created, just in the single unscoped namespace.
+    A ``None`` context carries no engine information and leaves the spec
+    as declared.
+    """
     if spec.schema is not None and context is not None and not _is_postgres(context):
         return replace(spec, schema=None)
-
     return spec
 
 
@@ -4553,26 +4560,45 @@ def generate_migration(
     spec = _resolve_spec(service_name, context)
     if spec is None:
         return None
+    return _write_migration(project_path, spec)
 
+
+def _write_migration(project_path: Path, spec: ServiceMigrationSpec) -> Path:
+    """Render ``spec`` as the next revision under ``alembic/versions``."""
     versions_dir = get_versions_dir(project_path)
-
-    # Ensure versions directory exists
     versions_dir.mkdir(parents=True, exist_ok=True)
 
-    # Get revision info
     revision = get_next_revision_id(project_path)
     down_revision = get_previous_revision(project_path)
-
-    # Render migration content
     content = _render_migration(spec, revision, down_revision)
 
-    # Write migration file
-    filename = f"{revision}_{service_name}.py"
-    migration_path = versions_dir / filename
-
+    migration_path = versions_dir / f"{revision}_{spec.service_name}.py"
     migration_path.write_text(content)
-
     return migration_path
+
+
+def generate_plugin_migrations(
+    project_path: Path,
+    plugin_spec: Any,
+    context: dict[str, Any] | None = None,
+) -> list[Path]:
+    """Write every migration a plugin declares, once.
+
+    Third-party plugins are not in the static registry ``generate_migration``
+    resolves names against, but ``aegis add <plugin>`` holds the spec in
+    hand, so its ``migrations`` list is rendered directly. Each spec gets
+    the same engine gating in-tree services get, and one that already has
+    a file in ``alembic/versions`` is skipped, so re-adding a plugin never
+    stacks a duplicate revision.
+
+    Returns the paths written, in declaration order.
+    """
+    written: list[Path] = []
+    for migration in getattr(plugin_spec, "migrations", None) or []:
+        if service_has_migration(project_path, migration.service_name):
+            continue
+        written.append(_write_migration(project_path, _gate_schema(migration, context)))
+    return written
 
 
 def generate_migrations_for_services(

--- a/tests/core/test_manual_updater_plugins.py
+++ b/tests/core/test_manual_updater_plugins.py
@@ -348,3 +348,118 @@ class TestBackupLabelSegmentsArePathSafe:
         majority — or backup paths stop being recognizable."""
         for ordinary in ("scraper", "metrics_hub", "1.2.0", "2.0.0-rc1"):
             assert _safe_path_segment(ordinary) == ordinary
+
+
+class TestAddPluginRunsMigrationTail:
+    """A plugin that declares ``migrations`` gets the same tail
+    ``add_service`` gives in-tree services: alembic bootstrapped when
+    missing, its migrations generated, migrations run. Without it the
+    plugin's tables never exist (``aegis add crawl4ai`` shipped a router
+    over a table nobody created)."""
+
+    @staticmethod
+    def _spec_with_migrations() -> object:
+        from dataclasses import replace
+
+        from aegis_plugin_test.spec import get_spec
+
+        from aegis.core.migration_spec import (
+            ColumnSpec,
+            MigrationSpec,
+            TableSpec,
+        )
+
+        migration = MigrationSpec(
+            service_name="test_plugin",
+            description="Test plugin table",
+            tables=[
+                TableSpec(
+                    name="test_plugin_thing",
+                    columns=[
+                        ColumnSpec(
+                            "id", "sa.Integer()", nullable=False, primary_key=True
+                        )
+                    ],
+                )
+            ],
+        )
+        return replace(get_spec(), migrations=[migration])
+
+    @staticmethod
+    def _quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            ManualUpdater, "run_post_generation_tasks", lambda self: None
+        )
+        monkeypatch.setattr(
+            ManualUpdater,
+            "_regenerate_shared_files",
+            lambda self, ans: ([], [], []),
+        )
+
+    def test_plugin_with_migrations_bootstraps_generates_and_runs(
+        self, fake_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import patch
+
+        self._quiet(monkeypatch)
+        spec = self._spec_with_migrations()
+        with (
+            patch("aegis.core.migration_generator.bootstrap_alembic") as bootstrap,
+            patch(
+                "aegis.core.migration_generator.generate_plugin_migrations",
+                return_value=[fake_project / "alembic" / "versions" / "0001_x.py"],
+            ) as generate,
+            patch("aegis.core.post_gen_tasks.run_migrations") as run,
+        ):
+            result = ManualUpdater(fake_project).add_plugin(
+                spec=spec, plugin_module_name="aegis_plugin_test"
+            )
+
+        assert result.success
+        bootstrap.assert_called_once()
+        generate.assert_called_once()
+        # The project's answers ride along so the engine gates the schema.
+        assert generate.call_args.args[1] is spec
+        assert "project_slug" in generate.call_args.args[2]
+        run.assert_called_once_with(fake_project, include_migrations=True)
+
+    def test_plugin_without_migrations_skips_tail(
+        self, fake_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import patch
+
+        from aegis_plugin_test.spec import get_spec
+
+        self._quiet(monkeypatch)
+        with (
+            patch("aegis.core.migration_generator.bootstrap_alembic") as bootstrap,
+            patch("aegis.core.post_gen_tasks.run_migrations") as run,
+        ):
+            result = ManualUpdater(fake_project).add_plugin(
+                spec=get_spec(), plugin_module_name="aegis_plugin_test"
+            )
+
+        assert result.success
+        bootstrap.assert_not_called()
+        run.assert_not_called()
+
+    def test_existing_alembic_is_not_rebootstrapped(
+        self, fake_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import patch
+
+        self._quiet(monkeypatch)
+        (fake_project / "alembic").mkdir()
+        with (
+            patch("aegis.core.migration_generator.bootstrap_alembic") as bootstrap,
+            patch(
+                "aegis.core.migration_generator.generate_plugin_migrations",
+                return_value=[],
+            ),
+            patch("aegis.core.post_gen_tasks.run_migrations"),
+        ):
+            ManualUpdater(fake_project).add_plugin(
+                spec=self._spec_with_migrations(),
+                plugin_module_name="aegis_plugin_test",
+            )
+        bootstrap.assert_not_called()

--- a/tests/core/test_migration_generator.py
+++ b/tests/core/test_migration_generator.py
@@ -7,6 +7,7 @@ Alembic migration files on-demand for services like auth and AI.
 
 import ast
 from pathlib import Path
+from typing import Any
 
 import pytest
 
@@ -1718,3 +1719,79 @@ class TestSchemaEngineGating:
         )
         content = self._generate(tmp_path, "plain", StorageBackends.POSTGRES)
         assert "CREATE SCHEMA" not in content
+
+
+class TestPluginMigrations:
+    """Third-party plugins ship ``PluginSpec.migrations``; ``aegis add
+    <plugin>`` writes them through the same rail in-tree services use,
+    without the plugin having to be in the static registry."""
+
+    @staticmethod
+    def _plugin_spec(schema: str | None = "crawler") -> Any:
+        from types import SimpleNamespace
+
+        migration = ServiceMigrationSpec(
+            service_name="crawler",
+            description="Crawler documents store",
+            schema=schema,
+            tables=[
+                TableSpec(
+                    name="documents",
+                    columns=[
+                        ColumnSpec(
+                            "id", "sa.Integer()", nullable=False, primary_key=True
+                        ),
+                        ColumnSpec("source_url", "sa.Text()", nullable=False),
+                    ],
+                ),
+            ],
+        )
+        return SimpleNamespace(name="crawl4ai", migrations=[migration])
+
+    def test_writes_one_file_per_migration_spec(self, tmp_path: Path) -> None:
+        from aegis.core.migration_generator import generate_plugin_migrations
+
+        (tmp_path / "alembic" / "versions").mkdir(parents=True)
+        written = generate_plugin_migrations(
+            tmp_path,
+            self._plugin_spec(),
+            {AnswerKeys.DATABASE_ENGINE: StorageBackends.SQLITE},
+        )
+        assert [p.name.split("_", 1)[1] for p in written] == ["crawler.py"]
+        content = written[0].read_text()
+        ast.parse(content)
+        assert "'documents'" in content
+
+    def test_schema_gated_by_engine(self, tmp_path: Path) -> None:
+        from aegis.core.migration_generator import generate_plugin_migrations
+
+        (tmp_path / "alembic" / "versions").mkdir(parents=True)
+        sqlite = generate_plugin_migrations(
+            tmp_path / "a" if False else tmp_path,
+            self._plugin_spec(),
+            {AnswerKeys.DATABASE_ENGINE: StorageBackends.SQLITE},
+        )[0].read_text()
+        assert "schema='crawler'" not in sqlite
+
+        pg_root = tmp_path / "pg"
+        (pg_root / "alembic" / "versions").mkdir(parents=True)
+        postgres = generate_plugin_migrations(
+            pg_root,
+            self._plugin_spec(),
+            {AnswerKeys.DATABASE_ENGINE: StorageBackends.POSTGRES},
+        )[0].read_text()
+        assert 'CREATE SCHEMA IF NOT EXISTS "crawler"' in postgres
+        assert "schema='crawler'" in postgres
+
+    def test_idempotent_on_rerun(self, tmp_path: Path) -> None:
+        """A second ``aegis add`` of the same plugin must not stack a
+        duplicate migration."""
+        from aegis.core.migration_generator import generate_plugin_migrations
+
+        (tmp_path / "alembic" / "versions").mkdir(parents=True)
+        context = {AnswerKeys.DATABASE_ENGINE: StorageBackends.SQLITE}
+        first = generate_plugin_migrations(tmp_path, self._plugin_spec(), context)
+        second = generate_plugin_migrations(tmp_path, self._plugin_spec(), context)
+        assert len(first) == 1
+        assert second == []
+        assert len(list((tmp_path / "alembic" / "versions").glob("*.py"))) == 1


### PR DESCRIPTION
## Summary

A third-party plugin's declared `migrations` never reached the project. `add_plugin` skipped the migration tail that `add_service` gives in-tree services, and the generator only resolved names from the static registry. The crawl4ai reference plugin mounted a router over a table nobody created.

- `generate_plugin_migrations(project_path, spec, context)` renders revisions straight from the spec in hand, so plugins need no registry entry. Engine gating and the write step are extracted from the existing path and shared. Specs that already have a revision are skipped, so re-adding a plugin never stacks a duplicate.
- `ManualUpdater.add_plugin` bootstraps alembic when missing, generates the plugin's migrations with the project's answers, and runs them. Failure to run is non-fatal, as in `add_service`.

## Tests

Written first, five failing on the missing function:

- generator: one file per migration spec, schema kept on Postgres and dropped on SQLite, rerun writes nothing
- updater: `add_plugin` bootstraps, generates from the spec with the project answers, and runs migrations; a plugin without migrations skips the tail; an existing `alembic/` is not re-bootstrapped

## Verified end to end

With aegis-stack and `aegis-plugin-crawl4ai` installed editable into one venv: on a SQLite stack `aegis add crawl4ai` bootstraps alembic, writes `001_crawler.py`, and the `documents` table exists in `data/app.db`; a second add writes nothing. On a Postgres stack the migration carries `CREATE SCHEMA IF NOT EXISTS "crawler"` and `schema="crawler"`.