### PR TITLE
Plugin scaffold pins its aegis-stack; document the source-only path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **A scaffolded plugin pins the aegis-stack that made it.** The scaffold
+  emitted an unpinned `aegis-stack` dependency, so `pip install
+  aegis-stack-<name>` could resolve an older aegis-stack whose `PluginSpec`
+  has no field the plugin sets, and the failure landed on the plugin's user
+  as a validation error nobody could place. The floor is now the scaffolding
+  version.
+- **A plugin does not have to be on PyPI.** `aegis` never installs plugins
+  itself, so a path or git-URL install is discovered through the
+  `aegis.plugins` entry point exactly like a published one. The Plugins page
+  documents the source-only path and the `aegis-stack-plugin` GitHub topic
+  the directory finds them by, and says what the two listing sections
+  differ on: a published plugin resolves by version and carries an install
+  command, a source-only one carries its repository link and pins nothing.
+
 ## [0.11.1] - 2026-09-10
 
 ### Changed
@@ -175,6 +191,13 @@
   `make lint-frontend` fail.
 - **Generated `test_app_js_is_loaded` no longer fails once assets are
   built**: it accepts the fingerprinted path as well as the source path.
+- **`aegis add <plugin>` creates the plugin's tables.** A third-party
+  plugin's `migrations` were never written: `add_plugin` skipped the
+  migration tail in-tree services get, and the generator only resolved
+  names from the static registry. The plugin's revisions are now rendered
+  straight from its spec (`generate_plugin_migrations`), with alembic
+  bootstrapped when missing, schema dropped on SQLite, and re-adding the
+  plugin never stacking a duplicate revision.
 
 ## [0.11.0] - 2026-09-06
 

--- a/aegis/core/plugins/scaffold.py
+++ b/aegis/core/plugins/scaffold.py
@@ -32,6 +32,7 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader
 
+from ... import __version__
 from .naming import dist_name, package_name
 
 JINJA_EXTENSION = ".jinja"
@@ -112,6 +113,10 @@ def scaffold_plugin(
         "dist": dist_name(name),
         "pkg": package_name(name),
         "description": description,
+        # The plugin is written against this aegis-stack's spec surface,
+        # so the scaffold pins it as the floor rather than letting a
+        # resolver pick an older one that lacks a field the plugin sets.
+        "aegis_version": __version__,
     }
 
     # Single Jinja2 environment rooted at the scaffold templates.

