### PR TITLE
add-service: bracket requests can add a provider or flag to an installed AI service

### DIFF
--- a/aegis/commands/add_service.py
+++ b/aegis/commands/add_service.py
@@ -419,6 +419,15 @@ def add_service_command(
                 if isinstance(framework, str):
                     service_data[AnswerKeys.AI_FRAMEWORK] = framework
 
+            # An upgrade of an installed service applies what the project
+            # still lacks: for a multi option that is the union with what it
+            # has (``ai[openai]`` on an ollama project keeps ollama), for a
+            # flag it is simply on.
+            if existing_answers.get(AnswerKeys.include_key(base_service)) is True:
+                service_data.update(
+                    variant_delta(service, SERVICES[base_service], existing_answers)
+                )
+
             # For insights service, pass source flags
             if base_service == AnswerKeys.SERVICE_INSIGHTS:
                 from ..core.insights_service_parser import (

--- a/aegis/core/option_spec.py
+++ b/aegis/core/option_spec.py
@@ -240,10 +240,17 @@ def variant_answers(spec_str: str, plugin_spec: Any) -> dict[str, Any]:
     return {
         opt.answer_key: parsed[opt.name]
         for opt in options
-        if opt.name in explicit
-        and opt.answer_key is not None
-        and opt.mode is OptionMode.SINGLE
+        if opt.name in explicit and opt.answer_key is not None
     }
+
+
+def _multi_values(value: Any) -> list[str]:
+    """A multi option's answer as a list, whether copier holds it as the
+    comma-separated string the template renders (``ai_providers:
+    "ollama,openai"``) or a list."""
+    if isinstance(value, str):
+        return [v.strip() for v in value.split(",") if v.strip()]
+    return [str(v) for v in (value or [])]
 
 
 def variant_delta(
@@ -264,9 +271,13 @@ def answers_delta(
     An answer that is missing or not one of the option's choices is
     treated as unset. Ordered options are satisfied by any current value
     at or above the request; unordered ones raise
-    :class:`VariantConflictError` on a mismatch. Shared by the resolver,
-    ``add-service`` and ``ManualUpdater``, so a downgrade request is
-    "already satisfied" everywhere and never rewrites a level.
+    :class:`VariantConflictError` on a mismatch. A multi option (AI
+    providers) is satisfied when the project already holds every
+    requested value, else the delta is the union, current values first,
+    as the comma-separated string copier stores; a flag (rag, voice) is
+    satisfied when already on. Shared by the resolver, ``add-service``
+    and ``ManualUpdater``, so a downgrade request is "already satisfied"
+    everywhere and never rewrites a level.
     """
     by_key = {
         opt.answer_key: opt
@@ -279,6 +290,16 @@ def answers_delta(
         if opt is None:
             continue
         current = answers.get(key)
+        if opt.mode is OptionMode.MULTI:
+            have = [v for v in _multi_values(current) if v in opt.choices]
+            missing = [v for v in wanted if v not in have]
+            if missing:
+                delta[key] = ",".join(have + missing)
+            continue
+        if opt.mode is OptionMode.FLAG:
+            if current is not True:
+                delta[key] = True
+            continue
         if current not in opt.choices:
             delta[key] = wanted
         elif opt.ordered:

--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -449,18 +449,21 @@ SERVICES: dict[str, ServiceSpec] = {
                 mode=OptionMode.MULTI,
                 choices=sorted(AIProviders.ALL),
                 default=list(AIProviders.DEFAULT),
+                answer_key=AnswerKeys.AI_PROVIDERS,
             ),
             OptionSpec(
                 name="rag",
                 mode=OptionMode.FLAG,
                 choices=["rag"],
                 default=False,
+                answer_key=AnswerKeys.AI_RAG,
             ),
             OptionSpec(
                 name="voice",
                 mode=OptionMode.FLAG,
                 choices=["voice"],
                 default=False,
+                answer_key=AnswerKeys.AI_VOICE,
             ),
         ],
         pyproject_deps=[

--- a/tests/core/test_option_spec.py
+++ b/tests/core/test_option_spec.py
@@ -324,8 +324,58 @@ class TestVariantDelta:
                     default="pydantic-ai",
                     answer_key="ai_framework",
                 ),
+                OptionSpec(
+                    name="providers",
+                    mode=OptionMode.MULTI,
+                    choices=["anthropic", "ollama", "openai"],
+                    default=["openai"],
+                    answer_key="ai_providers",
+                ),
+                OptionSpec(
+                    name="rag",
+                    mode=OptionMode.FLAG,
+                    choices=["rag"],
+                    default=False,
+                    answer_key="ai_rag",
+                ),
             ],
         )
+
+    def test_multi_and_flag_options_name_answers_too(self) -> None:
+        """``ai[openai,rag]`` names the providers list and the flag, not
+        only single-choice options; before this ``add-service`` could not
+        add a provider or a flag to an installed AI service at all (the
+        request read as already enabled)."""
+        assert variant_answers("ai[openai,rag]", self._ai()) == {
+            "ai_providers": ["openai"],
+            "ai_rag": True,
+        }
+
+    def test_provider_request_merges_with_what_the_project_has(self) -> None:
+        """Providers accumulate: ``ai[openai]`` on an ollama project keeps
+        ollama and adds openai, as the comma string copier stores."""
+        assert variant_delta("ai[openai]", self._ai(), {"ai_providers": "ollama"}) == {
+            "ai_providers": "ollama,openai"
+        }
+        assert variant_delta(
+            "ai[openai,anthropic]", self._ai(), {"ai_providers": "ollama,openai"}
+        ) == {"ai_providers": "ollama,openai,anthropic"}
+
+    def test_provider_already_held_is_satisfied(self) -> None:
+        assert (
+            variant_delta("ai[ollama]", self._ai(), {"ai_providers": "ollama,openai"})
+            == {}
+        )
+        assert (
+            variant_delta("ai[openai]", self._ai(), {"ai_providers": ["openai"]}) == {}
+        )
+
+    def test_flag_turns_on_once(self) -> None:
+        assert variant_delta("ai[rag]", self._ai(), {"ai_rag": False}) == {
+            "ai_rag": True
+        }
+        assert variant_delta("ai[rag]", self._ai(), {}) == {"ai_rag": True}
+        assert variant_delta("ai[rag]", self._ai(), {"ai_rag": True}) == {}
 
     def test_missing_service_returns_every_requested_option(self) -> None:
         assert variant_delta("auth[org]", self._auth(), {}) == {"auth_level": "org"}


### PR DESCRIPTION
## Summary

- `aegis add-service "ai[openai]"` (or `ai[rag]`) on a project that already has the AI service exited with "already enabled" and changed nothing. `variant_answers` named only single-choice options, so multi options and flags never produced an answer and the delta was empty.
- A multi option now names its list and a flag names `True`. `answers_delta` treats a multi option as satisfied when the project holds every requested value, otherwise the delta is the union with the project's values first, as the comma-separated string copier stores; a flag is satisfied when already on.
- The AI `providers`, `rag` and `voice` options declare their answer keys, and `add-service` applies the delta for an installed service, so an upgrade never drops providers the project already has.

Found while adding hosted providers to aegis-steward (generated at 0.11.0 with `ai_providers: ollama`).

## Test plan

- [x] `tests/core/test_option_spec.py`: multi and flag answers, provider merge, already-held provider, flag on/once
- [x] `tests/core`, `tests/cli/test_add_service_experimental.py`, `test_add_command.py`, `test_add_plugin_resolver_integration.py` pass; ruff clean; the three `ty` diagnostics are present on main