### PR TITLE
Release 0.11.1

### DIFF
--- a/aegis/__init__.py
+++ b/aegis/__init__.py
@@ -2,4 +2,4 @@
 Aegis Stack CLI - Component generation and project management tools.
 """
 
-__version__ = "0.11.1rc1"
+__version__ = "0.11.1"

--- a/copier.yml
+++ b/copier.yml
@@ -6,7 +6,7 @@
 # - Update support
 
 _min_copier_version: "9.0.0"
-_version: "0.11.1rc1"
+_version: "0.11.1"
 
 # IMPORTANT: Template content is in subdirectory
 # This allows the template to be recognized as git-tracked (aegis-stack repo root has .git)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aegis-stack"
-version = "0.11.1rc1"
+version = "0.11.1"
 description = "A production-ready FastAPI platform with modular components and a built-in control plane. Try: uvx aegis-stack init my-project"
 readme = "README.md"
 requires-python = ">=3.11,<3.15"

--- a/uv.lock
+++ b/uv.lock
@@ -9,7 +9,7 @@ source = { editable = "tests/fixtures/aegis_plugin_test" }
 
 [[package]]
 name = "aegis-stack"
-version = "0.11.1rc1"
+version = "0.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "copier" },


### PR DESCRIPTION
Final version bump 0.11.1rc1 -> 0.11.1. Changelog section `[0.11.1] - 2026-09-10` was cut in #1090.

rc1 verified on TestPyPI: 0.11.0 init -> 0.11.1rc1 update, 0 .rej files, 0 conflict markers.