### PR TITLE
Plugin install path: services card, dashboard naming, and a conformance test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 
 ### Changed
 
+- **A plugin names itself once and every dashboard surface honours it.**
+  `get_component_subtitle` now prefers the `subtitle` a health check
+  declares in its metadata, and both the stack view and the architecture
+  diagram route their fallback through it. A plugin is in no label
+  registry, so the stack view showed a blank description and the diagram
+  showed the raw health id.
 - **Plugin dependencies can name a service variant.** A plugin declaring
   `required_services=["auth[org]"]` now gets auth at org level: installed
   fresh at that level, upgraded when the project has a lower level, left
@@ -56,6 +62,11 @@
 
 ### Fixed
 
+- **`aegis add <plugin>` restores the services card.** The shared
+  `cards/__init__.py` imports `ServicesCard` once any plugin is present,
+  but only the component install path ensured that module exists, so
+  adding a plugin to a project with no services left a dangling import
+  and the frontend died on boot with `ModuleNotFoundError`.
 - **htmx dev stack no longer breaks host tooling.** The tailwind container
   installs `node_modules` into a named volume instead of the bind mount, so
   a macOS or Windows host never inherits Linux binaries that make

--- a/aegis/core/manual_updater.py
+++ b/aegis/core/manual_updater.py
@@ -40,6 +40,7 @@ from .component_files import (
     get_template_path,
 )
 from .copier_manager import is_copier_project, load_copier_answers
+from .plugins.composer import PLUGINS_ANSWER_KEY
 from .plugins.template_resolver import get_plugin_template_root
 from .render_diff import FilePolicy, RenderDiffEngine, build_template_env
 from .template_cleanup import run_ruff_on_text
@@ -1068,16 +1069,21 @@ class ManualUpdater:
         """Create ``services_card.py`` when an add brings the first service.
 
         ``ServicesCard`` is rendered at init and removed by post-gen cleanup
-        when zero services are selected. On ``add-service`` the first service
-        flips that condition back on, and the shared ``cards/__init__.py``
-        regenerates to import ``ServicesCard`` — so the module must exist or the
-        frontend import chain breaks (``ModuleNotFoundError`` on boot). The
-        removal direction lives in ``post_gen_tasks.cleanup_components``; this is
-        its add-side mirror.
+        when zero services are selected. The first service — or the first
+        plugin, which the dashboard treats the same way — flips that
+        condition back on, and the shared ``cards/__init__.py`` regenerates
+        to import ``ServicesCard``, so the module must exist or the frontend
+        import chain breaks (``ModuleNotFoundError`` on boot). The removal
+        direction lives in ``post_gen_tasks.cleanup_components``; this is its
+        add-side mirror, called from both ``add_component`` and ``add_plugin``.
 
         Returns the project-relative path if it created the file, else None.
         """
-        if not any(answers.get(key) for key in _SERVICE_ANSWER_KEYS):
+        # Mirrors the condition in ``cards/__init__.py.jinja``: a plugin
+        # is a service on the dashboard, so it brings ServicesCard back
+        # just as an in-tree service does.
+        has_service = any(answers.get(key) for key in _SERVICE_ANSWER_KEYS)
+        if not has_service and not answers.get(PLUGINS_ANSWER_KEY):
             return None
         output_path = self.project_path / SERVICES_CARD_FILE
         if output_path.exists():
@@ -1273,7 +1279,6 @@ class ManualUpdater:
         clear error message if the plugin isn't currently installed.
         """
         from .file_manifest import apply_cleanup_path, iter_cleanup_paths
-        from .plugins.composer import PLUGINS_ANSWER_KEY
 
         files_deleted: list[str] = []
         try:
@@ -1374,7 +1379,7 @@ class ManualUpdater:
         once at the end (avoids the N+1 sync that nesting would
         otherwise produce).
         """
-        from .plugins.composer import PLUGINS_ANSWER_KEY, serialize_plugin_to_answer
+        from .plugins.composer import serialize_plugin_to_answer
 
         files_modified: list[str] = []
         try:
@@ -1452,6 +1457,12 @@ class ManualUpdater:
                         path=f"{PLUGIN_BACKUP_DIR / backup_label}",
                     )
                 )
