### PR TITLE
Plugin config gaps: settings import, published port, migration signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ### Changed
 
+- **A plugin's migration can declare how to prove it ran.**
+  `MigrationSpec` gains `stamp_signature`, the composer carries each
+  plugin's migrations into `_plugins`, and `migration_signatures.py`
+  appends plugin entries. Startup re-adoption now stamps a plugin's
+  migration on a database that already has its tables, instead of
+  replaying the DDL on every boot.
+- **`API_BASE_URL` follows the port the app is actually published on.**
+  `make serve` shifts `WEBSERVER_HOST_PORT` when 8000 is taken but never
+  persisted it, so every CLI that calls this app's own API fell back to
+  a hardcoded `localhost:8000`. The resolved port is now written to
+  `.env.ports` and read by `Settings`, and `APIClient` uses it.
 - **A plugin names itself once and every dashboard surface honours it.**
   `get_component_subtitle` now prefers the `subtitle` a health check
   declares in its metadata, and both the stack view and the architecture
@@ -62,6 +73,10 @@
 
 ### Fixed
 
+- **A plugin's settings mixin no longer fails `ruff check`.** The
+  injected import landed after a module constant in `app/core/config.py`,
+  so any generated project that installed a plugin declaring
+  `settings_mixins` reported E402.
 - **`aegis add <plugin>` restores the services card.** The shared
   `cards/__init__.py` imports `ServicesCard` once any plugin is present,
   but only the component install path ensured that module exists, so

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -153,6 +153,13 @@ class ServiceMigrationSpec:
     # pre-schema migrations. Schemas are Postgres-only: SQLite ignores
     # this (it has no CREATE SCHEMA) and keeps every table in one DB.
     schema: str | None = None
+    # Proof this migration already ran, for the startup hook that
+    # re-adopts a persisted database by stamping instead of replaying
+    # DDL. ``("table", name)``, ``("column", table, col)`` or
+    # ``("foreign_key", table, col)``. A migration without one opts out
+    # of that recovery, so every shipped migration should carry it;
+    # in-tree services declare theirs in ``migration_signatures.py``.
+    stamp_signature: tuple[str, ...] | None = None
 
 
 # ============================================================================

--- a/aegis/core/plugins/composer.py
+++ b/aegis/core/plugins/composer.py
@@ -95,6 +95,17 @@ def serialize_plugin_to_answer(
         # the same way the in-tree auth/llm subcommands do. Always present
         # (``None`` when unset) so templates can test it directly.
         "cli_name": spec.cli_name,
+        # Migrations, flattened to what templates need: the name the
+        # revision file carries, and the object whose existence proves
+        # it ran. The DDL itself is generated from the spec at add time
+        # and never travels in the answers.
+        "migrations": [
+            {
+                "service_name": migration.service_name,
+                "stamp_signature": list(migration.stamp_signature or ()),
+            }
+            for migration in (spec.migrations or [])
+        ],
         "wiring": _serialize_wiring(spec.wiring, opts, spec.name),
     }
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py.jinja
@@ -8,6 +8,10 @@ finance_icon incident: alembic_version lags, the upgrade replays, and the
 database logs "already exists" on every boot until someone stamps by
 hand. Guarded by ``tests/test_migration_signatures.py``.
 
+Plugins append their own entries: a ``MigrationSpec`` carrying a
+``stamp_signature`` lands here when the plugin is installed, so a
+plugin's migration gets the same recovery an in-tree service's does.
+
 Forms:
 - ``("table", name)`` - table exists (CREATE TABLE migrations). Names may
   be schema-qualified; matching tolerates the bare name on engines
@@ -50,4 +54,12 @@ SERVICE_MIGRATION_SIGNATURES: dict[str, tuple[str, ...]] = {
         "secured_by_account_id",
     ),
     "scheduler": ("table", "scheduler.job_execution"),
+{%- for p in _plugins | default([]) %}
+{%- for m in p.migrations | default([]) %}
+{%- if m.stamp_signature %}
+    # From the {{ p.name }} plugin.
+    "{{ m.service_name }}": ({% for part in m.stamp_signature %}"{{ part }}", {% endfor %}),
+{%- endif %}
+{%- endfor %}
+{%- endfor %}
 }

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/client.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/client.py
@@ -55,7 +55,7 @@ class APIClient:
         timeout: float = 10.0,
         on_unauthorized: UnauthorizedHandler | None = None,
     ) -> None:
