### PR TITLE
STORAGE_ROOT reaches every container

### DIFF
--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/Dockerfile.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/Dockerfile.jinja
@@ -105,6 +105,11 @@ RUN chmod +x /code/scripts/entrypoint.sh
 # Set default port as an environment variable
 ARG PORT=8000
 ENV PORT=$PORT
+# The object store every process shares (the storage-data volume in
+# compose). Set here, not in a compose environment list: a service that
+# declares its own list replaces the anchor's wholesale, and this was
+# quietly dropping to the code directory in every container.
+ENV STORAGE_ROOT=/data/storage
 
 # Expose the port
 EXPOSE $PORT

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
@@ -9,10 +9,12 @@ x-app: &app
   env_file:
     - ${AEGIS_STACK_ENV_FILE:-.env}
   environment:
-    # Docker container marker for entrypoint script
+    # Docker container marker for entrypoint script. A service that sets
+    # its own environment list REPLACES this one (YAML merge keys do not
+    # join lists), so anything every container must see lives in the
+    # Dockerfile's ENV (PORT, STORAGE_ROOT), not here.
     - DOCKER_CONTAINER=1
     - PORT=${PORT:-8000}
-    - STORAGE_ROOT=/data/storage
   volumes:
     # Every process that runs the app shares one object store. Compose
     # merges volume lists across override files by target path, so the

--- a/tests/core/test_storage_root_reaches_every_container.py
+++ b/tests/core/test_storage_root_reaches_every_container.py
@@ -1,0 +1,30 @@
+"""STORAGE_ROOT reaches every container.
+
+The compose anchor's ``environment`` list is replaced, not merged, by a
+service that declares its own (YAML merge keys join mappings, never
+lists); four services do, so a value put only on the anchor never
+reached them and object storage fell back to the code directory inside
+every container. The Dockerfile's ENV is what every container sees.
+"""
+
+from __future__ import annotations
+
+import yaml
+
+from tests.core.test_observability_oom_renders import _ctx, _render
+
+
+def test_dockerfile_sets_the_storage_root() -> None:
+    assert "ENV STORAGE_ROOT=/data/storage" in _render("Dockerfile.jinja", _ctx())
+
+
+def test_compose_does_not_rely_on_the_anchor_for_it() -> None:
+    """Every service that overrides the anchor's environment still sees
+    the storage root, because nothing in compose is expected to carry it."""
+    compose = yaml.safe_load(_render("docker-compose.yml.jinja", _ctx()))
+    for name, service in compose["services"].items():
+        for entry in service.get("environment") or []:
+            assert not str(entry).startswith("STORAGE_ROOT="), (
+                f"{name}: STORAGE_ROOT in a compose environment list is lost by "
+                "any service that declares its own; it belongs in the Dockerfile"
+            )


### PR DESCRIPTION
## Summary

- The compose anchor set `STORAGE_ROOT` on its `environment` list, but a service that declares its own list replaces the anchor's wholesale (YAML merge keys join mappings, never lists). Four services do, so inside every container the variable was empty and object storage fell back to the code directory: the bind-mounted checkout in dev, a path that dies with the container in prod, while the `storage-data` volume stayed empty.
- The value moves to the Dockerfile's `ENV`, which every container sees the way `PORT` already does. The anchor's comment now says why nothing that must reach every container belongs on it.
- A render test asserts the Dockerfile sets it and that no compose environment list carries it.

Found in aegis-steward: chat attachments were landing in `/code/storage_data` inside the webserver container.

## Test plan

- [x] `tests/core/test_storage_root_reaches_every_container.py` and the existing compose render tests pass; ruff clean