+
+            # Cross-spec: the shared cards/__init__.py imports ServicesCard
+            # once any plugin is present, so make sure the module exists.
+            created_card = self._ensure_services_card(updated_answers)
+            if created_card:
+                files_modified.append(created_card)
 
             # Migration tail, the same one ``add_service`` gives in-tree
             # services: a plugin that declares tables needs alembic

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/diagram/diagram_node.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/diagram/diagram_node.py
@@ -6,17 +6,16 @@ click-to-open-modal functionality and hover effects.
 """
 
 import flet as ft
-
 from app.components.frontend.theme import AegisTheme as Theme
 from app.services.system.models import ComponentStatus, ComponentStatusType
-from app.services.system.ui import get_component_label, get_component_subtitle
+from app.services.system.ui import get_component_subtitle
 
 from ..cards.card_utils import _open_modal, get_ai_engine_display
 
 # Display names per component id. The id itself is what opens the modal:
 # cards, overview rows and diagram nodes all use the health-tree id, and
 # the modal registers under it, so there is no second name to keep in step.
-# Subtitles are generated dynamically via get_component_label()
+# Subtitles are generated dynamically via get_component_subtitle()
 COMPONENT_NAMES: dict[str, str] = {
     "backend": "Server",
     "database": "Database",
@@ -112,11 +111,10 @@ class DiagramNode(ft.Container):
             return get_ai_engine_display(metadata)
         elif component_name == "service_auth":
             return "JWT Authentication"
-        elif component_name in ("ingress", "worker", "service_insights"):
-            return get_component_subtitle(component_name, metadata)
-
-        # Fall back to static label
-        return get_component_label(component_name)
+        # Everything else, plugins included, takes its name from the
+        # health metadata when it declares one and the static label
+        # otherwise.
+        return get_component_subtitle(component_name, metadata)
 
     def _build(self) -> None:
         """Build the node visual content."""

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/status_overview.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/dashboard/status_overview.py.jinja
@@ -139,9 +139,11 @@ def get_component_display_info(
         return ("Frontend", "Flet")
 
     else:
-        # Generic fallback
+        # Generic fallback, which is the path every plugin takes: the name
+        # comes from the health metadata the plugin declares.
         display_name = component_name.replace("_", " ").replace("service ", "").title()
-        return (display_name, "")
+        subtitle = get_component_subtitle(component_name, metadata)
+        return (display_name, "" if subtitle == display_name else subtitle)
 
 
 def create_status_cell(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/ui.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/ui.py.jinja
@@ -160,8 +160,11 @@ def get_component_subtitle(
 ) -> str:
     """Get a versioned subtitle for a component (e.g. 'Dramatiq 1.17.0').
 