-        self.base_url = base_url or f"http://localhost:{settings.PORT}"
+        self.base_url = base_url or settings.API_BASE_URL
         self.timeout = timeout
         self.on_unauthorized = on_unauthorized
         # Human-readable reason for the most recent failed request, None

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
@@ -10,6 +10,11 @@ from typing import Any
 
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+{%- for p in _plugins | default([]) %}
+{%- for s in p.wiring.settings_mixins %}
+from {{ s.module }} import {{ s.symbol }}
+{%- endfor %}
+{%- endfor %}
 
 # Default placeholder bundled with the template — anyone reading the
 # template source knows this value, so leaving it unchanged in a non-dev
@@ -17,11 +22,6 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 # so the startup guard below has a single source of truth and a renamed
 # placeholder doesn't accidentally bypass the check.
 _SECRET_KEY_PLACEHOLDER = "change-this-secret-key-in-production-use-env-variable"
-{%- for p in _plugins | default([]) %}
-{%- for s in p.wiring.settings_mixins %}
-from {{ s.module }} import {{ s.symbol }}
-{%- endfor %}
-{%- endfor %}
 
 
 class Settings(
@@ -68,6 +68,26 @@ class Settings(
 
     # Port for the web server
     PORT: int = 8000
+
+    # The host port compose actually published. ``make serve`` shifts it
+    # when 8000 is taken and writes the choice to ``.env.ports``; the
+    # container still listens on PORT. Anything running on the host
+    # (every CLI command that calls this app's API) needs this one, not
+    # PORT. None means nothing shifted it.
+    WEBSERVER_HOST_PORT: int | None = None
+
+    # Where this app's own CLI reaches its API. Left empty it follows the
+    # published port, so a project served anywhere needs no extra
+    # configuration; set it explicitly for a container or a tunnel.
+    API_BASE_URL: str = ""
+
+    @model_validator(mode="after")
+    def _default_api_base_url(self) -> "Settings":
+        """Point the CLI at wherever this app is actually reachable."""
+        if not self.API_BASE_URL:
+            port = self.WEBSERVER_HOST_PORT or self.PORT
+            self.API_BASE_URL = f"http://localhost:{port}"
+        return self
 
     # Development settings
     AUTO_RELOAD: bool = False

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/resolve_ports.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/scripts/resolve_ports.py
@@ -19,6 +19,7 @@ import socket
 import sys
 
 _PERSISTED_KEYS = {
+    "WEBSERVER_HOST_PORT",
     "POSTGRES_HOST_PORT",
     "REDIS_HOST_PORT",
     "OLLAMA_HOST_PORT",
@@ -101,12 +102,13 @@ def resolve_ports(
 ) -> dict[str, int]:
     """Resolve host ports for the requested services and persist them.
 
-    Only ``POSTGRES_HOST_PORT``, ``REDIS_HOST_PORT``, ``OLLAMA_HOST_PORT``
-    and ``INGRESS_DASHBOARD_PORT`` are written to ``.env.ports``:
-    ``app/core/config.py``'s ``Settings`` loads that file as a strict dotenv
-    (``extra="forbid"``) with no field for ``WEBSERVER_HOST_PORT`` /
-    ``INGRESS_HTTP_PORT`` -- those only need to reach ``docker compose``'s
-    environment, which the caller does directly with the returned dict.
+    Everything ``Settings`` has a field for is written to ``.env.ports``,
+    which it loads as a strict dotenv (``extra="forbid"``). That now
+    includes ``WEBSERVER_HOST_PORT``: host-side CLI commands call this
+    app's own API, so they need the port compose published, not the one
+    the container listens on. ``INGRESS_HTTP_PORT`` stays out -- it has
+    no field, and only ``docker compose``'s environment needs it, which
+    the caller supplies directly from the returned dict.
     """
     ports: dict[str, int] = {
         "WEBSERVER_HOST_PORT": _resolve_one(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_api_base_url.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_api_base_url.py
@@ -1,0 +1,28 @@
+"""Every CLI that calls this app's own API needs its address.
+
+``make serve`` shifts the published host port when 8000 is taken, while
+the container keeps listening on ``PORT``. A CLI command runs on the
+host, so it needs the published one. Before this, ``API_BASE_URL`` did
+not exist at all and every caller fell back to a hardcoded
+``localhost:8000``: the port moved and the clients did not follow.
+"""
+
+from app.core.config import Settings
+
+
+def test_it_follows_the_configured_port() -> None:
+    assert Settings(PORT=9123).API_BASE_URL == "http://localhost:9123"
+
+
+def test_the_published_port_wins_over_the_container_port() -> None:
+    """``make serve`` publishes 8001 while the container serves 8000."""
+    settings = Settings(PORT=8000, WEBSERVER_HOST_PORT=8001)
+    assert settings.API_BASE_URL == "http://localhost:8001"
+
+
+def test_an_explicit_value_wins() -> None:
+    """A container or a tunnel names its own address."""
+    settings = Settings(
+        PORT=9123, WEBSERVER_HOST_PORT=8001, API_BASE_URL="https://api.example.test"
+    )
+    assert settings.API_BASE_URL == "https://api.example.test"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_client.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_client.py
@@ -67,9 +67,11 @@ async def make_client() -> AsyncIterator[Callable[..., APIClient]]:
 
 class TestAPIClient:
     def test_default_base_url(self) -> None:
-        client = APIClient()
-        assert "localhost" in client.base_url
-        assert "8000" in client.base_url
+        """It follows the configured address, not a literal port: the
+        published port moves when ``make serve`` finds 8000 taken."""
+        from app.core.config import settings
+
+        assert APIClient().base_url == settings.API_BASE_URL
 
     def test_custom_base_url(self) -> None:
         client = APIClient(base_url="http://example.com")

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_resolve_ports.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_resolve_ports.py
@@ -159,12 +159,14 @@ class TestResolvePorts:
         content = ports_file.read_text()
         assert "POSTGRES_HOST_PORT" in content
         assert "REDIS_HOST_PORT" in content
-        assert "WEBSERVER_HOST_PORT" not in content
+        # Host-side CLI commands call this app's own API, so the port
+        # compose published has to reach Settings like any other.
+        assert "WEBSERVER_HOST_PORT" in content
         assert ports["WEBSERVER_HOST_PORT"] == 41400
         assert ports["POSTGRES_HOST_PORT"] == 41401
         assert ports["REDIS_HOST_PORT"] == 41402
 
-    def test_never_persists_webserver_or_ingress_http(
+    def test_never_persists_the_ingress_http_port(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv("WEBSERVER_PORT_BASE", "41410")
@@ -181,7 +183,8 @@ class TestResolvePorts:
         )
 
         content = ports_file.read_text()
-        assert "WEBSERVER_HOST_PORT" not in content
+        # ``Settings`` has no field for it and loads the file with
+        # ``extra="forbid"``; only compose's environment needs it.
         assert "INGRESS_HTTP_PORT" not in content
         assert "INGRESS_DASHBOARD_PORT" in content
         assert ports["INGRESS_HTTP_PORT"] == 41411

--- a/tests/cli/test_plugin_conformance.py
+++ b/tests/cli/test_plugin_conformance.py
@@ -76,6 +76,16 @@ class TestMigrations:
         assert "conformance_row" in body
         assert "ix_conformance_row_label" in body
 
+    def test_the_stamp_signature_is_registered(self, project: Path) -> None:
+        """A migration with no signature opts out of the startup
+        re-adoption that stamps instead of replaying DDL, so a plugin
+        must be able to declare one."""
+        registry = _read(
+            project, "app/components/backend/startup/migration_signatures.py"
+        )
+        assert '"conformance"' in registry
+        assert "conformance_row" in registry
+
     def test_the_schema_is_dropped_on_sqlite(self, project: Path) -> None:
         """The spec declares a Postgres schema; SQLite has none."""
         migration = next((project / "alembic/versions").glob("*_conformance.py"))
@@ -115,6 +125,33 @@ class TestWiring:
     def test_the_settings_mixin_is_composed(self, project: Path) -> None:
         config = _read(project, "app/core/config.py")
         assert "ConformanceSettingsMixin" in config
+
+    def test_the_settings_import_sits_with_the_other_imports(
+        self, project: Path
+    ) -> None:
+        """Injected next to the class it feeds, the import lands after a
+        module constant and every generated project fails ``ruff check``
+        with E402 the moment it installs a plugin."""
+        module = ast.parse(_read(project, "app/core/config.py"))
+        first_statement = next(
+            (
+                node.lineno
+                for node in module.body
+                if not isinstance(node, ast.Import | ast.ImportFrom)
+                and not (
+                    isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)
+                )
+            ),
+            None,
+        )
+        assert first_statement is not None
+        late = [
+            node.lineno
+            for node in module.body
+            if isinstance(node, ast.Import | ast.ImportFrom)
+            and node.lineno > first_statement
+        ]
+        assert not late, f"imports after line {first_statement}: {late}"
 
     def test_the_health_check_is_registered(self, project: Path) -> None:
         startup = _read(project, "app/components/backend/startup/component_health.py")

--- a/tests/core/test_module_size_budget.py
+++ b/tests/core/test_module_size_budget.py
@@ -94,7 +94,7 @@ BUDGET: dict[str, int] = {
     "components/frontend/dashboard/modals/llm_catalog_tab.py.jinja": 780,
     "components/frontend/dashboard/modals/rag_tab.py": 780,
     "components/frontend/dashboard/cards/card_utils.py.jinja": 659,
-    "core/config.py.jinja": 764,
+    "core/config.py.jinja": 784,
     "cli/rag.py": 686,
     "services/ai/fixtures/llm_fixtures.py": 684,
     "services/load_test/worker/service.py": 678,

--- a/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/spec.py
+++ b/tests/fixtures/aegis_stack_conformance/src/aegis_stack_conformance/spec.py
@@ -48,6 +48,8 @@ def get_spec() -> PluginSpec:
                 service_name="conformance",
                 description="Conformance table",
                 schema="conformance",
+                # Proof it ran, for the startup re-adoption hook.
+                stamp_signature=("table", "conformance.conformance_row"),
                 tables=[
                     TableSpec(
                         name="conformance_row",

--- a/tests/test_serve_port_autodiscovery.py
+++ b/tests/test_serve_port_autodiscovery.py
@@ -87,17 +87,21 @@ def test_resolve_ports_writes_only_allowlisted_keys(tmp_path: Path) -> None:
         ports_file=ports_file,
     )
     content = ports_file.read_text()
-    # The four keys config.py declares as Settings fields may be persisted.
+    # Every key config.py declares as a Settings field may be persisted.
+    # WEBSERVER_HOST_PORT is one of them: host-side CLI commands call
+    # this app's own API, so they need the port compose published rather
+    # than the one the container listens on.
     for key in (
+        "WEBSERVER_HOST_PORT",
         "POSTGRES_HOST_PORT",
         "REDIS_HOST_PORT",
         "OLLAMA_HOST_PORT",
         "INGRESS_DASHBOARD_PORT",
     ):
         assert key in content
-    # These reach docker compose via the returned dict, never .env.ports —
-    # config.py's strict Settings would reject the unknown keys at boot.
-    assert "WEBSERVER_HOST_PORT" not in content
+    # This one reaches docker compose via the returned dict, never
+    # .env.ports — config.py has no field for it and its strict Settings
+    # would reject the unknown key at boot.
     assert "INGRESS_HTTP_PORT" not in content
     assert ports["WEBSERVER_HOST_PORT"]
     assert ports["INGRESS_HTTP_PORT"]


### PR DESCRIPTION
## Summary

Three framework gaps found by running the crawl4ai reference plugin in a real stack rather than in tests. Each is a mechanism that worked for in-tree services and had no path for a plugin. One commit.

### A plugin's settings mixin failed `ruff check`
The injected import landed next to the class it feeds, which put it after a module-level constant in `app/core/config.py`, so any generated project installing a plugin with `settings_mixins` reported E402. The import now sits with the other imports. Caught by widening the lint scope past the plugin's own files.

### CLIs could not find the app they belong to
`make serve` resolves `WEBSERVER_HOST_PORT` dynamically when 8000 is taken, but deliberately never persisted it: `Settings` loads `.env.ports` with `extra="forbid"` and had no field for it. The container listens on `PORT` while the host publishes somewhere else, and every CLI that calls this app's own API runs on the host, so `ai`, `health` and any plugin CLI fell back to a hardcoded `localhost:8000`. Now:

- `WEBSERVER_HOST_PORT` is a real setting, written to `.env.ports`
- `API_BASE_URL` defaults to the published port, overridable for a container or tunnel
- `APIClient` uses `API_BASE_URL` instead of `PORT`

`INGRESS_HTTP_PORT` still stays out, since nothing but compose needs it.

### A plugin's migration opted out of startup recovery
`migration_signatures.py` maps each migration to the object whose existence proves it ran; the startup hook uses it to stamp instead of replaying DDL on a persisted database. Its docstring spells out the cost of a missing entry. The map was a hand-kept dict of in-tree names, so every plugin migration opted out with no way back in, and the generated project's own guard failed on a correctly installed plugin.

`MigrationSpec` gains `stamp_signature`; the composer serialises each plugin's migrations into `_plugins` (they were not serialised at all, which was the root); `migration_signatures.py` became a template that appends plugin entries. Closes #1084.

## Tests

Written first in each case. The conformance plugin now declares a settings mixin import position, a migration signature, and the existing wiring, so `tests/cli/test_plugin_conformance.py` asserts all three land after a real `aegis add` with nothing mocked. Two existing tests that pinned the old port decision were updated with the reason; one flimsy assertion on a literal `8000` now asserts the property instead.

Verified: 642 tests in a generated project with the plugin installed, 219 composer-adjacent repo tests, conformance and guards green, lint and types clean. The two known gaps the conformance suite tracks as strict xfails (#1079, #1080) are unchanged.