### PR TITLE
Plugin deps can name a service variant: auth[org] installs or upgrades auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@
 
 ### Changed
 
+- **Plugin dependencies can name a service variant.** A plugin declaring
+  `required_services=["auth[org]"]` now gets auth at org level: installed
+  fresh at that level, upgraded when the project has a lower level, left
+  alone when it already satisfies the request. The spec's options say
+  where a variant lives in the answers (`answer_key`) and whether its
+  choices are ordered levels; `add-service auth[org]` on basic auth uses
+  the same rule, and the level-specific migrations are generated on both
+  paths. Unordered mismatches are refused, not swapped (docs, Plugins).
 - **Plugin packages are named `aegis-stack-<name>`.** `aegis plugins create`
   now scaffolds `aegis-stack-<name>` with the `aegis_stack_<name>` import
   package, replacing `aegis-plugin-<name>`. `aegis-stack-` is the one

--- a/aegis/commands/add.py
+++ b/aegis/commands/add.py
@@ -194,6 +194,12 @@ def _install_plugin(
     except UnknownDependencyError as e:
         brand.error(str(e), err=True)
         raise typer.Exit(1) from e
+    except ValueError as e:
+        # A variant the project cannot satisfy without a deliberate change
+        # (``ai[langchain]`` on a pydantic-ai project), or a bracket value
+        # the spec does not know.
+        brand.error(str(e), err=True)
+        raise typer.Exit(1) from e
 
     if plan.unresolved_plugins:
         brand.error(
@@ -243,13 +249,17 @@ def _install_plugin(
     # syncs. Recursive calls pass ``yes=True`` because the user
     # already confirmed the full plan.
     for dep in plan.to_install:
-        typer.echo(f"\n→ Installing dependency: {dep.name}")
+        typer.echo(f"\n→ Installing dependency: {dep.variant or dep.name}")
+        # A variant dep (``auth[org]``) carries the answers it changes;
+        # ``add_service`` treats a delta on an installed service as an
+        # upgrade. Bare deps pass None and get the defaults.
+        data = dep.answers_delta or None
         if dep.kind == PluginKind.COMPONENT:
             dep_updater = ManualUpdater(target_path)
-            dep_result = dep_updater.add_component(dep.name, None, run_post_gen=False)
+            dep_result = dep_updater.add_component(dep.name, data, run_post_gen=False)
         elif dep.name in SERVICES:
             dep_updater = ManualUpdater(target_path)
-            dep_result = dep_updater.add_service(dep.name, None, run_post_gen=False)
+            dep_result = dep_updater.add_service(dep.name, data, run_post_gen=False)
         else:
             _install_plugin(
                 dep.name, target_path, yes=True, force=force, run_post_gen=False

--- a/aegis/commands/add_service.py
+++ b/aegis/commands/add_service.py
@@ -18,14 +18,9 @@ from ..cli.validation import (
 from ..constants import (
     AIProviders,
     AnswerKeys,
-    AuthLevels,
     ComponentNames,
     Messages,
     StorageBackends,
-)
-from ..core.auth_service_parser import (
-    is_auth_service_with_options,
-    parse_auth_service_config,
 )
 from ..core.component_utils import (
     extract_base_component_name,
@@ -38,8 +33,13 @@ from ..core.migration_generator import (
     MIGRATION_SPECS,
     bootstrap_alembic,
     generate_migration,
-    get_services_needing_migrations,
+    generate_missing_migrations,
     service_has_migration,
+)
+from ..core.option_spec import (
+    VariantConflictError,
+    variant_answers,
+    variant_delta,
 )
 from ..core.project_map import render_project_map
 from ..core.service_resolver import ServiceResolver
@@ -185,24 +185,16 @@ def add_service_command(
         base_service = service_base_map[service]
         include_key = AnswerKeys.include_key(base_service)
         if existing_answers.get(include_key) is True:
-            # Special case: auth level upgrades (basic → rbac → org)
-            if base_service == AnswerKeys.SERVICE_AUTH and is_auth_service_with_options(
-                service
-            ):
-                auth_config = parse_auth_service_config(service)
-                current_level = existing_answers.get(
-                    AnswerKeys.AUTH_LEVEL, AuthLevels.BASIC
-                )
-                level_order = {
-                    AuthLevels.BASIC: 0,
-                    AuthLevels.RBAC: 1,
-                    AuthLevels.ORG: 2,
-                }
-                if level_order.get(auth_config.level, 0) > level_order.get(
-                    current_level, 0
-                ):
-                    # Upgrading auth level — don't skip
-                    continue
+            # A bracket request against an installed service is an upgrade
+            # when the project's answers fall short of it (auth basic ->
+            # org); the spec's options decide, not a per-service table.
+            try:
+                delta = variant_delta(service, SERVICES[base_service], existing_answers)
+            except VariantConflictError as exc:
+                brand.error(str(exc), err=True)
+                raise typer.Exit(1) from None
+            if delta:
+                continue
             already_enabled.append(service)
 
     if already_enabled:
@@ -403,17 +395,10 @@ def add_service_command(
             # Get base service name (strips variant syntax like [langchain,sqlite])
             base_service = service_base_map[service]
 
-            # For auth service, pass auth level data
-            if base_service == AnswerKeys.SERVICE_AUTH and is_auth_service_with_options(
-                service
-            ):
-                auth_config = parse_auth_service_config(service)
-                service_data[AnswerKeys.AUTH_LEVEL] = auth_config.level
-                service_data[AnswerKeys.AUTH_RBAC] = auth_config.level in (
-                    AuthLevels.RBAC,
-                    AuthLevels.ORG,
-                )
-                service_data[AnswerKeys.AUTH_ORG] = auth_config.level == AuthLevels.ORG
+            # Answers the bracket request names (auth level today); the
+            # updater derives whatever a level implies. Upgrades of an
+            # installed service were filtered above through variant_delta.
+            service_data.update(variant_answers(service, SERVICES[base_service]))
 
             # For AI service, use the captured configuration
             if base_service == AnswerKeys.SERVICE_AI:
@@ -517,21 +502,12 @@ def add_service_command(
                         f"   {t('add_service.generated_migration', name=migration_path.name)}"
                     )
 
-        # For auth level upgrades, generate any missing level-specific migrations
-        # (e.g., auth_rbac, auth_org, auth_tokens)
-        updated_answers = updater.answers
-        needed_migrations = get_services_needing_migrations(updated_answers)
-        for migration_service in needed_migrations:
-            if migration_service in MIGRATION_SPECS and not service_has_migration(
-                target_path, migration_service
-            ):
-                migration_path = generate_migration(
-                    target_path, migration_service, updated_answers
-                )
-                if migration_path:
-                    brand.success(
-                        f"   {t('add_service.generated_migration', name=migration_path.name)}"
-                    )
+        # Level-specific revisions the new answers call for (an auth upgrade
+        # to org needs auth_rbac and auth_org).
+        for migration_path in generate_missing_migrations(target_path, updater.answers):
+            brand.success(
+                f"   {t('add_service.generated_migration', name=migration_path.name)}"
+            )
 
         # Auto-run migrations for services that need them
         # Exclude AI service with memory backend (doesn't need migrations)

--- a/aegis/core/auth_service_parser.py
+++ b/aegis/core/auth_service_parser.py
@@ -8,7 +8,9 @@ back-compat with existing callers.
 """
 
 from dataclasses import dataclass
+from typing import Any
 
+from ..constants import AnswerKeys, AuthLevels
 from .option_spec import is_spec_with_options, parse_options
 from .services import SERVICES
 
@@ -36,3 +38,15 @@ def is_auth_service_with_options(service_string: str) -> bool:
     """True when ``service_string`` uses ``auth[...]`` bracket syntax."""
     s = service_string.strip()
     return s.startswith("auth[") and is_spec_with_options(s)
+
+
+def auth_level_answers(level: str) -> dict[str, Any]:
+    """The answers an auth level implies: the level plus the two
+    ``include_auth_*`` flags templates gate on. The single derivation,
+    used wherever a level is set (``add-service auth[org]``, the
+    resolver upgrading auth for a plugin, marker inference on update)."""
+    return {
+        AnswerKeys.AUTH_LEVEL: level,
+        AnswerKeys.AUTH_RBAC: level in (AuthLevels.RBAC, AuthLevels.ORG),
+        AnswerKeys.AUTH_ORG: level == AuthLevels.ORG,
+    }

--- a/aegis/core/manual_updater.py
+++ b/aegis/core/manual_updater.py
@@ -26,6 +26,7 @@ from aegis.constants import (
 from aegis.i18n import t
 
 from ..cli import brand
+from .auth_service_parser import auth_level_answers
 from .component_files import (
     JINJA_EXTENSION,
     MIGRATION_SKILL_FILE,
@@ -110,6 +111,12 @@ _SERVICE_ANSWER_KEYS = (
     AnswerKeys.DOCUMENTS,
     AnswerKeys.FINANCE,
 )
+
+
+def _true_flags(answers: dict[str, Any]) -> dict[str, Any]:
+    """Marker inference only ever asserts what it can see; a flag it
+    cannot confirm stays as the project recorded it."""
+    return {k: v for k, v in answers.items() if v is not False}
 
 
 def _is_empty_stub(path: Path) -> bool:
@@ -425,19 +432,19 @@ class ManualUpdater:
         try:
             # Check if already enabled
             include_key = AnswerKeys.include_key(component)
-            if self.answers.get(include_key) is True:
-                # Allow auth level upgrades (basic → rbac → org)
-                is_auth_upgrade = (
-                    component == AnswerKeys.SERVICE_AUTH
-                    and additional_data
-                    and AnswerKeys.AUTH_LEVEL in additional_data
-                )
-                if not is_auth_upgrade:
-                    raise ValueError(f"Component '{component}' is already enabled")
+            is_variant_upgrade = self._is_variant_upgrade(component, additional_data)
+            if self.answers.get(include_key) is True and not is_variant_upgrade:
+                raise ValueError(f"Component '{component}' is already enabled")
 
             # Merge additional data
-            update_data = additional_data or {}
+            update_data = dict(additional_data or {})
             update_data[include_key] = True
+            # A level implies its include_auth_* flags; derive them here so
+            # every caller that sets a level lands the same answers.
+            if AnswerKeys.AUTH_LEVEL in update_data:
+                update_data.update(
+                    auth_level_answers(update_data[AnswerKeys.AUTH_LEVEL])
+                )
 
             # Update answers with new component
             updated_answers = {**self.answers, **update_data}
@@ -496,9 +503,10 @@ class ManualUpdater:
                     # Check for conflicts
                     if output_path.exists():
                         # Some files have conditional content and must be regenerated
-                        is_auth_upgrade = (
-                            additional_data
-                            and AnswerKeys.AUTH_LEVEL in additional_data
+                        # Files whose body depends on the variant. Only auth
+                        # has entries today; the trigger itself is generic.
+                        regenerate_for_variant = (
+                            is_variant_upgrade
                             and relative_path in REGENERATE_ON_AUTH_LEVEL_CHANGE
                         )
                         # Existing-but-empty files are empty stubs left behind
@@ -509,7 +517,7 @@ class ManualUpdater:
                         is_empty_stub = _is_empty_stub(output_path)
                         if (
                             relative_path in REGENERATE_ON_COMPONENT_CHANGE
-                            or is_auth_upgrade
+                            or regenerate_for_variant
                             or is_empty_stub
                         ):
                             self._write_rendered(output_path, content)
@@ -634,6 +642,7 @@ class ManualUpdater:
             MIGRATION_SPECS,
             bootstrap_alembic,
             generate_migration,
+            generate_missing_migrations,
             service_has_migration,
         )
         from .post_gen_tasks import run_migrations
@@ -650,6 +659,9 @@ class ManualUpdater:
                 # Answers carry the project's database engine, which decides
                 # whether a spec's Postgres schema survives — SQLite has none.
                 generate_migration(self.project_path, service, self.answers)
+            # Level-specific revisions the new answers call for (an auth
+            # upgrade to org needs auth_rbac and auth_org).
+            generate_missing_migrations(self.project_path, self.answers)
             # run_migrations failure is non-fatal — match
             # add_service_command's behaviour. The user can ``alembic
             # upgrade head`` manually later.
@@ -1485,6 +1497,36 @@ class ManualUpdater:
         generate_plugin_migrations(self.project_path, spec, self.answers)
         run_migrations(self.project_path, include_migrations=True)
 
+    def _is_variant_upgrade(
+        self, component: str, additional_data: dict[str, Any] | None
+    ) -> bool:
+        """An already-enabled service asked for a variant above its current one.
+
+        The spec's options say which answers hold its variant
+        (``auth_level``, ``ai_framework``). ``answers_delta`` applies the
+        one rule every caller shares: at or below the current level is
+        satisfied (so a downgrade never rewrites a level), above it is an
+        upgrade, an unordered mismatch is a conflict. ``add-service
+        auth[org]`` on basic auth and the resolver installing a plugin
+        that requires ``auth[org]`` both land here.
+        """
+        if (
+            not additional_data
+            or self.answers.get(AnswerKeys.include_key(component)) is not True
+        ):
+            return False
+        from .option_spec import answers_delta, variant_answer_keys
+
+        spec = self._spec_for(component)
+        if spec is None:
+            return False
+        requested = {
+            key: additional_data[key]
+            for key in variant_answer_keys(spec)
+            if key in additional_data
+        }
+        return bool(answers_delta(spec, requested, self.answers))
+
     def _save_answers(self, answers: dict[str, Any]) -> None:
         """
         Save updated answers to .copier-answers.yml.
@@ -1607,12 +1649,9 @@ class ManualUpdater:
                 except (OSError, UnicodeDecodeError):
                     has_require_role = False
             if auth_module("orgs.py", "org_service.py") is not None:
-                inferred[AnswerKeys.AUTH_LEVEL] = AuthLevels.ORG
-                inferred[AnswerKeys.AUTH_ORG] = True
-                inferred[AnswerKeys.AUTH_RBAC] = True
+                inferred.update(_true_flags(auth_level_answers(AuthLevels.ORG)))
             elif has_require_role:
-                inferred[AnswerKeys.AUTH_LEVEL] = AuthLevels.RBAC
-                inferred[AnswerKeys.AUTH_RBAC] = True
+                inferred.update(_true_flags(auth_level_answers(AuthLevels.RBAC)))
 
         # Auth OAuth marker — file may exist as a non-stub when oauth was wired
         if has_file("app", "components", "backend", "api", "auth", "oauth.py"):

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -4577,6 +4577,26 @@ def _write_migration(project_path: Path, spec: ServiceMigrationSpec) -> Path:
     return migration_path
 
 
+def generate_missing_migrations(
+    project_path: Path, answers: dict[str, Any]
+) -> list[Path]:
+    """Write every migration the project's answers call for that has no
+    revision yet. An auth level upgrade is the common case: the answers
+    now say ``auth_level: org``, so ``auth_rbac`` and ``auth_org`` are
+    needed and missing. Shared by ``add-service`` and the resolver's
+    ``ManualUpdater.add_service`` so both tails agree."""
+    written: list[Path] = []
+    specs = _get_migration_specs()
+    for service_name in get_services_needing_migrations(answers):
+        if service_name in specs and not service_has_migration(
+            project_path, service_name
+        ):
+            path = generate_migration(project_path, service_name, answers)
+            if path is not None:
+                written.append(path)
+    return written
+
+
 def generate_plugin_migrations(
     project_path: Path,
     plugin_spec: Any,

--- a/aegis/core/option_spec.py
+++ b/aegis/core/option_spec.py
@@ -78,6 +78,17 @@ class OptionSpec:
         auto_requires=lambda v: [f"database[{v}]"] if v != "memory" else []
     """
 
+    answer_key: str | None = None
+    """Where this option's chosen value lives in the project's answers
+    (``auth_level``, ``ai_framework``). Set only on SINGLE options whose
+    value is project-wide state; it is what lets a dependency such as
+    ``auth[org]`` be compared against what the project already has."""
+
+    ordered: bool = False
+    """``choices`` are ascending levels (auth: basic < rbac < org). A
+    request at or below the project's current value is satisfied; above
+    it is an upgrade. Unordered options treat any mismatch as a conflict."""
+
 
 # ---------------------------------------------------------------------
 # Parsing
@@ -148,7 +159,7 @@ def parse_options(spec_str: str, plugin_spec: Any) -> dict[str, Any]:
     # Bracket values are case-insensitive (matches the pre-R3 auth /
     # insights behaviour; safe for AI since its choices are already
     # lowercase).
-    values = [v.strip().lower() for v in content.split(",") if v.strip()]
+    values = _bracket_values(content)
 
     # Track per-option occurrences (so we can reject duplicates in SINGLE
     # and duplicates in MULTI / FLAG).
@@ -193,6 +204,102 @@ def parse_options(spec_str: str, plugin_spec: Any) -> dict[str, Any]:
             result[opt.name] = True
 
     return result
+
+
+class VariantConflictError(ValueError):
+    """A bracket request names a value the project holds differently on an
+    unordered option (``ai[langchain]`` on a pydantic-ai project). Never
+    swapped silently: the caller reports it."""
+
+
+def _bracket_values(content: str) -> list[str]:
+    """Bracket content split into normalised values (case-insensitive,
+    matching the pre-R3 auth / insights behaviour)."""
+    return [v.strip().lower() for v in content.split(",") if v.strip()]
+
+
+def variant_answers(spec_str: str, plugin_spec: Any) -> dict[str, Any]:
+    """The answers a request such as ``auth[org]`` names: ``{answer_key:
+    value}`` for every option spelled out in the brackets that maps to an
+    answer. A bare name, or a flag with no ``answer_key``, names nothing.
+    This is what a fresh install applies; it looks at nothing the project
+    already holds (copier records defaults such as ``ai_backend: memory``
+    even for services that are not installed, so comparing there would
+    invent conflicts).
+    """
+    options: list[OptionSpec] = list(getattr(plugin_spec, "options", []) or [])
+    content = _bracket_content(spec_str, plugin_spec.name)
+    if not content or not options:
+        return {}
+    parsed = parse_options(spec_str, plugin_spec)
+    explicit = {
+        opt.name
+        for value in _bracket_values(content)
+        if (opt := _find_option_for_value(value, options)) is not None
+    }
+    return {
+        opt.answer_key: parsed[opt.name]
+        for opt in options
+        if opt.name in explicit
+        and opt.answer_key is not None
+        and opt.mode is OptionMode.SINGLE
+    }
+
+
+def variant_delta(
+    spec_str: str, plugin_spec: Any, answers: dict[str, Any]
+) -> dict[str, Any]:
+    """Answers a request such as ``auth[org]`` would still change on a
+    project that HAS the service: :func:`variant_answers` filtered through
+    :func:`answers_delta`."""
+    return answers_delta(plugin_spec, variant_answers(spec_str, plugin_spec), answers)
+
+
+def answers_delta(
+    plugin_spec: Any, requested: dict[str, Any], answers: dict[str, Any]
+) -> dict[str, Any]:
+    """The subset of ``requested`` (``{answer_key: value}``) the project's
+    answers do not already satisfy.
+
+    An answer that is missing or not one of the option's choices is
+    treated as unset. Ordered options are satisfied by any current value
+    at or above the request; unordered ones raise
+    :class:`VariantConflictError` on a mismatch. Shared by the resolver,
+    ``add-service`` and ``ManualUpdater``, so a downgrade request is
+    "already satisfied" everywhere and never rewrites a level.
+    """
+    by_key = {
+        opt.answer_key: opt
+        for opt in (getattr(plugin_spec, "options", []) or [])
+        if opt.answer_key is not None
+    }
+    delta: dict[str, Any] = {}
+    for key, wanted in requested.items():
+        opt = by_key.get(key)
+        if opt is None:
+            continue
+        current = answers.get(key)
+        if current not in opt.choices:
+            delta[key] = wanted
+        elif opt.ordered:
+            if opt.choices.index(wanted) > opt.choices.index(current):
+                delta[key] = wanted
+        elif current != wanted:
+            raise VariantConflictError(
+                f"{plugin_spec.name}[{wanted}] conflicts with the project's "
+                f"{key}={current!r}; change it deliberately rather than "
+                "through a dependency"
+            )
+    return delta
+
+
+def variant_answer_keys(plugin_spec: Any) -> list[str]:
+    """The answer keys a spec's options map to, in declaration order."""
+    return [
+        opt.answer_key
+        for opt in (getattr(plugin_spec, "options", []) or [])
+        if opt.answer_key is not None
+    ]
 
 
 def _find_option_for_value(value: str, options: list[OptionSpec]) -> OptionSpec | None:

--- a/aegis/core/plugins/resolver.py
+++ b/aegis/core/plugins/resolver.py
@@ -34,6 +34,7 @@ from typing import Any
 
 from ..component_utils import extract_base_component_name
 from ..components import COMPONENTS, CORE_COMPONENTS
+from ..option_spec import variant_answers, variant_delta
 from ..services import SERVICES
 from .compat import _installed_plugins, _is_present, _plugin_name_only
 from .discovery import discover_plugins
@@ -67,11 +68,19 @@ class UnknownDependencyError(Exception):
 
 @dataclass(frozen=True)
 class ResolvedDep:
-    """One dependency the resolver wants the CLI to install."""
+    """One dependency the resolver wants the CLI to install.
+
+    ``variant`` is the constraint as declared (``"auth[org]"``) and
+    ``answers_delta`` the answers it changes on this project
+    (``{"auth_level": "org"}``); both empty for a bare-name dep. When the
+    base service is already installed the delta is an upgrade.
+    """
 
     name: str
     kind: PluginKind
     spec: PluginSpec
+    variant: str | None = None
+    answers_delta: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -200,51 +209,63 @@ def _resolve_one(
 ) -> None:
     """Process one entry from ``required_*``.
 
-    Strips any version-constraint suffix (``"auth>=1.0"`` → ``"auth"``)
-    AND any bracket-variant suffix (``"auth[org]"`` → ``"auth"``) so the
-    registry lookup matches the base-name keys ``SERVICES``/``COMPONENTS``
-    use. Variant-aware install (actually installing the ``[org]`` variant
-    rather than the base) is intentionally out of scope here — the
-    resolver canonicalises and the caller installs the base spec.
+    Strips any version-constraint suffix (``"auth>=1.0"`` → ``"auth"``);
+    the registry keys on the base name, so the bracket variant
+    (``"auth[org]"``) is kept aside and compared against the project's
+    answers through the spec's options. Decides whether the dep is:
 
-    With both suffixes stripped, decides whether the dep is:
-
-    * already installed (skip),
+    * already installed at a level that satisfies the request (skip),
+    * installed below the requested level (queue an upgrade carrying the
+      answers delta),
     * known to the registry but missing from the project (queue for
-      install + recurse for transitive deps),
+      install with the delta, and recurse for transitive deps),
     * a plugin name we have no spec for (record as unresolved and
       stop — can't recurse without a spec).
     """
-    dep_name = _plugin_name_only(dep_constraint)
-    # Collapse bracket variants AFTER version stripping. ``_is_present``
-    # already canonicalises internally, but the registry lookup further
-    # down keys on the bare name, so we have to canonicalise here too —
-    # otherwise ``"auth[org]"`` falls through to ``UnknownDependencyError``
-    # despite ``auth`` being in the registry.
-    dep_name = extract_base_component_name(dep_name)
-    if _is_present(dep_name, answers, plugins_present) or dep_name in CORE_COMPONENTS:
-        return
-
+    requested = _plugin_name_only(dep_constraint)
+    dep_name = extract_base_component_name(requested)
+    variant = requested if requested != dep_name else None
     spec = registry.get(dep_name)
-    if spec is None:
-        # Plugin-kind misses are recoverable: tell the user to pip
-        # install the package and re-run. Service/component misses are
-        # not — those specs are seeded from in-tree registries that are
-        # always present, so a miss is a typo or stale declaration on
-        # the parent spec. Fail loud rather than silently no-op.
-        if kind_hint == "plugin":
-            if dep_name not in result.unresolved_plugins:
-                result.unresolved_plugins.append(dep_name)
-            return
-        raise UnknownDependencyError(
-            f"required {kind_hint} {dep_name!r} declared on a plugin "
-            f"spec is not in the registry (typo or stale declaration?)"
-        )
 
-    # Recurse first so deepest-first ordering is preserved.
-    recurse(spec)
-    if not any(d.name == dep_name for d in result.to_install):
-        result.to_install.append(ResolvedDep(name=dep_name, kind=spec.kind, spec=spec))
+    if _is_present(dep_name, answers, plugins_present) or dep_name in CORE_COMPONENTS:
+        # Installed: a bracket request is met only if the project's
+        # answers already satisfy it; otherwise this is an upgrade.
+        if spec is None or variant is None:
+            return
+        delta = variant_delta(requested, spec, answers)
+        if not delta:
+            return
+    else:
+        if spec is None:
+            # Plugin-kind misses are recoverable: tell the user to pip
+            # install the package and re-run. Service/component misses are
+            # not — those specs are seeded from in-tree registries that are
+            # always present, so a miss is a typo or stale declaration on
+            # the parent spec. Fail loud rather than silently no-op.
+            if kind_hint == "plugin":
+                if dep_name not in result.unresolved_plugins:
+                    result.unresolved_plugins.append(dep_name)
+                return
+            raise UnknownDependencyError(
+                f"required {kind_hint} {dep_name!r} declared on a plugin "
+                f"spec is not in the registry (typo or stale declaration?)"
+            )
+        # Recurse first so deepest-first ordering is preserved. A fresh
+        # install applies what the brackets name; nothing to compare.
+        recurse(spec)
+        delta = variant_answers(requested, spec) if variant else {}
+
+    if spec is None or any(d.name == dep_name for d in result.to_install):
+        return
+    result.to_install.append(
+        ResolvedDep(
+            name=dep_name,
+            kind=spec.kind,
+            spec=spec,
+            variant=variant,
+            answers_delta=delta,
+        )
+    )
 
 
 def format_plan(result: ResolutionResult, target_name: str) -> str:
@@ -263,7 +284,7 @@ def format_plan(result: ResolutionResult, target_name: str) -> str:
     lines: list[str] = [f"Installing {target_name!r} requires:"]
     by_kind: dict[PluginKind, list[str]] = {}
     for dep in result.to_install:
-        by_kind.setdefault(dep.kind, []).append(dep.name)
+        by_kind.setdefault(dep.kind, []).append(dep.variant or dep.name)
 
     for kind in (PluginKind.COMPONENT, PluginKind.SERVICE):
         names = by_kind.get(kind)

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -224,6 +224,8 @@ SERVICES: dict[str, ServiceSpec] = {
                 name="level",
                 mode=OptionMode.SINGLE,
                 choices=list(AuthLevels.ALL),
+                answer_key=AnswerKeys.AUTH_LEVEL,
+                ordered=True,
                 default=AuthLevels.BASIC,
             ),
             OptionSpec(
@@ -425,6 +427,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 mode=OptionMode.SINGLE,
                 choices=list(AIFrameworks.ALL),
                 default=AIFrameworks.PYDANTIC_AI,
+                answer_key=AnswerKeys.AI_FRAMEWORK,
             ),
             OptionSpec(
                 name="backend",
@@ -435,6 +438,7 @@ SERVICES: dict[str, ServiceSpec] = {
                     StorageBackends.POSTGRES,
                 ],
                 default=StorageBackends.MEMORY,
+                answer_key=AnswerKeys.AI_BACKEND,
                 # Persistence backends auto-add the matching database engine.
                 auto_requires=lambda v: [f"{ComponentNames.DATABASE}[{v}]"]
                 if v != StorageBackends.MEMORY

--- a/aegis/core/template_generator.py
+++ b/aegis/core/template_generator.py
@@ -23,7 +23,11 @@ from ..constants import (
     WorkerBackends,
 )
 from .ai_service_parser import is_ai_service_with_options, parse_ai_service_config
-from .auth_service_parser import is_auth_service_with_options, parse_auth_service_config
+from .auth_service_parser import (
+    auth_level_answers,
+    is_auth_service_with_options,
+    parse_auth_service_config,
+)
 from .component_utils import (
     extract_base_component_name,
     extract_base_service_name,
@@ -254,12 +258,13 @@ class TemplateGenerator:
             "needs_redis": ComponentNames.REDIS in self.components,
             # Auth level selection (basic, rbac, or org)
             AnswerKeys.AUTH_LEVEL: (auth_level := self._get_auth_level()),
-            # Derived auth level flags for template conditionals
-            # Org level implies RBAC (org gets both roles and orgs)
-            AnswerKeys.AUTH_RBAC: "yes"
-            if auth_level in (AuthLevels.RBAC, AuthLevels.ORG)
-            else "no",
-            AnswerKeys.AUTH_ORG: "yes" if auth_level == AuthLevels.ORG else "no",
+            # Derived auth level flags for template conditionals, as the
+            # yes/no strings copier expects.
+            **{
+                key: "yes" if value else "no"
+                for key, value in auth_level_answers(auth_level).items()
+                if key != AnswerKeys.AUTH_LEVEL
+            },
             # OAuth social login (GitHub + Google) — opt-in via the
             # ``auth[oauth]`` modifier in the bracket syntax (composes
             # with ``auth[rbac,oauth]`` etc.). Defaults off so existing

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -44,6 +44,13 @@ it out again.
 A plugin that declares `migrations` gets them written and applied on
 `aegis add`, with a Postgres schema of its own when it declares one.
 
+Dependencies can name a variant. `required_services = ["auth[org]"]` asks
+for auth at org level: `aegis add` installs it at that level when the
+project has no auth, upgrades it when the project is at basic or rbac,
+and does nothing when org is already there. A request that would swap an
+unordered choice, such as `ai[langchain]` on a pydantic-ai project, is
+refused with a message rather than applied silently.
+
 ## Publish and get listed
 
 Publish to PyPI as you would any package. The plugin directory at

--- a/tests/cli/test_add_plugin_resolver_integration.py
+++ b/tests/cli/test_add_plugin_resolver_integration.py
@@ -142,6 +142,90 @@ class TestResolverIntegration:
             "add_plugin:needs_auth",
         ]
 
+    def test_variant_dep_upgrades_installed_service(self, fake_project: Path) -> None:
+        """Project has basic auth; the plugin requires ``auth[org]``. The
+        resolver must not treat auth as present: ``add_service`` is called
+        with the org level so the upgrade path runs."""
+        answers = fake_project / ".copier-answers.yml"
+        answers.write_text(
+            answers.read_text().replace(
+                "include_auth: false", "include_auth: true\nauth_level: basic"
+            )
+        )
+        spec = PluginSpec(
+            name="needs_org",
+            kind=PluginKind.SERVICE,
+            description="Plugin that depends on org-level auth",
+            version="0.0.1",
+            verified=False,
+            required_services=["auth[org]"],
+        )
+        calls: list[tuple[str, dict | None]] = []
+
+        def _add_service_side_effect(name: str, data, **_kw) -> MagicMock:
+            calls.append((name, data))
+            return MagicMock(success=True, error_message=None)
+
+        mock_updater = MagicMock()
+        mock_updater.add_service.side_effect = _add_service_side_effect
+        mock_updater.add_component.return_value = MagicMock(success=True)
+        mock_updater.add_plugin.return_value = MagicMock(success=True)
+
+        with (
+            patch(
+                "aegis.commands.add._resolve_plugin",
+                return_value=(spec, "fake_module"),
+            ),
+            patch("aegis.commands.add.ManualUpdater", return_value=mock_updater),
+            patch(
+                "aegis.commands.add.validate_version_compatibility",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["needs_org", "--project-path", str(fake_project), "--yes"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert calls == [("auth", {"auth_level": "org"})]
+
+    def test_conflicting_variant_dep_is_refused(self, fake_project: Path) -> None:
+        """``ai[langchain]`` required on a pydantic-ai project is a conflict:
+        the command exits non-zero before installing anything."""
+        answers = fake_project / ".copier-answers.yml"
+        answers.write_text(
+            answers.read_text() + "include_ai: true\nai_framework: pydantic-ai\n"
+        )
+        spec = PluginSpec(
+            name="needs_langchain",
+            kind=PluginKind.SERVICE,
+            description="Plugin that depends on the LangChain framework",
+            version="0.0.1",
+            verified=False,
+            required_services=["ai[langchain]"],
+        )
+        mock_updater = MagicMock()
+        with (
+            patch(
+                "aegis.commands.add._resolve_plugin",
+                return_value=(spec, "fake_module"),
+            ),
+            patch("aegis.commands.add.ManualUpdater", return_value=mock_updater),
+            patch(
+                "aegis.commands.add.validate_version_compatibility",
+                return_value=None,
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                ["needs_langchain", "--project-path", str(fake_project), "--yes"],
+            )
+
+        assert result.exit_code == 1
+        mock_updater.add_service.assert_not_called()
+        mock_updater.add_plugin.assert_not_called()
+
     def test_dep_install_runs_post_gen_exactly_once(self, fake_project: Path) -> None:
         """Adding a plugin with N transitive deps must trigger exactly
         ONE ``run_post_generation_tasks`` invocation across the whole

--- a/tests/core/test_manual_updater_service.py
+++ b/tests/core/test_manual_updater_service.py
@@ -234,3 +234,136 @@ class TestAddComponentRunPostGenFlag:
             updater.add_component("worker", None)
 
         run_post_gen_mock.assert_called_once()
+
+
+class TestAddServiceVariantUpgrade:
+    """``add_service("auth", {"auth_level": "org"})`` against installed
+    basic auth is an upgrade, not an "already enabled" error, and the
+    level-specific migrations the new answers call for get generated."""
+
+    @staticmethod
+    def _project_with_basic_auth(tmp_path: Path) -> Path:
+        project = tmp_path / "demo"
+        project.mkdir()
+        (project / ".copier-answers.yml").write_text(
+            COPIER_ANSWERS.replace(
+                "include_auth: false", "include_auth: true\nauth_level: basic"
+            )
+        )
+        return project
+
+    def test_variant_upgrade_is_allowed_and_recorded(self, tmp_path: Path) -> None:
+        project = self._project_with_basic_auth(tmp_path)
+        with (
+            patch("aegis.core.migration_generator.bootstrap_alembic"),
+            patch("aegis.core.migration_generator.generate_migration"),
+            patch(
+                "aegis.core.migration_generator.service_has_migration",
+                return_value=True,
+            ),
+            patch("aegis.core.post_gen_tasks.run_migrations"),
+            patch.object(
+                ManualUpdater, "_regenerate_shared_files", return_value=([], [], [])
+            ),
+            patch("aegis.core.manual_updater.get_component_files", return_value=[]),
+        ):
+            result = _make_updater(project).add_service(
+                "auth", {AnswerKeys.AUTH_LEVEL: "org"}, run_post_gen=False
+            )
+        assert result.success, result.error_message
+        answers = _make_updater(project).answers
+        assert answers[AnswerKeys.AUTH_LEVEL] == "org"
+
+    def test_same_variant_is_still_already_enabled(self, tmp_path: Path) -> None:
+        project = self._project_with_basic_auth(tmp_path)
+        with patch.object(
+            ManualUpdater, "_regenerate_shared_files", return_value=([], [], [])
+        ):
+            result = _make_updater(project).add_service(
+                "auth", {AnswerKeys.AUTH_LEVEL: "basic"}, run_post_gen=False
+            )
+        assert not result.success
+        assert _make_updater(project).answers[AnswerKeys.AUTH_LEVEL] == "basic"
+
+    def test_lower_variant_is_already_satisfied(self, tmp_path: Path) -> None:
+        """A downgrade request never rewrites the level: org stays org."""
+        project = tmp_path / "demo"
+        project.mkdir()
+        (project / ".copier-answers.yml").write_text(
+            COPIER_ANSWERS.replace(
+                "include_auth: false", "include_auth: true\nauth_level: org"
+            )
+        )
+        with patch.object(
+            ManualUpdater, "_regenerate_shared_files", return_value=([], [], [])
+        ):
+            result = _make_updater(project).add_service(
+                "auth", {AnswerKeys.AUTH_LEVEL: "basic"}, run_post_gen=False
+            )
+        assert not result.success
+        assert _make_updater(project).answers[AnswerKeys.AUTH_LEVEL] == "org"
+
+    def test_upgrade_generates_level_migrations(self, tmp_path: Path) -> None:
+        """The migration tail asks ``get_services_needing_migrations`` with
+        the post-upgrade answers and writes every one still missing, so
+        the org tables exist after ``add_service`` alone."""
+        project = self._project_with_basic_auth(tmp_path)
+        generated: list[str] = []
+        with (
+            patch("aegis.core.migration_generator.bootstrap_alembic"),
+            patch(
+                "aegis.core.migration_generator.generate_migration",
+                side_effect=lambda _p, name, _a=None: generated.append(name),
+            ),
+            patch(
+                "aegis.core.migration_generator.service_has_migration",
+                return_value=False,
+            ),
+            patch("aegis.core.post_gen_tasks.run_migrations"),
+            patch.object(
+                ManualUpdater, "_regenerate_shared_files", return_value=([], [], [])
+            ),
+            patch("aegis.core.manual_updater.get_component_files", return_value=[]),
+        ):
+            _make_updater(project).add_service(
+                "auth", {AnswerKeys.AUTH_LEVEL: "org"}, run_post_gen=False
+            )
+        assert "auth_org" in generated
+
+
+class TestAuthLevelDerivedFlags:
+    """``auth_level`` implies ``include_auth_rbac`` / ``include_auth_org``.
+    The updater derives them itself, so every caller that sets a level
+    (``add-service auth[org]``, the resolver installing a plugin that
+    requires ``auth[org]``) lands the same answers and the org templates
+    render."""
+
+    def test_upgrade_to_org_sets_both_flags(self, tmp_path: Path) -> None:
+        project = tmp_path / "demo"
+        project.mkdir()
+        (project / ".copier-answers.yml").write_text(
+            COPIER_ANSWERS.replace(
+                "include_auth: false",
+                "include_auth: true\nauth_level: basic\n"
+                "include_auth_rbac: false\ninclude_auth_org: false",
+            )
+        )
+        with (
+            patch("aegis.core.migration_generator.bootstrap_alembic"),
+            patch("aegis.core.migration_generator.generate_migration"),
+            patch(
+                "aegis.core.migration_generator.service_has_migration",
+                return_value=True,
+            ),
+            patch("aegis.core.post_gen_tasks.run_migrations"),
+            patch.object(
+                ManualUpdater, "_regenerate_shared_files", return_value=([], [], [])
+            ),
+            patch("aegis.core.manual_updater.get_component_files", return_value=[]),
+        ):
+            _make_updater(project).add_service(
+                "auth", {AnswerKeys.AUTH_LEVEL: "org"}, run_post_gen=False
+            )
+        answers = _make_updater(project).answers
+        assert answers[AnswerKeys.AUTH_RBAC] is True
+        assert answers[AnswerKeys.AUTH_ORG] is True

--- a/tests/core/test_option_spec.py
+++ b/tests/core/test_option_spec.py
@@ -14,9 +14,12 @@ import pytest
 from aegis.core.option_spec import (
     OptionMode,
     OptionSpec,
+    VariantConflictError,
     compute_auto_requires,
     is_spec_with_options,
     parse_options,
+    variant_answers,
+    variant_delta,
 )
 
 
@@ -279,3 +282,108 @@ class TestComputeAutoRequires:
             "two",
             "three",
         ]
+
+
+class TestVariantDelta:
+    """``variant_delta`` decides whether a bracket request is already met
+    by the project's answers, needs an upgrade, or conflicts.
+
+    Options declare where their value lives in the answers
+    (``answer_key``); ordered options (auth level) treat a lower request
+    as satisfied, unordered ones (AI framework) treat any mismatch as a
+    conflict rather than a silent swap."""
+
+    @staticmethod
+    def _auth() -> _FakeSpec:
+        return _FakeSpec(
+            "auth",
+            [
+                OptionSpec(
+                    name="level",
+                    mode=OptionMode.SINGLE,
+                    choices=["basic", "rbac", "org"],
+                    default="basic",
+                    answer_key="auth_level",
+                    ordered=True,
+                ),
+                OptionSpec(
+                    name="oauth", mode=OptionMode.FLAG, choices=["oauth"], default=False
+                ),
+            ],
+        )
+
+    @staticmethod
+    def _ai() -> _FakeSpec:
+        return _FakeSpec(
+            "ai",
+            [
+                OptionSpec(
+                    name="framework",
+                    mode=OptionMode.SINGLE,
+                    choices=["pydantic-ai", "langchain"],
+                    default="pydantic-ai",
+                    answer_key="ai_framework",
+                ),
+            ],
+        )
+
+    def test_missing_service_returns_every_requested_option(self) -> None:
+        assert variant_delta("auth[org]", self._auth(), {}) == {"auth_level": "org"}
+
+    def test_no_brackets_requests_nothing(self) -> None:
+        assert variant_delta("auth", self._auth(), {"auth_level": "basic"}) == {}
+
+    def test_ordered_option_already_at_or_above_is_satisfied(self) -> None:
+        assert variant_delta("auth[org]", self._auth(), {"auth_level": "org"}) == {}
+        assert variant_delta("auth[basic]", self._auth(), {"auth_level": "org"}) == {}
+
+    def test_ordered_option_below_needs_upgrade(self) -> None:
+        assert variant_delta("auth[org]", self._auth(), {"auth_level": "basic"}) == {
+            "auth_level": "org"
+        }
+
+    def test_installed_without_a_recorded_level_needs_the_request(self) -> None:
+        """Auth installed before levels existed, or a hand-edited answer
+        that is not a choice: treated as unset, so the request applies."""
+        assert variant_delta("auth[rbac]", self._auth(), {"include_auth": True}) == {
+            "auth_level": "rbac"
+        }
+        assert variant_delta("auth[rbac]", self._auth(), {"auth_level": "weird"}) == {
+            "auth_level": "rbac"
+        }
+
+    def test_options_without_answer_key_are_ignored(self) -> None:
+        """Flags such as ``oauth`` have no project-level answer to compare;
+        they never drive an upgrade."""
+        assert variant_delta("auth[oauth]", self._auth(), {"auth_level": "basic"}) == {}
+
+    def test_unordered_mismatch_is_a_conflict(self) -> None:
+        with pytest.raises(VariantConflictError, match="ai_framework"):
+            variant_delta("ai[langchain]", self._ai(), {"ai_framework": "pydantic-ai"})
+
+    def test_fresh_install_ignores_recorded_defaults(self) -> None:
+        """Copier records ``ai_backend: memory`` even when AI is not
+        installed. A fresh ``ai[sqlite]`` names sqlite and compares with
+        nothing; only ``variant_delta`` looks at the project."""
+        ai = _FakeSpec(
+            "ai",
+            [
+                OptionSpec(
+                    name="backend",
+                    mode=OptionMode.SINGLE,
+                    choices=["memory", "sqlite", "postgres"],
+                    default="memory",
+                    answer_key="ai_backend",
+                )
+            ],
+        )
+        assert variant_answers("ai[sqlite]", ai) == {"ai_backend": "sqlite"}
+        assert variant_answers("ai", ai) == {}
+        with pytest.raises(VariantConflictError):
+            variant_delta("ai[sqlite]", ai, {"ai_backend": "memory"})
+
+    def test_unordered_match_is_satisfied(self) -> None:
+        assert (
+            variant_delta("ai[langchain]", self._ai(), {"ai_framework": "langchain"})
+            == {}
+        )

--- a/tests/core/test_plugin_resolver.py
+++ b/tests/core/test_plugin_resolver.py
@@ -75,26 +75,108 @@ class TestServiceDeps:
 
 
 class TestBracketVariants:
-    def test_bracket_variant_resolves_to_base_service(self) -> None:
-        """``required_services=["auth[org]"]`` should canonicalize to
-        ``auth`` and queue the base service. Variant-aware install
-        (actually picking the org variant) is intentionally out of
-        scope for the resolver; the registry keys on base names so
-        without bracket stripping the lookup raises
-        ``UnknownDependencyError`` despite ``auth`` being present."""
-        target = _spec("stripe", required_services=["auth[org]"])
-        registry = {
-            "stripe": target,
-            "auth": _spec("auth"),
-        }
-        result = resolve_dependencies(target, answers={}, registry=registry)
-        assert [d.name for d in result.to_install] == ["auth"]
+    """A dep like ``auth[org]`` is a request for a service AT a level.
+    Presence of the base service is not enough; the resolver compares the
+    requested variant against the project's answers and queues an
+    upgrade when the project falls short."""
 
-    def test_bracket_variant_already_installed_skipped(self) -> None:
-        """Bracket variant should also collapse for the
-        ``already-installed`` short-circuit. ``required_components=
-        ["database[sqlite]"]`` against a project with ``include_database:
-        true`` must NOT re-queue the dep."""
+    @staticmethod
+    def _auth() -> PluginSpec:
+        """The real auth spec: its level option carries the answer key and
+        ordering the resolver relies on."""
+        from aegis.core.services import SERVICES
+
+        return SERVICES["auth"]
+
+    @classmethod
+    def _registry(cls, target: PluginSpec) -> dict[str, PluginSpec]:
+        """Target, the real auth spec, and the database component auth
+        itself requires; every test marks database installed so only
+        auth's own state is under test."""
+        return {
+            target.name: target,
+            "auth": cls._auth(),
+            "database": _spec("database", kind=PluginKind.COMPONENT),
+        }
+
+    def test_missing_service_is_queued_with_its_variant(self) -> None:
+        target = _spec("stripe", required_services=["auth[org]"])
+        registry = self._registry(target)
+        result = resolve_dependencies(
+            target, answers={"include_database": True}, registry=registry
+        )
+        (dep,) = result.to_install
+        assert dep.name == "auth"
+        assert dep.variant == "auth[org]"
+        assert dep.answers_delta == {"auth_level": "org"}
+
+    def test_missing_service_ignores_stale_default_answers(self) -> None:
+        """Answers hold ``auth_level: basic`` from an earlier install or a
+        copier default while ``include_auth`` is false. The service is
+        absent, so the request is applied, never compared."""
+        target = _spec("stripe", required_services=["auth[org]"])
+        registry = self._registry(target)
+        result = resolve_dependencies(
+            target,
+            answers={
+                "include_database": True,
+                "include_auth": False,
+                "auth_level": "basic",
+            },
+            registry=registry,
+        )
+        (dep,) = result.to_install
+        assert dep.answers_delta == {"auth_level": "org"}
+
+    def test_lower_level_installed_is_queued_as_upgrade(self) -> None:
+        target = _spec("stripe", required_services=["auth[org]"])
+        registry = self._registry(target)
+        result = resolve_dependencies(
+            target,
+            answers={
+                "include_database": True,
+                "include_auth": True,
+                "auth_level": "basic",
+            },
+            registry=registry,
+        )
+        (dep,) = result.to_install
+        assert dep.name == "auth"
+        assert dep.answers_delta == {"auth_level": "org"}
+
+    def test_same_level_installed_is_satisfied(self) -> None:
+        target = _spec("stripe", required_services=["auth[org]"])
+        registry = self._registry(target)
+        result = resolve_dependencies(
+            target,
+            answers={
+                "include_database": True,
+                "include_auth": True,
+                "auth_level": "org",
+            },
+            registry=registry,
+        )
+        assert result.is_empty
+
+    def test_base_name_dep_on_installed_service_is_satisfied(self) -> None:
+        """No brackets means any level will do."""
+        target = _spec("stripe", required_services=["auth"])
+        registry = self._registry(target)
+        result = resolve_dependencies(
+            target,
+            answers={
+                "include_database": True,
+                "include_auth": True,
+                "auth_level": "basic",
+            },
+            registry=registry,
+        )
+        assert result.is_empty
+
+    def test_bracket_variant_already_installed_component_skipped(self) -> None:
+        """A component with no declared options still collapses to
+        presence: ``database[sqlite]`` against ``include_database: true``
+        must not re-queue."""
         target = _spec("stripe", required_components=["database[sqlite]"])
         registry = {
             "stripe": target,


### PR DESCRIPTION
## Summary

Closes #671. A plugin declaring `required_services=["auth[org]"]` used to get plain auth, or nothing when any auth was present, then fail at runtime on missing org tables. All three rows of the ticket's matrix now behave:

| project has | plugin needs | result |
|---|---|---|
| no auth | `auth[org]` | auth installed at org level |
| auth basic | `auth[org]` | upgraded to org, rbac and org migrations generated and applied |
| auth org | `auth[org]` | nothing |

### Design
- `OptionSpec` gains `answer_key` and `ordered`, so each spec declares where its variant lives in the answers and whether its choices are levels. No per-service table anywhere.
- `variant_answers` names what a bracket request sets; `answers_delta` decides what an installed service still lacks. At or below the current level is satisfied, above is an upgrade, an unordered mismatch (`ai[langchain]` on a pydantic-ai project) raises `VariantConflictError`. The resolver, `add-service` and `ManualUpdater` share the rule, so a downgrade never rewrites a level, and a fresh install never compares against the defaults copier records for services that are not installed.
- `ResolvedDep` carries the variant and delta; `aegis add` passes it through and reports conflicts with a message.
- `ManualUpdater.add_component` treats a variant delta on an installed service as an upgrade, replacing the auth-only special case. `add_service` writes the level migrations the new answers require through `generate_missing_migrations`, shared with the add-service command.
- `auth_level_answers` is the single derivation of the rbac and org flags from a level, used by the updater, add-service, the template generator and marker inference. This fixed a gap found on the real run: the resolver path landed the level but not the flags.

### Tests
Written first at each layer: delta helper (satisfied, upgrade, conflict, stale and missing answers, fresh install ignoring defaults), resolver (missing, lower, same, bare-name, component bracket), updater (upgrade allowed, same and lower refused, level migrations generated, derived flags), add-command integration (upgrade passes the org level, conflict exits 1 and installs nothing). Scoped run across touched files: 372 passed.

### Proven on real stacks
`add-service auth[org]` on basic auth, a fresh `add-service ai[sqlite]` against the stale memory default, and `aegis add` of a scaffolded plugin requiring `auth[org]` on basic auth: org level, both flags, org modules rendered, `organization` table present.

Out of scope, per the ticket: component variants, version constraints combined with variants.