-    Uses the base label from ``get_component_label`` and appends the version
-    from health-check metadata when available.
+    The base label is whatever the health metadata declares as
+    ``subtitle`` (how a plugin names itself, being in no registry),
+    otherwise ``get_component_label``. The metadata ``version`` is
+    appended when known. Every dashboard surface routes through here, so
+    the stack view, the cards and the diagram cannot disagree.
     """
     if component_name == "database":
         return get_database_subtitle(metadata)
@@ -180,11 +183,14 @@ def get_component_subtitle(
         return "Adoption Analytics"
 {% endif %}
 
-    label = get_component_label(component_name)
-    if metadata:
-        version = metadata.get("version", "")
-        if version and version != "unknown":
-            return f"{label} {version}"
+    # A plugin is in no label registry, so it names itself in its health
+    # metadata; that name wins over the derived one.
+    metadata = metadata or {}
+    declared = metadata.get("subtitle")
+    label = str(declared) if declared else get_component_label(component_name)
+    version = metadata.get("version", "")
+    if version and version != "unknown":
+        return f"{label} {version}"
     return label
 
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_plugin_display.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/frontend/test_plugin_display.py
@@ -1,0 +1,64 @@
+"""A plugin names itself once, in health metadata, and every dashboard
+surface honours it.
+
+A plugin is not in the component registry the stack view and the
+architecture diagram look their labels up in, so both fell back to the
+raw health id: the stack view showed a blank description and the diagram
+showed "Service Crawler" for a crawl4ai plugin. The convention a health
+check follows is to put ``subtitle`` (and optionally ``version``) in its
+metadata; these are the surfaces that have to read it.
+"""
+
+from app.components.frontend.dashboard.diagram.diagram_node import DiagramNode
+from app.components.frontend.dashboard.status_overview import (
+    get_component_display_info,
+)
+from app.services.system.models import ComponentStatus, ComponentStatusType
+from app.services.system.ui import get_component_subtitle
+
+PLUGIN_ID = "service_Crawler"
+PLUGIN_METADATA = {"subtitle": "Crawl4AI", "version": "0.9.3"}
+
+
+def _status(metadata: dict[str, object]) -> ComponentStatus:
+    return ComponentStatus(
+        name="Crawler",
+        status=ComponentStatusType.HEALTHY,
+        message="OK",
+        metadata=metadata,
+    )
+
+
+def test_helper_prefers_the_name_health_metadata_declares() -> None:
+    assert get_component_subtitle(PLUGIN_ID, PLUGIN_METADATA) == "Crawl4AI 0.9.3"
+
+
+def test_helper_falls_back_to_the_registry_label() -> None:
+    """An in-tree component names nothing in metadata and is unaffected."""
+    assert get_component_subtitle("cache", {}) == "Redis"
+
+
+def test_stack_view_shows_the_declared_name() -> None:
+    title, subtitle = get_component_display_info(PLUGIN_ID, _status(PLUGIN_METADATA))
+    assert title == "Crawler"
+    assert subtitle == "Crawl4AI 0.9.3"
+
+
+def test_diagram_shows_the_declared_name() -> None:
+    # ``_get_subtitle`` reads only its arguments, so it needs no node.
+    subtitle = DiagramNode._get_subtitle(None, PLUGIN_ID, _status(PLUGIN_METADATA))
+    assert subtitle == "Crawl4AI 0.9.3"
+
+
+def test_surfaces_agree_without_a_version() -> None:
+    status = _status({"subtitle": "Crawl4AI"})
+    assert get_component_display_info(PLUGIN_ID, status)[1] == "Crawl4AI"
+    assert DiagramNode._get_subtitle(None, PLUGIN_ID, status) == "Crawl4AI"
+
+
+def test_plugin_with_no_declared_name_never_shows_the_raw_id() -> None:
+    status = _status({})
+    title, subtitle = get_component_display_info(PLUGIN_ID, status)
+    assert title == "Crawler"
+    assert "service_" not in subtitle
+    assert "service_" not in DiagramNode._get_subtitle(None, PLUGIN_ID, status)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,6 +84,7 @@ dev = [
     "alembic>=1.13.0",    # For migrate-fix integration tests
     "opencc-python-reimplemented>=0.1.7",  # Simplified → Traditional Chinese conversion
     "aegis-plugin-test",  # In-repo fake plugin (tests/fixtures); see [tool.uv.sources]
+    "aegis-stack-conformance",  # In-repo plugin declaring every mechanism
 ]
 docs = [
     "mkdocs>=1.5.0",
@@ -125,6 +126,7 @@ aegis-stack = "aegis.__main__:app"
 # (entry point + src layout). Pinned via path so ``uv sync --all-extras``
 # installs it editable in CI.
 aegis-plugin-test = { path = "tests/fixtures/aegis_plugin_test", editable = true }
+aegis-stack-conformance = { path = "tests/fixtures/aegis_stack_conformance", editable = true }
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/cli/test_plugin_conformance.py
+++ b/tests/cli/test_plugin_conformance.py
@@ -1,0 +1,188 @@
+"""Every mechanism ``aegis add <plugin>`` is supposed to fire, checked once.
+
+Three gaps shipped because a mechanism existed for in-tree services and
+was never wired for the plugin path: a plugin's migrations never ran
+(#1075), the cross-spec ``services_card.py`` was never restored so the
+frontend died on import, and ``auto_requires`` is still never applied
+(#1079). Each was found by hand, in a real project, one at a time.
+
+``aegis_stack_conformance`` declares one of everything. This installs it
+into a real generated project through the real CLI, with nothing mocked,
+and asserts each mechanism left the consequence it is supposed to leave.
+A fourth gap of the same shape fails here instead of in someone's stack.
+
+Deliberately not covered: dashboard cards and modals, which need Flet
+controls to import cleanly and are exercised end to end by the crawl4ai
+reference plugin instead.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from tests.cli.test_utils import run_aegis_command, run_aegis_init
+
+pytestmark = pytest.mark.slow
+
+
+@pytest.fixture(scope="module")
+def project(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A bare database project with the conformance plugin added."""
+    out = tmp_path_factory.mktemp("conformance")
+    result = run_aegis_init("conf-app", components=["database"], output_dir=out)
+    assert result.success, f"init failed: {result.stderr}"
+    target = out / "conf-app"
+
+    added = run_aegis_command(
+        "add", "conformance", "--project-path", str(target), "--yes"
+    )
+    assert added.success, f"add conformance failed: {added.stderr}\n{added.stdout}"
+    return target
+
+
+def _read(project: Path, relative: str) -> str:
+    path = project / relative
+    assert path.is_file(), f"{relative} was never written"
+    return path.read_text()
+
+
+class TestFilesAndAnswers:
+    def test_the_plugins_own_files_render(self, project: Path) -> None:
+        assert (project / "app/services/conformance/api.py").is_file()
+        assert (project / "app/cli/conformance.py").is_file()
+
+    def test_the_plugin_is_recorded_in_answers(self, project: Path) -> None:
+        answers = _read(project, ".copier-answers.yml")
+        assert "name: conformance" in answers
+
+
+class TestMigrations:
+    """#1075: a plugin's declared migrations have to be written and run."""
+
+    def test_the_migration_is_written(self, project: Path) -> None:
+        versions = sorted((project / "alembic/versions").glob("*_conformance.py"))
+        assert versions, "no migration was generated for the plugin"
+
+    def test_the_migration_creates_the_declared_table(self, project: Path) -> None:
+        """Applying it needs a synced project venv, which this test has
+        no business building; that the revision is valid Python and
+        creates the declared table is the property #1075 was about."""
+        migration = next((project / "alembic/versions").glob("*_conformance.py"))
+        body = migration.read_text()
+        ast.parse(body)
+        assert "conformance_row" in body
+        assert "ix_conformance_row_label" in body
+
+    def test_the_schema_is_dropped_on_sqlite(self, project: Path) -> None:
+        """The spec declares a Postgres schema; SQLite has none."""
+        migration = next((project / "alembic/versions").glob("*_conformance.py"))
+        body = migration.read_text()
+        assert "CREATE SCHEMA" not in body
+        assert "schema='conformance'" not in body
+
+
+class TestCrossSpecFiles:
+    """A plugin is a service on the dashboard, so the shared card that
+    only exists when a project has services must come back with it."""
+
+    def test_the_services_card_is_restored(self, project: Path) -> None:
+        card = "app/components/frontend/dashboard/cards/services_card.py"
+        assert (project / card).is_file(), (
+            "cards/__init__.py imports ServicesCard once any plugin is "
+            "present; the module has to exist or the frontend dies on import"
+        )
+
+    def test_the_cards_index_imports_what_exists(self, project: Path) -> None:
+        index = _read(project, "app/components/frontend/dashboard/cards/__init__.py")
+        for line in index.splitlines():
+            if line.startswith("from .") and " import " in line:
+                module = line.split()[1].lstrip(".").split(" ")[0]
+                path = project / "app/components/frontend/dashboard/cards"
+                assert (path / f"{module}.py").is_file(), (
+                    f"cards/__init__.py imports {module}, which does not exist"
+                )
+
+
+class TestWiring:
+    def test_the_router_is_mounted(self, project: Path) -> None:
+        routing = _read(project, "app/components/backend/api/routing.py")
+        assert "app.services.conformance.api" in routing
+        assert "/api/v1/conformance" in routing
+
+    def test_the_settings_mixin_is_composed(self, project: Path) -> None:
+        config = _read(project, "app/core/config.py")
+        assert "ConformanceSettingsMixin" in config
+
+    def test_the_health_check_is_registered(self, project: Path) -> None:
+        startup = _read(project, "app/components/backend/startup/component_health.py")
+        assert "conformance_health" in startup
+        assert 'register_service_health_check("Conformance"' in startup
+
+    def test_the_cli_group_is_registered(self, project: Path) -> None:
+        main = _read(project, "app/cli/main.py")
+        assert "conformance" in main
+
+
+class TestAutoRequires:
+    """#1079: an option declaring ``auto_requires`` must install what it
+    asks for, the way ``ai[sqlite]`` pulls in a database."""
+
+    @pytest.mark.xfail(
+        reason="#1079: compute_auto_requires is never called on the plugin path",
+        strict=True,
+    )
+    def test_an_option_pulls_in_the_component_it_requires(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        out = tmp_path_factory.mktemp("conformance-objects")
+        result = run_aegis_init("obj-app", components=["database"], output_dir=out)
+        assert result.success, f"init failed: {result.stderr}"
+        target = out / "obj-app"
+
+        added = run_aegis_command(
+            "add", "conformance[objects]", "--project-path", str(target), "--yes"
+        )
+        assert added.success, f"add failed: {added.stderr}"
+        answers = (target / ".copier-answers.yml").read_text()
+        assert "include_storage: true" in answers
+
+
+class TestLateComponent:
+    """A component added after the plugin has to reach the plugin's
+    render-time gates.
+
+    Jinja decides ``{% if include_worker %}`` when the tree is rendered.
+    Installing the worker later changes the answer without re-rendering
+    anything the plugin owns, so the plugin keeps the branch it was born
+    with. The same is true of the in-tree documents service, whose
+    ``extraction/dispatch.py`` stays on its no-worker branch after
+    ``aegis add worker``.
+    """
+
+    @pytest.mark.xfail(
+        reason="#1080: adding a component never re-renders installed plugin trees",
+        strict=True,
+    )
+    def test_adding_a_component_rerenders_the_plugin(
+        self, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        out = tmp_path_factory.mktemp("conformance-late")
+        result = run_aegis_init("late-app", components=["database"], output_dir=out)
+        assert result.success, f"init failed: {result.stderr}"
+        target = out / "late-app"
+
+        added = run_aegis_command(
+            "add", "conformance", "--project-path", str(target), "--yes"
+        )
+        assert added.success, f"add conformance failed: {added.stderr}"
+        dispatch = target / "app/services/conformance/dispatch.py"
+        assert 'DISPATCH = "in-process"' in dispatch.read_text()
+
+        worker = run_aegis_command(
+            "add", "worker", "--project-path", str(target), "--yes"
+        )
+        assert worker.success, f"add worker failed: {worker.stderr}"
+        assert 'DISPATCH = "worker"' in dispatch.read_text()

--- a/tests/core/test_manual_updater_plugins.py
+++ b/tests/core/test_manual_updater_plugins.py
@@ -19,7 +19,11 @@ from pathlib import Path
 
 import pytest
 
-from aegis.core.manual_updater import ManualUpdater, _safe_path_segment
+from aegis.core.manual_updater import (
+    SERVICES_CARD_FILE,
+    ManualUpdater,
+    _safe_path_segment,
+)
 
 # Make sure the in-repo fake plugin is importable via importlib.resources.
 TESTS_FIXTURES = Path(__file__).resolve().parent.parent / "fixtures"
@@ -463,3 +467,62 @@ class TestAddPluginRunsMigrationTail:
                 plugin_module_name="aegis_plugin_test",
             )
         bootstrap.assert_not_called()
+
+
+class TestAddPluginEnsuresServicesCard:
+    """A plugin counts as a service on the dashboard.
+
+    ``cards/__init__.py`` imports ``ServicesCard`` when the project has any
+    service OR any plugin, and init deletes ``services_card.py`` from a
+    project that has neither. Installing a plugin flips that condition back
+    on, so the module must be restored or the frontend import chain dies
+    with ``ModuleNotFoundError`` on boot. ``add_component`` has always done
+    this; the plugin path did not.
+    """
+
+    def test_first_plugin_restores_services_card(
+        self, fake_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aegis_plugin_test.spec import get_spec
+
+        monkeypatch.setattr(
+            ManualUpdater, "run_post_generation_tasks", lambda self: None
+        )
+        monkeypatch.setattr(
+            ManualUpdater,
+            "_regenerate_shared_files",
+            lambda self, ans: ([], [], []),
+        )
+        card = fake_project / SERVICES_CARD_FILE
+        assert not card.exists()
+
+        result = ManualUpdater(fake_project).add_plugin(
+            spec=get_spec(), plugin_module_name="aegis_plugin_test"
+        )
+
+        assert result.success
+        assert card.is_file()
+        assert str(SERVICES_CARD_FILE) in result.files_modified
+
+    def test_existing_services_card_is_left_alone(
+        self, fake_project: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from aegis_plugin_test.spec import get_spec
+
+        monkeypatch.setattr(
+            ManualUpdater, "run_post_generation_tasks", lambda self: None
+        )
+        monkeypatch.setattr(
+            ManualUpdater,
+            "_regenerate_shared_files",
+            lambda self, ans: ([], [], []),
+        )
+        card = fake_project / SERVICES_CARD_FILE
+        card.parent.mkdir(parents=True, exist_ok=True)
+        card.write_text("# hand-edited\n")
+
+        ManualUpdater(fake_project).add_plugin(
+            spec=get_spec(), plugin_module_name="aegis_plugin_test"
+        )
+
+        assert card.read_text() == "# hand-edited\n"

--- a/tests/fixtures/aegis_stack_conformance/pyproject.toml
+++ b/tests/fixtures/aegis_stack_conformance/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "aegis-stack-conformance"
+version = "0.0.1"
+description = "Fake plugin that exercises every PluginSpec mechanism, for tests."
+requires-python = ">=3.10"
+
+[project.entry-points."aegis.plugins"]
+conformance = "aegis_stack_conformance.spec:get_spec"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aegis_stack_conformance"]

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/__init__.py
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/__init__.py
@@ -1,0 +1,2 @@
+"""A plugin that declares one of everything, so the plugin install path
+can be checked mechanism by mechanism. See ``spec.py``."""

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/spec.py
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/spec.py
@@ -1,0 +1,96 @@
+"""A plugin that declares one of everything the install path can wire.
+
+Nothing here is useful at runtime. The point is that every mechanism
+``aegis add <plugin>`` is supposed to fire has a visible consequence in
+the generated project, so ``tests/cli/test_plugin_conformance.py`` can
+assert on it. Three gaps shipped because a mechanism existed for in-tree
+services and was never wired for plugins: migrations never ran (#1075),
+the cross-spec services card was never restored, and ``auto_requires``
+is still never applied (#1079). Each was found by hand, one at a time.
+"""
+
+from aegis.core.file_manifest import FileManifest
+from aegis.core.migration_spec import ColumnSpec, IndexSpec, MigrationSpec, TableSpec
+from aegis.core.option_spec import OptionMode, OptionSpec
+from aegis.core.plugins.spec import (
+    HealthCheckWiring,
+    PluginKind,
+    PluginSpec,
+    PluginWiring,
+    RouterWiring,
+    SymbolWiring,
+)
+
+
+def get_spec() -> PluginSpec:
+    return PluginSpec(
+        name="conformance",
+        kind=PluginKind.SERVICE,
+        description="Declares one of every plugin mechanism.",
+        version="0.0.1",
+        verified=False,
+        cli_name="conformance",
+        required_components=["database"],
+        options=[
+            # ``objects`` should pull in the storage component the way
+            # ``ai[sqlite]`` pulls in a database. It does not today.
+            OptionSpec(
+                name="bodies",
+                mode=OptionMode.SINGLE,
+                choices=["column", "objects"],
+                default="column",
+                answer_key="conformance_bodies",
+                auto_requires=lambda v: ["storage"] if v == "objects" else [],
+            ),
+        ],
+        migrations=[
+            MigrationSpec(
+                service_name="conformance",
+                description="Conformance table",
+                schema="conformance",
+                tables=[
+                    TableSpec(
+                        name="conformance_row",
+                        columns=[
+                            ColumnSpec(
+                                "id", "sa.Integer()", nullable=False, primary_key=True
+                            ),
+                            ColumnSpec("label", "sa.String(length=64)", nullable=False),
+                            ColumnSpec(
+                                "created_at",
+                                "sa.DateTime(timezone=True)",
+                                nullable=False,
+                            ),
+                        ],
+                        indexes=[IndexSpec("ix_conformance_row_label", ["label"])],
+                    ),
+                ],
+            ),
+        ],
+        files=FileManifest(
+            primary=["app/services/conformance", "app/cli/conformance.py"]
+        ),
+        wiring=PluginWiring(
+            routers=[
+                RouterWiring(
+                    module="app.services.conformance.api",
+                    symbol="router",
+                    prefix="/api/v1/conformance",
+                    tags=["conformance"],
+                ),
+            ],
+            settings_mixins=[
+                SymbolWiring(
+                    module="app.services.conformance.settings",
+                    symbol="ConformanceSettingsMixin",
+                ),
+            ],
+            health_checks=[
+                HealthCheckWiring(
+                    module="app.services.conformance.health",
+                    symbol="conformance_health",
+                    label="Conformance",
+                ),
+            ],
+        ),
+    )

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/cli/conformance.py.jinja
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/cli/conformance.py.jinja
@@ -1,0 +1,11 @@
+"""CLI group: proves ``cli_name`` reached the project's CLI."""
+
+import typer
+
+app = typer.Typer(help="Conformance plugin commands.")
+
+
+@app.command()
+def marker() -> None:
+    """Print the marker."""
+    typer.echo("wired")

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/__init__.py.jinja
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/__init__.py.jinja
@@ -1,0 +1,1 @@
+"""Files this plugin owns in the target project."""

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/api.py.jinja
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/api.py.jinja
@@ -1,0 +1,10 @@
+"""Router: proves ``routers`` wiring reached routing.py."""
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/marker")
+async def marker() -> dict[str, str]:
+    return {"marker": "wired"}

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/dispatch.py.jinja
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/dispatch.py.jinja
@@ -1,0 +1,13 @@
+"""Where work runs: the worker when the stack has one, else this process.
+
+Gated at render time, the way the documents service gates its extraction
+dispatch. A component added after this plugin was installed has to reach
+this file, or the plugin keeps the branch it was born with.
+"""
+{%- if include_worker %}
+
+DISPATCH = "worker"
+{%- else %}
+
+DISPATCH = "in-process"
+{%- endif %}

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/health.py.jinja
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/health.py.jinja
@@ -1,0 +1,12 @@
+"""Health check: proves ``health_checks`` wiring reached the health tree."""
+
+from app.services.system.models import ComponentStatus, ComponentStatusType
+
+
+async def conformance_health() -> ComponentStatus:
+    return ComponentStatus(
+        name="Conformance",
+        status=ComponentStatusType.HEALTHY,
+        message="OK",
+        metadata={"subtitle": "Conformance", "version": "0.0.1"},
+    )

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/models.py.jinja
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/models.py.jinja
@@ -1,0 +1,18 @@
+"""One table, so the migration mechanism has something to create."""
+
+from datetime import datetime
+
+from sqlmodel import Field, SQLModel
+
+from app.core.time import utcnow
+
+
+class ConformanceRow(SQLModel, table=True):
+    __tablename__ = "conformance_row"
+{%- if database_engine == "postgres" %}
+    __table_args__ = {"schema": "conformance"}
+{%- endif %}
+
+    id: int | None = Field(default=None, primary_key=True)
+    label: str = Field(max_length=64)
+    created_at: datetime = Field(default_factory=utcnow)

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/settings.py.jinja
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/templates/{{ project_slug }}/app/services/conformance/settings.py.jinja
@@ -1,0 +1,7 @@
+"""Settings mixin: proves ``settings_mixins`` wiring reached config.py."""
+
+from pydantic_settings import BaseSettings
+
+
+class ConformanceSettingsMixin(BaseSettings):
+    CONFORMANCE_MARKER: str = "wired"

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ dependencies = [
 [package.optional-dependencies]
 dev = [
     { name = "aegis-plugin-test" },
+    { name = "aegis-stack-conformance" },
     { name = "alembic" },
     { name = "opencc-python-reimplemented" },
     { name = "pip-audit" },
@@ -50,6 +51,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "aegis-plugin-test", marker = "extra == 'dev'", editable = "tests/fixtures/aegis_plugin_test" },
+    { name = "aegis-stack-conformance", marker = "extra == 'dev'", editable = "tests/fixtures/aegis_stack_conformance" },
     { name = "alembic", marker = "extra == 'dev'", specifier = ">=1.13.0" },
     { name = "copier", specifier = ">=9.11.2,<9.15" },
     { name = "filelock", specifier = ">=3.20.1" },
@@ -74,10 +76,15 @@ requires-dist = [
     { name = "ruff", specifier = ">=0.9.0" },
     { name = "sqlalchemy", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "ty", marker = "extra == 'dev'", specifier = ">=0.0.8" },
-    { name = "typer", specifier = "==0.27.1" },
+    { name = "typer", specifier = "==0.27.2" },
     { name = "urllib3", specifier = ">=2.7.0" },
 ]
 provides-extras = ["dev", "docs"]
+
+[[package]]
+name = "aegis-stack-conformance"
+version = "0.0.1"
+source = { editable = "tests/fixtures/aegis_stack_conformance" }
 
 [[package]]
 name = "alembic"
@@ -1515,7 +1522,7 @@ wheels = [
 
 [[package]]
 name = "typer"
-version = "0.27.1"
+version = "0.27.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1523,9 +1530,9 @@ dependencies = [
     { name = "rich" },
     { name = "shellingham" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/40/4a3db7990d1f62a53182aa96eaef57aeb2886a27f90a195bc66713565d31/typer-0.27.1.tar.gz", hash = "sha256:a79bef8469a79c45498e7b814ecf8d603cc7644e9acbd9e19cac0334240b18df", size = 203994, upload-time = "2026-08-03T14:41:03.438Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/16/f7/57713ba479fd405eb76de31404b2c744c289e336b2d999511ebf51e496f7/typer-0.27.2.tar.gz", hash = "sha256:269b7eb9d3c202ca84b4bc9618cb04ebb43d3d4d1e567e4c768607232c05f945", size = 204045, upload-time = "2026-08-28T10:26:55.046Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/89/9518bc0c3929bee36b3a4a8e3daddd6e03f92f9961c66d4983b837160543/typer-0.27.1-py3-none-any.whl", hash = "sha256:53150287edd11baeb4e4722c8e394fcdf8181c0ae89485cba8d25c778d5edd56", size = 122874, upload-time = "2026-08-03T14:41:04.391Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/bf/205d0004930ede8f542fb58f601526fccf4ae7626075ca1e6c4de5d3d652/typer-0.27.2-py3-none-any.whl", hash = "sha256:b3a5fc4342d5fc8fda8fc3010b1cf117e9249aab7fae800c2eff62fd3842d97d", size = 123130, upload-time = "2026-08-28T10:26:53.752Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Three findings from putting the crawl4ai reference plugin into a fresh stack and actually booting it. The first two broke the webserver on import, and no unit test could see either.

### `aegis add <plugin>` never restored the services card
The shared `cards/__init__.py` imports `ServicesCard` once any plugin is present, but only the component install path ensured that module exists. Adding a plugin to a project with no services left a dangling import and the frontend died with `ModuleNotFoundError` on boot. `_ensure_services_card` is now plugin-aware and `add_plugin` calls it, the same way `add_component` always has. Same family as the migrations gap in #1075.

### A plugin had no name on two dashboard surfaces
A plugin is in no label registry, so the stack view showed a blank description and the architecture diagram showed the raw health id (`Service Crawler`). `get_component_subtitle` now prefers whatever a health check declares as `subtitle` in its metadata, and both the stack view fallback and the diagram fallback route through it. Generic: any plugin that names itself in health metadata gets it. Six tests in the generated suite pin it.

### A conformance test, so the next one fails here
`tests/fixtures/aegis_stack_conformance` declares one of every plugin mechanism: migrations with a Postgres schema, an option with `auto_requires`, a required component, a router, a settings mixin, a health check, a CLI group, and a file manifest. `tests/cli/test_plugin_conformance.py` installs it into a real generated project through the real CLI with nothing mocked, and asserts each mechanism left the consequence it is supposed to leave.

Two known gaps are recorded as **strict** xfails, so they fail loudly when fixed:

- #1079 `auto_requires` is never applied on the plugin path
- #1080 adding a component never re-renders a plugin's component-gated files

Every plugin gap so far has been a mechanism that existed for in-tree services and was never wired for plugins, found by hand, one at a time. This is where the fourth one fails instead.

## Tests

Conformance suite: 11 passed, 2 xfailed. Plugin discovery, updater, commands, resolver integration, render parity, template cleanup, size budget all pass. Lint and types clean.

Deliberately not covered by the conformance plugin: dashboard cards and modals, which need Flet controls to import cleanly and are exercised end to end by the crawl4ai reference plugin.