--- a/aegis/templates/plugin_scaffold/README.md.jinja
+++ b/aegis/templates/plugin_scaffold/README.md.jinja
@@ -48,8 +48,12 @@ That will:
 
 Publish to PyPI and the plugin is listed at
 [aegis-stack.io/plugins](https://aegis-stack.io/plugins) after the nightly
-sweep; the markers it looks for are already set in `pyproject.toml`. How the
-listing works, and same-day submission:
+sweep; the markers it looks for are already set in `pyproject.toml`.
+
+Not publishing is fine too. A plugin installed from a path or a git URL works
+the same way, and gets listed in the directory's source-only section if the
+GitHub repository carries the `aegis-stack-plugin` topic. How both listings
+work, and same-day submission:
 [docs.aegis-stack.io/plugins](https://docs.aegis-stack.io/plugins/).
 
 ## Develop

--- a/aegis/templates/plugin_scaffold/pyproject.toml.jinja
+++ b/aegis/templates/plugin_scaffold/pyproject.toml.jinja
@@ -10,7 +10,7 @@ authors = [{ name = "{{ author }}" }]
 requires-python = ">=3.11"
 keywords = ["aegis-stack", "aegis-stack-plugin"]
 dependencies = [
-    "aegis-stack",
+    "aegis-stack>={{ aegis_version }}",
 ]
 
 [project.urls]

--- a/aegis/templates/plugin_scaffold/tests/test_plugin.py.jinja
+++ b/aegis/templates/plugin_scaffold/tests/test_plugin.py.jinja
@@ -24,3 +24,4 @@ def test_entry_point_is_what_aegis_and_the_directory_look_for() -> None:
     entry_points = project["entry-points"]["aegis.plugins"]
     assert entry_points["{{ name }}"] == "{{ pkg }}.plugin:get_spec"
     assert "aegis-stack-plugin" in project["keywords"]
+    assert project["urls"]["Aegis Plugin"].endswith("{{ dist }}")

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -75,6 +75,33 @@ community with the same detail page: summary, latest release, supported
 `aegis-stack` versions, downloads, repository and PyPI links, and the install
 command.
 
+### Source-only plugins
+
+A plugin does not have to be on PyPI to work. `aegis` never installs anything
+itself: discovery is the `aegis.plugins` entry point on whatever is in the
+environment, so a plugin installed from a path or a git URL is found exactly
+like a published one.
+
+```bash
+uv pip install git+https://github.com/you/aegis-stack-scraper
+aegis add scraper
+```
+
+The directory lists these in their own section, separate from published
+plugins. It finds them by GitHub topic, which is the only marker GitHub
+indexes; the PyPI keyword is invisible there.
+
+```text
+topic:aegis-stack-plugin
+```
+
+The two sections are not cosmetic. A published plugin resolves by version, so
+its listing carries a version, the `aegis-stack` range it supports, and a
+copyable install command. A source-only plugin installs from a mutable branch
+and pins nothing, so its listing carries the repository link and says so, and
+offers no install one-liner. Publishing to PyPI later moves the entry to the
+published section; nothing about the plugin has to change.
+
 For a same-day listing, or for a package published without the markers,
 submit the PyPI name at
 [aegis-stack.io/plugins/submit](https://aegis-stack.io/plugins/submit). The

--- a/tests/core/test_plugin_scaffold.py
+++ b/tests/core/test_plugin_scaffold.py
@@ -109,6 +109,24 @@ class TestScaffoldContent:
         pyproject = (tmp_path / "aegis-stack-scraper" / "pyproject.toml").read_text()
         assert 'requires-python = ">=3.11"' in pyproject
 
+    def test_pyproject_pins_the_aegis_stack_that_scaffolded_it(
+        self, tmp_path: Path
+    ) -> None:
+        """A plugin is written against the spec surface of the aegis-stack
+        it was scaffolded from. Unpinned, ``pip install aegis-stack-X``
+        happily resolves an older aegis-stack whose ``PluginSpec`` has no
+        field the plugin sets, and the failure lands on the plugin's user
+        as an import or validation error nobody can place."""
+        import tomllib
+
+        from aegis import __version__
+
+        scaffold_plugin("scraper", tmp_path)
+        project = tomllib.loads(
+            (tmp_path / "aegis-stack-scraper" / "pyproject.toml").read_text()
+        )["project"]
+        assert f"aegis-stack>={__version__}" in project["dependencies"]
+
     def test_plugin_py_returns_valid_pluginspec(self, tmp_path: Path) -> None:
         scaffold_plugin("scraper", tmp_path, description="Web scraping")
         plugin_py = (


### PR DESCRIPTION
Follow-on to 0.11.1, setting up for the plugin directory without building the registry or frontend.

- **Scaffold pin.** `dependencies = ["aegis-stack"]` was unpinned, so `pip install aegis-stack-<name>` could resolve an older aegis-stack whose `PluginSpec` lacks a field the plugin sets; the failure lands on the plugin's user as an unplaceable validation error. The scaffold now pins the version that generated it, with a test asserting the pin matches `aegis.__version__`.
- **Source-only plugins documented.** `aegis` never installs plugins itself, so a path or git-URL install is found through the `aegis.plugins` entry point exactly like a published one. `docs/plugins.md` gains a section covering that path, the `aegis-stack-plugin` GitHub topic (the only marker GitHub indexes), and what separates the two listing sections: published resolves by version and gets an install command, source-only gets a repository link and says it pins nothing.
- **Scaffolded test covers the third marker**, the `Aegis Plugin` project URL, alongside the entry point and keyword it already checked.
- **Changelog repair.** The `aegis add <plugin>` migrations entry was dropped from the 0.11.1 section by a merge; it shipped, and the release notes mention it.