### PR TITLE
Release 0.11.1rc1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-09-10
+
 ### Changed
 
 - **A plugin's migration can declare how to prove it ran.**

--- a/aegis/__init__.py
+++ b/aegis/__init__.py
@@ -2,4 +2,4 @@
 Aegis Stack CLI - Component generation and project management tools.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.11.1rc1"

--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@
 # - Update support
 
 _min_copier_version: "9.0.0"
-_version: "0.11.0"
+_version: "0.11.1rc1"
 
 # IMPORTANT: Template content is in subdirectory
 # This allows the template to be recognized as git-tracked (aegis-stack repo root has .git)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-stack"
-version = "0.11.0"
+version = "0.11.1rc1"
 description = "A production-ready FastAPI platform with modular components and a built-in control plane. Try: uvx aegis-stack init my-project"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { editable = "tests/fixtures/aegis_plugin_test" }
 
 [[package]]
 name = "aegis-stack"
-version = "0.11.0"
+version = "0.11.1rc1"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
Version bump to 0.11.1rc1 and changelog cut for 0.11.1 (2026-09-10).

Files: `aegis/__init__.py`, `pyproject.toml`, `copier.yml`, `CHANGELOG.md`, `uv.lock`.

CI is the release gate. Tag `v0.11.1-rc1` after merge to publish to TestPyPI.