### PR TITLE
Adopt queryspy: N+1 gate on the stack matrix, three query fixes

### DIFF
--- a/aegis/core/services.py
+++ b/aegis/core/services.py
@@ -309,6 +309,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 "app/models/refresh_token.py",
                 "tests/components/test_frontend_auth_session.py",
                 "tests/services/test_refresh_service.py",
+                "tests/services/test_user_lookup_queries.py",
                 "tests/test_factories_demo.py",
             ],
             # Option-gated files live in extras, not primary: the add path
@@ -1005,6 +1006,7 @@ SERVICES: dict[str, ServiceSpec] = {
                 "tests/services/test_finance_service.py",
                 "tests/services/test_finance_analyst.py",
                 "tests/services/test_finance_analyst_run.py",
+                "tests/services/test_finance_currency_cache.py",
                 "tests/services/test_finance_demo_seed.py",
                 "tests/services/test_finance_import.py",
                 "tests/services/test_finance_reconcile.py",

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/CLAUDE.md.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/CLAUDE.md.jinja
@@ -86,8 +86,9 @@ CLI wires routes, tests, health checks, and dependencies for you.
 
 Models are SQLModel classes; every schema change goes through an alembic
 migration. Never query inside a loop (N+1); batch with `WHERE id IN (...)` or
-eager-load with `selectinload()`/`joinedload()`. See the
-`add-model-and-migration` skill.
+eager-load with `selectinload()`/`joinedload()`. `make check-queries` runs
+the test suite under queryspy and names the call site of anything that
+slipped through. See the `add-model-and-migration` skill.
 
 {% endif %}{% if include_worker %}## Worker
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/Makefile.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/Makefile.jinja
@@ -179,7 +179,11 @@ typecheck: ## Run type checking with ty
 	@echo "Running type checking..."
 	@uv run ty check
 
-check: lint typecheck test ## Run all code quality checks
+{% if include_database %}check-queries: ## Detect N+1 queries in the test suite
+	@echo "Checking for N+1 queries..."
+	@uv run pytest --queryspy-strict
+
+{% endif %}check: lint typecheck test ## Run all code quality checks
 	@echo "All checks completed successfully!"
 
 #=============================================================================

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/memory_modules.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/chat/memory_modules.py
@@ -80,7 +80,6 @@ async def create_memory_module(
     )
     session.add(module)
     await session.commit()
-    await session.refresh(module)
     logger.info("Created memory module", module_slug=slug)
     return module
 
@@ -117,7 +116,6 @@ async def update_memory_module(
     module.updated_at = utcnow()
     session.add(module)
     await session.commit()
-    await session.refresh(module)
     logger.info("Updated memory module", module_slug=slug)
     return module
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/invites.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/invites.py.jinja
@@ -57,7 +57,6 @@ class InviteService:
             )
             self.db.add(invite)
             await self.db.commit()
-            await self.db.refresh(invite)
             return invite
 
         # User doesn't exist — create pending invite
@@ -71,7 +70,6 @@ class InviteService:
         )
         self.db.add(invite)
         await self.db.commit()
-        await self.db.refresh(invite)
         return invite
 
     async def accept_pending_invites(self, email: str, user_id: int) -> int:
@@ -155,7 +153,6 @@ class InviteService:
         invite.status = "accepted"
         self.db.add(invite)
         await self.db.commit()
-        await self.db.refresh(invite)
         return invite
 
     async def list_pending_invites(self, org_id: int) -> list[OrgInvite]:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/memberships.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/memberships.py.jinja
@@ -35,7 +35,6 @@ class MembershipService:
         )
         self.db.add(member)
         await self.db.commit()
-        await self.db.refresh(member)
         return member
 
     async def remove_member(self, org_id: int, user_id: int) -> bool:
@@ -70,7 +69,6 @@ class MembershipService:
         member.role = role
         self.db.add(member)
         await self.db.commit()
-        await self.db.refresh(member)
         return member
 
     async def transfer_ownership(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/orgs.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/orgs.py.jinja
@@ -29,7 +29,6 @@ class OrgService:
         org = Organization.model_validate(org_data)
         self.db.add(org)
         await self.db.commit()
-        await self.db.refresh(org)
         return org
 
     async def get_org_by_id(self, org_id: int) -> Organization | None:
@@ -61,7 +60,6 @@ class OrgService:
         org.updated_at = utcnow()
         self.db.add(org)
         await self.db.commit()
-        await self.db.refresh(org)
         return org
 
     async def delete_org(self, org_id: int) -> bool:
@@ -152,7 +150,6 @@ class OrgService:
         org.updated_at = utcnow()
         self.db.add(org)
         await self.db.commit()
-        await self.db.refresh(org)
         return org
 {% else %}
 # Organization service not included (auth_level != org)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/users.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/auth/users.py.jinja
@@ -96,7 +96,6 @@ class UserService:
         await self.db.flush()
         await run_post_user_created(self.db, user)
         await self.db.commit()
-        await self.db.refresh(user)
 
         return user
 
@@ -110,13 +109,13 @@ class UserService:
         return result.first()
 
     async def get_user_by_id(self, user_id: int) -> User | None:
-        """Get user by ID asynchronously. Skips soft-deleted users."""
-        statement = select(User).where(
-            User.id == user_id,
-            User.deleted_at.is_(None),
-        )
-        result = await self.db.exec(statement)
-        return result.first()
+        """Get user by ID, skipping soft-deleted rows.
+
+        ``Session.get`` not ``select()``: the identity map answers a repeat PK
+        lookup without SQL, and ``deleted_at`` is filtered here instead.
+        """
+        user = await self.db.get(User, user_id)
+        return None if user is None or user.deleted_at is not None else user
 
     async def update_user(self, user_id: int, **updates) -> User | None:
         """Update user data asynchronously."""
@@ -131,7 +130,6 @@ class UserService:
         user.updated_at = utcnow()
         self.db.add(user)
         await self.db.commit()
-        await self.db.refresh(user)
 
         return user
 
@@ -380,7 +378,6 @@ class UserService:
         user.updated_at = utcnow()
         self.db.add(user)
         await self.db.commit()
-        await self.db.refresh(user)
         return user
 
     async def find_existing_emails_with_prefix(
@@ -414,7 +411,6 @@ class UserService:
         reset_token = PasswordResetToken(user_id=user.id, token=token)
         self.db.add(reset_token)
         await self.db.commit()
-        await self.db.refresh(reset_token)
         return token
 
     async def reset_password(self, token: str, new_password: str) -> None:
@@ -529,7 +525,6 @@ class UserService:
         verification_token = EmailVerificationToken(user_id=user_id, token=token)
         self.db.add(verification_token)
         await self.db.commit()
-        await self.db.refresh(verification_token)
         return token
 
     async def _invalidate_prior_email_verification_tokens(self, user_id: int) -> None:
@@ -560,7 +555,6 @@ class UserService:
 
         self.db.add(user)
         await self.db.commit()
-        await self.db.refresh(user)
 
     async def reset_login_attempts(self, user_id: int) -> None:
         """Reset failed login attempts and unlock account."""
@@ -572,7 +566,6 @@ class UserService:
         user.locked_until = None
         self.db.add(user)
         await self.db.commit()
-        await self.db.refresh(user)
 
     async def is_account_locked(self, user: User) -> bool:
         """Check if an account is currently locked.
@@ -591,7 +584,6 @@ class UserService:
         user.locked_until = None
         self.db.add(user)
         await self.db.commit()
-        await self.db.refresh(user)
         return False
 
 {% if include_oauth %}
@@ -667,7 +659,6 @@ class UserService:
                         identity.updated_at = utcnow()
                         self.db.add(identity)
                         await self.db.commit()
-                        await self.db.refresh(raw_user)
                         return raw_user
                 await self.db.delete(identity)
                 await self.db.commit()
@@ -740,7 +731,6 @@ class UserService:
         # has one place to subscribe.
         await run_post_user_created(self.db, user)
         await self.db.commit()
-        await self.db.refresh(user)
         return user
 
 {% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/blog/service.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/blog/service.py
@@ -146,7 +146,6 @@ class BlogService:
         self.db.add(post)
         await self.db.flush()
         await self._set_post_tags(post.id, payload.tag_slugs)  # type: ignore[arg-type]
-        await self.db.refresh(post)
         return await self._post_response(post)
 
     async def update_post(
@@ -185,7 +184,6 @@ class BlogService:
         if payload.tag_slugs is not None:
             await self._set_post_tags(post_id, payload.tag_slugs)
         await self.db.flush()
-        await self.db.refresh(post)
         return await self._post_response(post)
 
     async def publish_post(self, post_id: int) -> BlogPostResponse | None:
@@ -199,7 +197,6 @@ class BlogService:
         post.updated_at = now
         self.db.add(post)
         await self.db.flush()
-        await self.db.refresh(post)
         return await self._post_response(post)
 
     async def archive_post(self, post_id: int) -> BlogPostResponse | None:
@@ -211,7 +208,6 @@ class BlogService:
         post.updated_at = utcnow()
         self.db.add(post)
         await self.db.flush()
-        await self.db.refresh(post)
         return await self._post_response(post)
 
     async def delete_post(self, post_id: int) -> bool:
@@ -236,7 +232,6 @@ class BlogService:
         tag = BlogTag(name=payload.name, slug=slug)
         self.db.add(tag)
         await self.db.flush()
-        await self.db.refresh(tag)
         return self._tag_response(tag)
 
     async def update_tag(
@@ -255,7 +250,6 @@ class BlogService:
         tag.slug = new_slug
         self.db.add(tag)
         await self.db.flush()
-        await self.db.refresh(tag)
         return self._tag_response(tag)
 
     async def delete_tag(self, tag_id: int) -> bool:
@@ -537,7 +531,6 @@ class BlogService:
         tag = BlogTag(name=name, slug=slug)
         self.db.add(tag)
         await self.db.flush()
-        await self.db.refresh(tag)
         return tag
 
     async def _set_post_tags(self, post_id: int, tag_slugs: list[str]) -> None:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/accounts.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/finance/domains/ledger/accounts.py
@@ -33,14 +33,31 @@ async def get_or_create_currency(
     decimals: int = 2,
 ) -> FinanceCurrency:
     code = code.lower()
+    # Every row carrying a currency FK calls this - one per security, price,
+    # holding, trade, budget line, stream, and per row of a provider sync
+    # loop - against a table of a handful of immutable rows. ``Session.info``
+    # is SQLAlchemy's per-session scratch space, so the cache dies with the
+    # session and a rolled back currency is never handed to the next one.
+    cache: dict[str, FinanceCurrency] = db.info.setdefault(
+        "finance_currency_cache", {}
+    )
+    cached = cache.get(code)
+    # ``in db`` because a SAVEPOINT rollback (one per connection in a
+    # provider sync) expunges the instance: a cached row from a rolled back
+    # savepoint would be handed to the next connection and detach every row
+    # that referenced it.
+    if cached is not None and cached in db:
+        return cached
     existing = await queries.currency_by_code(db, code)
     if existing:
+        cache[code] = existing
         return existing
     currency = FinanceCurrency(
         code=code, name=name or code.upper(), symbol=symbol, decimals=decimals
     )
     db.add(currency)
     await db.flush()
+    cache[code] = currency
     return currency
 
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/insights/domains/events.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/insights/domains/events.py.jinja
@@ -125,7 +125,6 @@ class EventService:
         )
         self.db.add(event)
         await self.db.commit()
-        await self.db.refresh(event)
         return event
 
     async def update_user_event(
@@ -163,7 +162,6 @@ class EventService:
 
         self.db.add(event)
         await self.db.commit()
-        await self.db.refresh(event)
         return event
 
     async def delete_user_event(self, event_id: int) -> bool:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/insights/domains/goals.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/insights/domains/goals.py.jinja
@@ -106,7 +106,6 @@ class GoalService:
         )
         self.db.add(goal)
         await self.db.commit()
-        await self.db.refresh(goal)
         return goal
 
     async def update(
@@ -143,7 +142,6 @@ class GoalService:
         goal.updated_at = utcnow()
         self.db.add(goal)
         await self.db.commit()
-        await self.db.refresh(goal)
         return goal
 
     async def delete(self, goal_id: int, user_id: int) -> bool:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/insights/domains/projects.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/insights/domains/projects.py.jinja
@@ -81,7 +81,6 @@ class ProjectService:
         )
         self.db.add(project)
         await self.db.commit()
-        await self.db.refresh(project)
         # Detach so mutating plaintext fields can't flush ciphertext loss.
         self.db.expunge(project)
         # Caller passed plaintext; re-attach plaintext to the returned
@@ -198,7 +197,6 @@ class ProjectService:
         project.updated_at = utcnow()
 
         await self.db.commit()
-        await self.db.refresh(project)
         self.db.expunge(project)
         _decrypt_in_place(project)
         # Caller-supplied plaintext wins over decrypted (cheap consistency

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/pyproject.toml.jinja
@@ -187,6 +187,11 @@ dev = [
     "lxml>=6.1.3",
     "cssselect>=1.5.0",
 {%- endif %}
+{%- if include_database %}
+    # N+1 and query-budget detection for the test suite (make check-queries).
+    # Built on SQLAlchemy 2.0's do_orm_execute, so it needs a database stack.
+    "queryspy>=0.4.1",
+{%- endif %}
 {%- if include_database and database_engine != 'sqlite' %}
     # Tests use in-memory SQLite for speed/isolation regardless of the
     # production backend, so aiosqlite is required as a test dep even when
@@ -500,7 +505,11 @@ cmd = "npx --yes @biomejs/biome@2.5.1 format --write app/components/web_frontend
 help = "Run type checking with ty"
 cmd = "uv run ty check"
 
-[tool.poe.tasks.check]
+{% if include_database %}[tool.poe.tasks.check-queries]
+help = "Detect N+1 queries in the test suite"
+cmd = "uv run pytest --queryspy-strict"
+
+{% endif %}[tool.poe.tasks.check]
 help = "Run all code quality checks"
 sequence = ["lint", "typecheck", "test", { cmd = 'echo "All checks completed successfully!"' }]
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_currency_cache.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_currency_cache.py
@@ -1,0 +1,71 @@
+"""A currency lookup is resolved once per session, not once per row.
+
+``get_or_create_currency`` is called on every path that writes a row
+carrying a currency FK - every security, price, holding, trade, budget
+line, recurring stream, and every row of a provider sync loop. Each call
+issued its own SELECT for a table that holds a handful of immutable rows,
+which is the single largest source of repeated statements in the suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+from queryspy import assert_max_queries
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.finance.domains.ledger.accounts import get_or_create_currency
+
+
+class TestCurrencyLookupIsCachedPerSession:
+    @pytest.mark.asyncio
+    async def test_repeated_lookups_issue_one_select(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        first = await get_or_create_currency(async_db_session, "usd")
+
+        # The insert for a brand new currency is one statement; every
+        # lookup after it must add none.
+        with assert_max_queries(0):
+            for _ in range(5):
+                again = await get_or_create_currency(async_db_session, "usd")
+                assert again.id == first.id
+
+    @pytest.mark.asyncio
+    async def test_a_different_code_is_still_looked_up(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        usd = await get_or_create_currency(async_db_session, "usd")
+        eur = await get_or_create_currency(async_db_session, "eur")
+        assert usd.code == "usd"
+        assert eur.code == "eur"
+        assert usd.id != eur.id
+
+    @pytest.mark.asyncio
+    async def test_the_cache_does_not_leak_across_sessions(self, async_engine) -> None:
+        """A cache keyed on the session must die with it, or a rolled back
+        currency would be handed to the next request as if it existed."""
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        maker = async_sessionmaker(async_engine, class_=AsyncSession)
+        async with maker() as one:
+            await get_or_create_currency(one, "usd")
+            assert one.info.get("finance_currency_cache")
+        async with maker() as two:
+            assert not two.info.get("finance_currency_cache")
+
+
+    @pytest.mark.asyncio
+    async def test_a_rolled_back_savepoint_does_not_poison_the_cache(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        """Provider sync wraps each connection in a SAVEPOINT. A currency
+        created inside one that then rolls back must not be handed to the
+        next connection: the instance is expunged, and using it detaches
+        every row that referenced it."""
+        async with async_db_session.begin_nested() as savepoint:
+            await get_or_create_currency(async_db_session, "jpy")
+            await savepoint.rollback()
+
+        after = await get_or_create_currency(async_db_session, "jpy")
+        assert after in async_db_session
+        assert after.code == "jpy"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_user_lookup_queries.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_user_lookup_queries.py
@@ -1,0 +1,50 @@
+"""``get_user_by_id`` is a primary-key lookup, so it must go through the
+session's identity map rather than issuing a fresh SELECT every call.
+
+Every write path in ``UserService`` re-reads the user first - update,
+deactivate, verify, reset - so a single request routinely asks the
+database for the same row two or three times.
+"""
+
+from __future__ import annotations
+
+import pytest
+from queryspy import assert_max_queries
+from sqlmodel.ext.asyncio.session import AsyncSession
+
+from app.services.auth.users import UserService
+
+
+class TestUserByIdUsesTheIdentityMap:
+    @pytest.mark.asyncio
+    async def test_second_lookup_issues_no_sql(
+        self, async_db_session: AsyncSession, user_factory
+    ) -> None:
+        created = await user_factory()
+        service = UserService(async_db_session)
+
+        first = await service.get_user_by_id(created.id)
+        assert first is not None
+
+        with assert_max_queries(0):
+            again = await service.get_user_by_id(created.id)
+        assert again is not None
+        assert again.id == created.id
+
+    @pytest.mark.asyncio
+    async def test_a_soft_deleted_user_is_still_invisible(
+        self, async_db_session: AsyncSession, user_factory
+    ) -> None:
+        """The identity map has no idea about ``deleted_at``; the filter has
+        to survive the rewrite or soft delete stops working."""
+        created = await user_factory()
+        service = UserService(async_db_session)
+        assert await service.delete_user(created.id) is True
+        assert await service.get_user_by_id(created.id) is None
+
+    @pytest.mark.asyncio
+    async def test_a_missing_user_is_none(
+        self, async_db_session: AsyncSession
+    ) -> None:
+        service = UserService(async_db_session)
+        assert await service.get_user_by_id(999_999) is None

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -943,6 +943,7 @@ cp .env.example .env       # Configure environment (edit API keys, etc.)
 make serve                 # Start development server
 make test                  # Run test suite
 make check                 # Run all quality checks (lint + typecheck + test)
+make check-queries         # Detect N+1 queries in the suite (database stacks)
 ```
 
 ### Evolving Your Project

--- a/tests/cli/test_utils.py
+++ b/tests/cli/test_utils.py
@@ -226,6 +226,11 @@ def run_project_command(
     )
 
 
+QUERYSPY_BASELINE = (
+    Path(__file__).resolve().parent.parent / "fixtures" / "queryspy-baseline.json"
+)
+
+
 def run_quality_checks(project_path: Path, timeout: int = 120) -> list[CLITestResult]:
     """
     Run standard quality checks on a generated project.
@@ -283,10 +288,21 @@ def run_quality_checks(project_path: Path, timeout: int = 120) -> list[CLITestRe
         )
     )
 
-    # Tests
+    # Tests. A database stack ships queryspy in its dev extra, so the same
+    # run doubles as the N+1 gate rather than paying for a second suite pass.
+    # The baseline records what the templates already do; only a *new*
+    # finding fails. Entries key on paths relative to the generated project,
+    # identical across stacks, so one file serves the whole matrix and a
+    # stack that lacks a file just reports the entry as stale.
+    pytest_command = ["uv", "run", "pytest", "-v"]
+    if "queryspy" in (project_path / "pyproject.toml").read_text():
+        pytest_command += [
+            "--queryspy-strict",
+            f"--queryspy-baseline={QUERYSPY_BASELINE}",
+        ]
     results.append(
         run_project_command(
-            ["uv", "run", "pytest", "-v"],
+            pytest_command,
             project_path,
             timeout=QUALITY_CHECK_TIMEOUTS["tests"],
             step_name="Tests",

--- a/tests/core/test_queryspy_adoption.py
+++ b/tests/core/test_queryspy_adoption.py
@@ -1,0 +1,102 @@
+"""The N+1 rule in CLAUDE.md is enforced by running the suite, not by review.
+
+``queryspy`` is a pytest plugin built on SQLAlchemy 2.0's ``do_orm_execute``,
+so it only means anything in a stack that has a database. It rides the dev
+extra, never the runtime dependencies: a generated project ships the
+capability, and its author decides what to do with it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from jinja2 import Environment, FileSystemLoader
+
+from aegis.core.component_files import get_copier_defaults, get_template_path
+
+PROJECT_SLUG_PLACEHOLDER = "{{ project_slug }}"
+
+
+def _render(path: str, context: dict[str, Any]) -> str:
+    env = Environment(
+        loader=FileSystemLoader(str(get_template_path())),
+        trim_blocks=False,
+        lstrip_blocks=False,
+        keep_trailing_newline=True,
+    )
+    return env.get_template(f"{PROJECT_SLUG_PLACEHOLDER}/{path}").render(context)
+
+
+def _ctx(**overrides: Any) -> dict[str, Any]:
+    # ``project_slug`` has no copier default; without it ``[project.scripts]``
+    # renders a nameless entry and the result is not parseable TOML.
+    return {**get_copier_defaults(), "project_slug": "demo_app", **overrides}
+
+
+class TestQuerySpyRidesTheDatabase:
+    def test_dep_is_dev_only_and_gated_on_a_database(self) -> None:
+        on = _render("pyproject.toml.jinja", _ctx(include_database=True))
+        off = _render("pyproject.toml.jinja", _ctx(include_database=False))
+        assert "queryspy" in on
+        assert "queryspy" not in off
+
+    def test_dep_is_not_a_runtime_dependency(self) -> None:
+        """It must sit in the dev extra, never in ``[project] dependencies``."""
+        import tomllib
+
+        project = tomllib.loads(
+            _render("pyproject.toml.jinja", _ctx(include_database=True))
+        )["project"]
+        runtime = " ".join(project["dependencies"])
+        dev = " ".join(project["optional-dependencies"]["dev"])
+        assert "queryspy" not in runtime
+        assert "queryspy" in dev
+
+    def test_check_queries_target_is_gated_the_same_way(self) -> None:
+        on = _render("Makefile.jinja", _ctx(include_database=True))
+        off = _render("Makefile.jinja", _ctx(include_database=False))
+        assert "check-queries:" in on
+        assert "check-queries:" not in off
+
+    def test_poe_mirrors_the_make_target(self) -> None:
+        """Windows has no ``make``; every target has a poe twin."""
+        rendered = _render("pyproject.toml.jinja", _ctx(include_database=True))
+        assert "[tool.poe.tasks.check-queries]" in rendered
+
+
+class TestTheGateIsUp:
+    BASELINE = Path("tests/fixtures/queryspy-baseline.json")
+
+    def test_the_stack_matrix_runs_strict_against_the_baseline(self) -> None:
+        """One suite run per stack carries the gate; no second pass."""
+        source = Path("tests/cli/test_utils.py").read_text()
+        assert "--queryspy-strict" in source
+        assert "--queryspy-baseline=" in source
+
+    def test_the_baseline_is_the_tools_own_format(self) -> None:
+        import json
+
+        doc = json.loads(self.BASELINE.read_text())
+        assert doc["tool"] == "queryspy"
+        assert {"kind", "label", "file", "function"} <= set(doc["entries"][0])
+
+    def test_no_app_code_column_load_is_frozen_in(self) -> None:
+        """``column_load`` in app code was one pattern - ``refresh()`` after a
+        write, with no ``server_default`` anywhere - and it was fixed, not
+        baselined. Test files re-reading a row a service updated are correct
+        and stay. A new one in ``app/`` is a regression, not debt."""
+        import json
+
+        offenders = [
+            f"{e['file']}:{e['function']}"
+            for e in json.loads(self.BASELINE.read_text())["entries"]
+            if e["kind"] == "column_load" and e["file"].startswith("app/")
+        ]
+        assert offenders == []
+
+    def test_the_plugin_is_inert_unless_asked(self) -> None:
+        """Installing it must not change a plain ``pytest`` run."""
+        rendered = _render("pyproject.toml.jinja", _ctx(include_database=True))
+        assert "queryspy_fail_on" not in rendered
+        assert "queryspy_budget" not in rendered

--- a/tests/fixtures/queryspy-baseline.json
+++ b/tests/fixtures/queryspy-baseline.json
@@ -1,0 +1,2190 @@
+{
+  "tool": "queryspy",
+  "version": "0.4.1",
+  "entries": [
+    {
+      "kind": "column_load",
+      "label": "Agent",
+      "file": "tests/services/ai/test_agent_loader.py",
+      "function": "_add_agent"
+    },
+    {
+      "kind": "column_load",
+      "label": "Agent",
+      "file": "tests/services/ai/test_agent_registry.py",
+      "function": "_add_agent"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/api/test_finance_endpoints.py",
+      "function": "test_batch_approve_with_a_veto"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_attach.py",
+      "function": "test_backfill_never_steals_claimed_rows"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_attach.py",
+      "function": "test_it_backfills_the_payees_history"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_bill_editing.py",
+      "function": "test_declaring_with_a_category_leaves_transactions_alone"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_bill_editing.py",
+      "function": "test_the_member_transactions_are_left_alone"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_declare_recurring.py",
+      "function": "test_detection_leaves_a_confirmed_bills_members_alone"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_pending_changes.py",
+      "function": "test_a_batch_shares_one_id_and_moves_nothing"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_pending_changes.py",
+      "function": "test_approve_assigns_the_payee_creating_it_once"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_pending_changes.py",
+      "function": "test_approve_attaches_the_payment_and_advances_the_bill"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_pending_changes.py",
+      "function": "test_approve_batch_executes_all_but_the_vetoed"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_pending_changes.py",
+      "function": "test_reject_batch_leaves_the_ledger_untouched"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_transfers.py",
+      "function": "test_a_same_day_purchase_and_refund_is_left_alone"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_transfers.py",
+      "function": "test_an_adjustment_pair_drops_out_of_reports"
+    },
+    {
+      "kind": "column_load",
+      "label": "FinanceTransaction",
+      "file": "tests/services/test_finance_transfers.py",
+      "function": "test_old_flagged_payments_pair_confirmed"
+    },
+    {
+      "kind": "column_load",
+      "label": "Tool",
+      "file": "tests/services/ai/test_agent_loader.py",
+      "function": "test_only_active_tools_are_exposed"
+    },
+    {
+      "kind": "column_load",
+      "label": "User",
+      "file": "tests/api/test_auth_endpoints.py",
+      "function": "_admin_and_target"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT \"user\".email, \"user\".full_name, \"user\".is_active, \"user\".is_verified, \"user\".id, \"user\".hashed_password, \"user\".last_login, \"user\".created_at, \"user\".updated_at, \"user\".deleted_at, \"user\".failed_login_attempts, \"user\".locked_until FROM \"user\" WHERE \"user\".email = :email_1 AND \"user\".deleted_at IS NULL",
+      "file": "app/services/auth/users.py",
+      "function": "get_user_by_email"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT \"user\".email, \"user\".full_name, \"user\".is_active, \"user\".is_verified, \"user\".id, \"user\".hashed_password, \"user\".last_login, \"user\".created_at, \"user\".updated_at, \"user\".deleted_at, \"user\".failed_login_attempts, \"user\".locked_until FROM \"user\" WHERE \"user\".id = :id_1",
+      "file": "app/services/auth/users.py",
+      "function": "hard_delete_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT \"user\".email, \"user\".full_name, \"user\".is_active, \"user\".is_verified, \"user\".id, \"user\".hashed_password, \"user\".last_login, \"user\".created_at, \"user\".updated_at, \"user\".deleted_at, \"user\".failed_login_attempts, \"user\".locked_until FROM \"user\" WHERE \"user\".id = :id_1",
+      "file": "app/services/auth/users.py",
+      "function": "restore_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT \"user\".email, \"user\".full_name, \"user\".is_active, \"user\".is_verified, \"user\".role, \"user\".id, \"user\".hashed_password, \"user\".last_login, \"user\".created_at, \"user\".updated_at, \"user\".deleted_at, \"user\".failed_login_attempts, \"user\".locked_until FROM \"user\" WHERE \"user\".email = :email_1 AND \"user\".deleted_at IS NULL",
+      "file": "app/services/auth/users.py",
+      "function": "get_user_by_email"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT \"user\".email, \"user\".full_name, \"user\".is_active, \"user\".is_verified, \"user\".role, \"user\".id, \"user\".hashed_password, \"user\".last_login, \"user\".created_at, \"user\".updated_at, \"user\".deleted_at, \"user\".failed_login_attempts, \"user\".locked_until FROM \"user\" WHERE \"user\".id = :id_1",
+      "file": "app/services/auth/users.py",
+      "function": "hard_delete_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT \"user\".email, \"user\".full_name, \"user\".is_active, \"user\".is_verified, \"user\".role, \"user\".id, \"user\".hashed_password, \"user\".last_login, \"user\".created_at, \"user\".updated_at, \"user\".deleted_at, \"user\".failed_login_attempts, \"user\".locked_until FROM \"user\" WHERE \"user\".id = :id_1",
+      "file": "app/services/auth/users.py",
+      "function": "restore_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT DISTINCT finance_transaction.recurring_stream_id FROM finance_transaction JOIN finance_transfer ON finance_transfer.from_transaction_id = finance_transaction.id JOIN finance_transaction AS finance_transaction_1 ON finance_transaction_1.id = finance_transfer.to_transaction_id JOIN finance_account ON finance_account.id = finance_transaction_1.account_id WHERE finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND finance_transfer.status = :status_1 AND finance_account.classification = :classification_1 AND finance_account.account_type = :account_type_1",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "card_payment_stream_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT DISTINCT finance_transaction.recurring_stream_id FROM finance_transaction WHERE finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND (EXISTS (SELECT finance_transfer.id FROM finance_transfer JOIN finance_account ON finance_account.id = (SELECT finance_transaction.account_id FROM finance_transaction WHERE finance_transaction.id = finance_transfer.to_transaction_id) WHERE finance_transfer.from_transaction_id = finance_transaction.id AND finance_transfer.status = :status_1 AND finance_account.classification = :classification_1))",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "payment_flagged_stream_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT DISTINCT finance_transaction.recurring_stream_id FROM finance_transaction WHERE finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND finance_transaction.is_transfer IS true",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "transfer_flagged_stream_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT agent.id, agent.slug, agent.name, agent.description, agent.category, agent.model_id, agent.system_prompt, agent.temperature, agent.max_tokens, agent.memory_modules, agent.knowledge_base_ids, agent.is_active, agent.code_mode, agent.created_at, agent.updated_at FROM agent WHERE agent.slug = :slug_1",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "agent_by_slug"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT agent.id, agent.slug, agent.name, agent.description, agent.category, agent.model_id, agent.system_prompt, agent.temperature, agent.max_tokens, agent.memory_modules, agent.knowledge_base_ids, agent.is_active, agent.code_mode, agent.created_at, agent.updated_at FROM agent WHERE agent.slug = :slug_1",
+      "file": "app/services/ai/fixtures/agent_fixtures.py",
+      "function": "load_agent_fixtures"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT agent_1.id AS agent_1_id, tool.id AS tool_id, tool.name AS tool_name, tool.description AS tool_description, tool.is_active AS tool_is_active FROM agent AS agent_1 JOIN agent_tool AS agent_tool_1 ON agent_1.id = agent_tool_1.agent_id JOIN tool ON tool.id = agent_tool_1.tool_id WHERE agent_1.id IN (__[POSTCOMPILE_primary_keys])",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "agent_by_slug"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT agent_user_memory.id, agent_user_memory.user_id, agent_user_memory.memory, agent_user_memory.created_at, agent_user_memory.updated_at FROM agent_user_memory WHERE agent_user_memory.user_id = :user_id_1",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "user_memory_for"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT apscheduler_jobs.id, apscheduler_jobs.next_run_time, apscheduler_jobs.job_state FROM apscheduler_jobs ORDER BY apscheduler_jobs.next_run_time DESC NULLS LAST",
+      "file": "app/services/scheduler/scheduled_task_manager.py",
+      "function": "list_tasks"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_post.id, blog_post.title, blog_post.slug, blog_post.excerpt, blog_post.content, blog_post.status, blog_post.author_id, blog_post.author_name, blog_post.created_at, blog_post.updated_at, blog_post.published_at, blog_post.seo_title, blog_post.seo_description, blog_post.hero_image_url, blog_post.syndicate_targets FROM blog_post WHERE blog_post.id = :id_1",
+      "file": "app/services/blog/service.py",
+      "function": "_get_post_model"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_post.id, blog_post.title, blog_post.slug, blog_post.excerpt, blog_post.content, blog_post.status, blog_post.author_id, blog_post.author_name, blog_post.created_at, blog_post.updated_at, blog_post.published_at, blog_post.seo_title, blog_post.seo_description, blog_post.hero_image_url, blog_post.syndicate_targets FROM blog_post WHERE blog_post.slug = :slug_1",
+      "file": "app/services/blog/service.py",
+      "function": "_ensure_slug_available"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_post.id, blog_post.title, blog_post.slug, blog_post.excerpt, blog_post.content, blog_post.status, blog_post.author_id, blog_post.author_name, blog_post.created_at, blog_post.updated_at, blog_post.published_at, blog_post.seo_title, blog_post.seo_description, blog_post.hero_image_url, blog_post.syndicate_targets FROM blog_post WHERE blog_post.slug = :slug_1",
+      "file": "app/services/blog/service.py",
+      "function": "_get_post_by_slug_any_status"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_post.id, blog_post.title, blog_post.slug, blog_post.excerpt, blog_post.content, blog_post.status, blog_post.author_id, blog_post.author_name, blog_post.created_at, blog_post.updated_at, blog_post.published_at, blog_post.seo_title, blog_post.seo_description, blog_post.hero_image_url, blog_post.syndicate_targets FROM blog_post WHERE blog_post.slug = :slug_1 AND blog_post.id != :id_1",
+      "file": "app/services/blog/service.py",
+      "function": "_ensure_slug_available"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_post.id, blog_post.title, blog_post.slug, blog_post.excerpt, blog_post.content, blog_post.status, blog_post.author_id, blog_post.author_name, blog_post.created_at, blog_post.updated_at, blog_post.published_at, blog_post.seo_title, blog_post.seo_description, blog_post.hero_image_url, blog_post.syndicate_targets FROM blog_post WHERE blog_post.slug = :slug_1 AND blog_post.status = :status_1",
+      "file": "app/services/blog/service.py",
+      "function": "_get_post_by_slug"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_post.id, blog_post.title, blog_post.slug, blog_post.excerpt, blog_post.content, blog_post.status, blog_post.author_id, blog_post.author_name, blog_post.created_at, blog_post.updated_at, blog_post.published_at, blog_post.seo_title, blog_post.seo_description, blog_post.hero_image_url, blog_post.syndicate_targets FROM blog_post WHERE blog_post.status = :status_1 ORDER BY blog_post.created_at DESC LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/blog/service.py",
+      "function": "list_posts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_post.id, blog_post.title, blog_post.slug, blog_post.excerpt, blog_post.content, blog_post.status, blog_post.author_id, blog_post.author_name, blog_post.created_at, blog_post.updated_at, blog_post.published_at, blog_post.seo_title, blog_post.seo_description, blog_post.hero_image_url, blog_post.syndicate_targets FROM blog_post WHERE blog_post.status = :status_1 ORDER BY blog_post.published_at DESC LIMIT :param_1",
+      "file": "app/services/blog/service.py",
+      "function": "get_health_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_tag.id, blog_tag.name, blog_tag.slug, blog_tag.created_at FROM blog_tag JOIN blog_post_tag ON blog_tag.id = blog_post_tag.tag_id WHERE blog_post_tag.post_id = :post_id_1 ORDER BY blog_tag.name",
+      "file": "app/services/blog/service.py",
+      "function": "_get_post_tags"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_tag.id, blog_tag.name, blog_tag.slug, blog_tag.created_at FROM blog_tag WHERE blog_tag.id = :id_1",
+      "file": "app/services/blog/service.py",
+      "function": "_get_tag_model"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT blog_tag.id, blog_tag.name, blog_tag.slug, blog_tag.created_at FROM blog_tag WHERE blog_tag.slug = :slug_1",
+      "file": "app/services/blog/service.py",
+      "function": "_get_or_create_tag"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT coalesce(sum(CASE WHEN (finance_account.classification = :classification_1 AND NOT finance_account.is_hidden) THEN finance_account.current_balance ELSE :param_1 END), :coalesce_2) AS coalesce_1, coalesce(sum(CASE WHEN (finance_account.classification = :classification_2 AND NOT finance_account.is_hidden) THEN finance_account.current_balance ELSE :param_2 END), :coalesce_4) AS coalesce_3, count(*) AS count_1 FROM finance_account WHERE finance_account.deleted_at IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "account_rollup"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT coalesce(sum(CASE WHEN (finance_account.classification = :classification_1 AND NOT finance_account.is_hidden) THEN finance_account.current_balance ELSE :param_1 END), :coalesce_2) AS coalesce_1, coalesce(sum(CASE WHEN (finance_account.classification = :classification_2 AND NOT finance_account.is_hidden) THEN finance_account.current_balance ELSE :param_2 END), :coalesce_4) AS coalesce_3, count(*) AS count_1 FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "account_rollup"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT coalesce(sum(finance_transaction.amount), :coalesce_2) AS coalesce_1 FROM finance_transaction WHERE finance_transaction.account_id = :account_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.status = :status_1 AND finance_transaction.date <= :date_1",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "register_balance_through"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT coalesce(sum(llm_usage.input_tokens), :coalesce_1) AS input_tokens, coalesce(sum(llm_usage.output_tokens), :coalesce_2) AS output_tokens, coalesce(sum(llm_usage.total_cost), :coalesce_3) AS total_cost, count(llm_usage.id) AS total_requests, sum(CAST(llm_usage.success AS INTEGER)) AS success_count FROM llm_usage",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "usage_totals"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT coalesce(sum(payment_transaction.amount), :coalesce_2) AS coalesce_1 FROM payment_transaction WHERE payment_transaction.status = :status_1 AND payment_transaction.type = :type_1",
+      "file": "app/services/payment/service.py",
+      "function": "get_status_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT conversation.id AS conversation_id, conversation.title AS conversation_title, conversation.user_id AS conversation_user_id, conversation.created_at AS conversation_created_at, conversation.updated_at AS conversation_updated_at, conversation.meta_data AS conversation_meta_data FROM conversation WHERE conversation.id = :pk_1",
+      "file": "app/services/ai/domains/chat/chat_kit/history.py",
+      "function": "append_turn"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT conversation.id AS conversation_id, conversation.title AS conversation_title, conversation.user_id AS conversation_user_id, conversation.created_at AS conversation_created_at, conversation.updated_at AS conversation_updated_at, conversation.meta_data AS conversation_meta_data FROM conversation WHERE conversation.id = :pk_1",
+      "file": "app/services/ai/domains/chat/conversation.py",
+      "function": "_save_to_db"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT conversation.id, conversation.title, conversation.user_id, conversation.created_at, conversation.updated_at, conversation.meta_data FROM conversation LEFT OUTER JOIN sentiment_analysis ON sentiment_analysis.conversation_id = conversation.id WHERE sentiment_analysis.id IS NULL ORDER BY conversation.updated_at LIMIT :param_1",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "unscored_conversations"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT conversation.id, conversation.title, conversation.user_id, conversation.created_at, conversation.updated_at, conversation.meta_data FROM conversation ORDER BY conversation.updated_at DESC",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "conversations_with_messages"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT conversation_message.conversation_id AS conversation_message_conversation_id, conversation_message.id AS conversation_message_id, conversation_message.role AS conversation_message_role, conversation_message.content AS conversation_message_content, conversation_message.timestamp AS conversation_message_timestamp, conversation_message.meta_data AS conversation_message_meta_data FROM conversation_message WHERE conversation_message.conversation_id IN (__[POSTCOMPILE_primary_keys])",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "conversations_with_messages"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT conversation_message.id AS conversation_message_id, conversation_message.conversation_id AS conversation_message_conversation_id, conversation_message.role AS conversation_message_role, conversation_message.content AS conversation_message_content, conversation_message.timestamp AS conversation_message_timestamp, conversation_message.meta_data AS conversation_message_meta_data FROM conversation_message WHERE conversation_message.id = :pk_1",
+      "file": "app/services/ai/domains/chat/conversation.py",
+      "function": "_save_to_db"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT conversation_message.id, conversation_message.conversation_id, conversation_message.role, conversation_message.content, conversation_message.timestamp, conversation_message.meta_data FROM conversation_message WHERE conversation_message.conversation_id = :conversation_id_1 ORDER BY conversation_message.timestamp",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "messages_for_conversation"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM \"user\"",
+      "file": "app/services/auth/users.py",
+      "function": "create_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM blog_post",
+      "file": "app/services/blog/service.py",
+      "function": "_count_posts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM blog_post WHERE blog_post.status = :status_1",
+      "file": "app/services/blog/service.py",
+      "function": "_count_posts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM blog_post WHERE blog_post.status = :status_1",
+      "file": "app/services/blog/service.py",
+      "function": "list_posts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM blog_post WHERE blog_post.status = :status_1 AND blog_post.updated_at < :updated_at_1",
+      "file": "app/services/blog/service.py",
+      "function": "get_health_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM blog_tag",
+      "file": "app/services/blog/service.py",
+      "function": "get_health_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM conversation",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "conversation_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM conversation_message",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "message_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM document WHERE document.deleted_at IS NULL AND document.received_at >= :received_at_1",
+      "file": "app/services/documents/queries.py",
+      "function": "store_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_account WHERE finance_account.deleted_at IS NULL AND NOT finance_account.is_hidden",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "accounts_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1 AND NOT finance_account.is_hidden",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "accounts_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_insight WHERE finance_insight.status = :status_1 AND finance_insight.insight_type != :insight_type_1",
+      "file": "app/services/finance/domains/planning/queries.py",
+      "function": "new_insight_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_net_worth_snapshot",
+      "file": "tests/services/test_finance_service.py",
+      "function": "test_recompute_is_idempotent"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_transfer IS false AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transactions_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_transfer IS false AND finance_transaction.owner_user_id = :owner_user_id_1 AND (lower(finance_transaction.name) LIKE lower(:name_1) OR lower(finance_transaction.merchant_name) LIKE lower(:merchant_name_1) OR lower(finance_transaction.original_description) LIKE lower(:original_description_1) OR lower(finance_transaction.memo) LIKE lower(:memo_1) OR finance_transaction.merchant_id IN (SELECT finance_merchant.id FROM finance_merchant WHERE lower(finance_merchant.name) LIKE lower(:name_2)) OR finance_transaction.category_id IN (SELECT finance_category.id FROM finance_category WHERE lower(finance_category.name) LIKE lower(:name_3)) OR finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE lower(finance_account.name) LIKE lower(:name_4)) OR abs(finance_transaction.amount) = :abs_1)",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transactions_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_transfer IS false AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.account_id = :account_id_1",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transactions_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_split IS false AND (finance_transaction.category_id IS NULL OR finance_transaction.category_id IN (SELECT finance_category.id FROM finance_category WHERE lower(finance_category.name) IN (__[POSTCOMPILE_lower_1]))) AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "uncategorized_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM insight_metric",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "metric_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM job_execution WHERE job_execution.job_id = :job_id_1",
+      "file": "app/services/scheduler/scheduled_task_manager.py",
+      "function": "list_executions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM organization",
+      "file": "app/services/auth/health.py",
+      "function": "check_auth_service_health"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM payment_dispute WHERE payment_dispute.status IN (__[POSTCOMPILE_status_1])",
+      "file": "app/services/payment/service.py",
+      "function": "get_status_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM payment_subscription WHERE payment_subscription.status = :status_1",
+      "file": "app/services/payment/service.py",
+      "function": "get_status_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM payment_transaction",
+      "file": "app/services/payment/service.py",
+      "function": "get_status_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1 FROM payment_transaction WHERE payment_transaction.customer_id IN (__[POSTCOMPILE_customer_id_1])",
+      "file": "app/services/payment/service.py",
+      "function": "get_transactions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1, coalesce(sum(CASE WHEN finance_connection.needs_user_action THEN :param_1 ELSE :param_2 END), :coalesce_2) AS coalesce_1 FROM finance_connection WHERE finance_connection.deleted_at IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "connection_rollup"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS count_1, coalesce(sum(CASE WHEN finance_connection.needs_user_action THEN :param_1 ELSE :param_2 END), :coalesce_2) AS coalesce_1 FROM finance_connection WHERE finance_connection.deleted_at IS NULL AND finance_connection.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "connection_rollup"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(*) AS total, sum(CASE WHEN (\"user\".is_verified = true) THEN :param_1 ELSE :param_2 END) AS verified FROM \"user\"",
+      "file": "app/services/auth/health.py",
+      "function": "check_auth_service_health"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT count(distinct(conversation.meta_data[:meta_data_1])) AS count_1 FROM conversation WHERE conversation.meta_data[:meta_data_1] IS NOT NULL",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "distinct_user_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document.id, document.owner_user_id, document.title, document.kind, document.storage_key, document.storage_backend, document.content_hash, document.media_type, document.byte_size, document.page_count, document.document_date, document.received_at, document.source, document.channel, document.supersedes_id, document.protected, document.note, document.meta_data, document.created_at, document.updated_at, document.deleted_at FROM document WHERE document.content_hash = :content_hash_1 AND document.deleted_at IS NULL",
+      "file": "app/services/documents/queries.py",
+      "function": "document_by_content"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document.id, document.owner_user_id, document.title, document.kind, document.storage_key, document.storage_backend, document.content_hash, document.media_type, document.byte_size, document.page_count, document.document_date, document.received_at, document.source, document.channel, document.supersedes_id, document.protected, document.note, document.meta_data, document.created_at, document.updated_at, document.deleted_at FROM document WHERE document.content_hash = :content_hash_1 AND document.deleted_at IS NULL AND document.owner_user_id = :owner_user_id_1",
+      "file": "app/services/documents/queries.py",
+      "function": "document_by_content"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document.id, document.owner_user_id, document.title, document.kind, document.storage_key, document.storage_backend, document.content_hash, document.media_type, document.byte_size, document.page_count, document.document_date, document.received_at, document.source, document.channel, document.supersedes_id, document.protected, document.note, document.meta_data, document.created_at, document.updated_at, document.deleted_at FROM document WHERE document.id = :id_1 AND document.deleted_at IS NULL",
+      "file": "app/services/documents/queries.py",
+      "function": "document_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document.id, document.owner_user_id, document.title, document.kind, document.storage_key, document.storage_backend, document.content_hash, document.media_type, document.byte_size, document.page_count, document.document_date, document.received_at, document.source, document.channel, document.supersedes_id, document.protected, document.note, document.meta_data, document.created_at, document.updated_at, document.deleted_at FROM document WHERE document.id = :id_1 AND document.deleted_at IS NULL AND document.owner_user_id = :owner_user_id_1",
+      "file": "app/services/documents/queries.py",
+      "function": "document_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document.kind, count(*) AS count_1, coalesce(sum(document.byte_size), :coalesce_2) AS coalesce_1 FROM document WHERE document.deleted_at IS NULL GROUP BY document.kind",
+      "file": "app/services/documents/queries.py",
+      "function": "store_summary"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document_page.id, document_page.document_id, document_page.page_number, document_page.status, document_page.method, document_page.text, document_page.image_key, document_page.model, document_page.detail, document_page.created_at, document_page.updated_at FROM document_page WHERE document_page.document_id = :document_id_1 AND document_page.page_number = :page_number_1",
+      "file": "app/services/documents/queries.py",
+      "function": "page_for"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document_page.id, document_page.document_id, document_page.page_number, document_page.status, document_page.method, document_page.text, document_page.image_key, document_page.model, document_page.detail, document_page.created_at, document_page.updated_at FROM document_page WHERE document_page.document_id = :document_id_1 ORDER BY document_page.page_number",
+      "file": "app/services/documents/queries.py",
+      "function": "pages_for"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document_tag.id, document_tag.document_id, document_tag.label FROM document_tag WHERE document_tag.document_id = :document_id_1 AND document_tag.label = :label_1",
+      "file": "app/services/documents/service.py",
+      "function": "tag"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document_tag.id, document_tag.document_id, document_tag.label FROM document_tag WHERE document_tag.document_id = :document_id_1 ORDER BY document_tag.label",
+      "file": "app/services/documents/queries.py",
+      "function": "tags_for"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT document_tag.id, document_tag.document_id, document_tag.label FROM document_tag WHERE document_tag.document_id IN (__[POSTCOMPILE_document_id_1]) ORDER BY document_tag.document_id, document_tag.label",
+      "file": "app/services/documents/queries.py",
+      "function": "tags_for_many"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT email_verification_token.id, email_verification_token.user_id, email_verification_token.token, email_verification_token.created_at, email_verification_token.used FROM email_verification_token WHERE email_verification_token.token = :token_1",
+      "file": "tests/services/test_auth_integration.py",
+      "function": "test_resend_marks_prior_token_used"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT email_verification_token.id, email_verification_token.user_id, email_verification_token.token, email_verification_token.created_at, email_verification_token.used FROM email_verification_token WHERE email_verification_token.user_id = :user_id_1 AND email_verification_token.used = false",
+      "file": "app/services/auth/users.py",
+      "function": "_invalidate_prior_email_verification_tokens"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id FROM finance_account WHERE finance_account.name = :name_1 AND finance_account.deleted_at IS NOT NULL AND finance_account.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "removed_account_exists"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id FROM finance_account WHERE finance_account.name = :name_1 AND finance_account.deleted_at IS NOT NULL AND finance_account.owner_user_id IS NULL",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "removed_account_exists"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id FROM finance_account WHERE finance_account.name = :name_1 AND finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "live_account_id_by_name"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id FROM finance_account WHERE finance_account.name = :name_1 AND finance_account.deleted_at IS NULL AND finance_account.owner_user_id IS NULL",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "live_account_id_by_name"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account",
+      "file": "tests/services/test_finance_import.py",
+      "function": "_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL",
+      "file": "tests/services/test_finance_demo_seed.py",
+      "function": "_accounts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL AND NOT finance_account.is_hidden ORDER BY finance_account.classification, finance_account.name LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "accounts_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.account_type = :account_type_1 AND finance_account.owner_user_id = :owner_user_id_1 ORDER BY finance_account.id",
+      "file": "app/services/finance/domains/planning/queries.py",
+      "function": "accounts_of_type"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.account_type = :account_type_1 ORDER BY finance_account.id",
+      "file": "app/services/finance/domains/planning/queries.py",
+      "function": "accounts_of_type"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "account_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1 AND NOT finance_account.is_hidden ORDER BY finance_account.classification, finance_account.name LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "accounts_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1 ORDER BY finance_account.id",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "live_accounts_for_owner"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "account_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.deleted_at IS NULL ORDER BY finance_account.id",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "live_accounts_for_owner"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.id = :id_1 AND finance_account.deleted_at IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "account_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.id = :id_1 AND finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "account_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/seeds/demo_seed.py",
+      "function": "_demo_accounts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.owner_user_id = :owner_user_id_1 AND finance_account.deleted_at IS NULL AND finance_account.classification = :classification_1 AND finance_account.account_type IN (__[POSTCOMPILE_account_type_1]) AND finance_account.is_closed IS false AND finance_account.is_hidden IS false",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "account_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.owner_user_id = :owner_user_id_1 AND finance_account.deleted_at IS NULL AND finance_account.classification = :classification_1 AND finance_account.is_closed IS false AND finance_account.is_hidden IS false",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "account_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.owner_user_id IS NULL AND finance_account.deleted_at IS NULL AND finance_account.classification = :classification_1 AND finance_account.account_type IN (__[POSTCOMPILE_account_type_1]) AND finance_account.is_closed IS false AND finance_account.is_hidden IS false",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "account_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.owner_user_id IS NULL AND finance_account.deleted_at IS NULL AND finance_account.classification = :classification_1 AND finance_account.is_closed IS false AND finance_account.is_hidden IS false",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "account_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.provider = :provider_1 AND finance_account.name = :name_1 AND finance_account.deleted_at IS NULL AND finance_account.mask = :mask_1 AND finance_account.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/adapters/providers/queries.py",
+      "function": "account_first_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_account.id, finance_account.owner_user_id, finance_account.subject_id, finance_account.organization_id, finance_account.connection_id, finance_account.institution_id, finance_account.provider, finance_account.provider_account_id, finance_account.persistent_account_id, finance_account.name, finance_account.official_name, finance_account.mask, finance_account.type, finance_account.subtype, finance_account.account_type, finance_account.classification, finance_account.currency, finance_account.current_balance, finance_account.available_balance, finance_account.credit_limit, finance_account.balance_as_of, finance_account.is_manual, finance_account.is_hidden, finance_account.is_closed, finance_account.is_on_budget, finance_account.linked_at, finance_account.last_synced_at, finance_account.deleted_at, finance_account.metadata, finance_account.created_at, finance_account.updated_at FROM finance_account WHERE finance_account.provider = :provider_1 AND finance_account.provider_account_id = :provider_account_id_1",
+      "file": "app/services/finance/adapters/providers/queries.py",
+      "function": "account_by_provider_account_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_balance_snapshot.balance_date, finance_account.classification, sum(finance_balance_snapshot.balance) AS sum_1 FROM finance_balance_snapshot JOIN finance_account ON finance_account.id = finance_balance_snapshot.account_id WHERE finance_balance_snapshot.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_balance_snapshot.balance_date >= :balance_date_1 AND finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_1 GROUP BY finance_balance_snapshot.balance_date, finance_account.classification ORDER BY finance_balance_snapshot.balance_date",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "balance_class_series"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_balance_snapshot.id, finance_balance_snapshot.account_id, finance_balance_snapshot.owner_user_id, finance_balance_snapshot.organization_id, finance_balance_snapshot.balance_date, finance_balance_snapshot.balance, finance_balance_snapshot.available_balance, finance_balance_snapshot.cash_balance, finance_balance_snapshot.holdings_value, finance_balance_snapshot.currency, finance_balance_snapshot.base_currency_value, finance_balance_snapshot.source, finance_balance_snapshot.is_estimated FROM finance_balance_snapshot WHERE finance_balance_snapshot.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_balance_snapshot.balance_date >= :balance_date_1 AND finance_balance_snapshot.balance_date <= :balance_date_2",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "balance_snapshots_between"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget.id, finance_budget.owner_user_id, finance_budget.organization_id, finance_budget.name, finance_budget.period, finance_budget.start_date, finance_budget.end_date, finance_budget.currency, finance_budget.philosophy, finance_budget.rollover, finance_budget.is_active, finance_budget.deleted_at, finance_budget.created_at, finance_budget.updated_at FROM finance_budget WHERE finance_budget.name = :name_1 AND finance_budget.deleted_at IS NULL AND finance_budget.owner_user_id = :owner_user_id_1 ORDER BY finance_budget.id",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "monthly_budget"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget.id, finance_budget.owner_user_id, finance_budget.organization_id, finance_budget.name, finance_budget.period, finance_budget.start_date, finance_budget.end_date, finance_budget.currency, finance_budget.philosophy, finance_budget.rollover, finance_budget.is_active, finance_budget.deleted_at, finance_budget.created_at, finance_budget.updated_at FROM finance_budget WHERE finance_budget.name = :name_1 AND finance_budget.deleted_at IS NULL ORDER BY finance_budget.id",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "monthly_budget"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget_category.id, finance_budget_category.owner_user_id, finance_budget_category.budget_id, finance_budget_category.category_id, finance_budget_category.payee_key, finance_budget_category.payee_label, finance_budget_category.period_month, finance_budget_category.allocated_amount, finance_budget_category.goal_amount, finance_budget_category.carryover_amount, finance_budget_category.rollover_enabled, finance_budget_category.currency, finance_budget_category.created_at, finance_budget_category.updated_at FROM finance_budget_category WHERE finance_budget_category.budget_id = :budget_id_1 AND finance_budget_category.category_id IS NOT NULL",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "budget_lines_with_category"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget_category.id, finance_budget_category.owner_user_id, finance_budget_category.budget_id, finance_budget_category.category_id, finance_budget_category.payee_key, finance_budget_category.payee_label, finance_budget_category.period_month, finance_budget_category.allocated_amount, finance_budget_category.goal_amount, finance_budget_category.carryover_amount, finance_budget_category.rollover_enabled, finance_budget_category.currency, finance_budget_category.created_at, finance_budget_category.updated_at FROM finance_budget_category WHERE finance_budget_category.budget_id = :budget_id_1 AND finance_budget_category.category_id IS NOT NULL AND finance_budget_category.period_month IS NULL",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "dismissal_marker_lines"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget_category.id, finance_budget_category.owner_user_id, finance_budget_category.budget_id, finance_budget_category.category_id, finance_budget_category.payee_key, finance_budget_category.payee_label, finance_budget_category.period_month, finance_budget_category.allocated_amount, finance_budget_category.goal_amount, finance_budget_category.carryover_amount, finance_budget_category.rollover_enabled, finance_budget_category.currency, finance_budget_category.created_at, finance_budget_category.updated_at FROM finance_budget_category WHERE finance_budget_category.budget_id = :budget_id_1 AND finance_budget_category.period_month = :period_month_1",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "budget_lines_for_period"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget_category.id, finance_budget_category.owner_user_id, finance_budget_category.budget_id, finance_budget_category.category_id, finance_budget_category.payee_key, finance_budget_category.payee_label, finance_budget_category.period_month, finance_budget_category.allocated_amount, finance_budget_category.goal_amount, finance_budget_category.carryover_amount, finance_budget_category.rollover_enabled, finance_budget_category.currency, finance_budget_category.created_at, finance_budget_category.updated_at FROM finance_budget_category WHERE finance_budget_category.budget_id = :budget_id_1 AND finance_budget_category.period_month = :period_month_1 AND finance_budget_category.category_id = :category_id_1",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "budget_line_for_target"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget_category.id, finance_budget_category.owner_user_id, finance_budget_category.budget_id, finance_budget_category.category_id, finance_budget_category.payee_key, finance_budget_category.payee_label, finance_budget_category.period_month, finance_budget_category.allocated_amount, finance_budget_category.goal_amount, finance_budget_category.carryover_amount, finance_budget_category.rollover_enabled, finance_budget_category.currency, finance_budget_category.created_at, finance_budget_category.updated_at FROM finance_budget_category WHERE finance_budget_category.id = :id_1",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "budget_line_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget_category.id, finance_budget_category.owner_user_id, finance_budget_category.budget_id, finance_budget_category.category_id, finance_budget_category.payee_key, finance_budget_category.payee_label, finance_budget_category.period_month, finance_budget_category.allocated_amount, finance_budget_category.goal_amount, finance_budget_category.carryover_amount, finance_budget_category.rollover_enabled, finance_budget_category.currency, finance_budget_category.created_at, finance_budget_category.updated_at FROM finance_budget_category WHERE finance_budget_category.id = :id_1 AND finance_budget_category.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "budget_line_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_budget_category.period_month FROM finance_budget_category WHERE finance_budget_category.budget_id = :budget_id_1 AND finance_budget_category.period_month < :period_month_1 ORDER BY finance_budget_category.period_month DESC LIMIT :param_1",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "latest_period_with_lines"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category.id, finance_category.owner_user_id, finance_category.organization_id, finance_category.parent_id, finance_category.name, finance_category.slug, finance_category.classification, finance_category.plaid_pfc_primary, finance_category.plaid_pfc_detailed, finance_category.icon, finance_category.color, finance_category.is_system, finance_category.is_archived, finance_category.sort_order, finance_category.tax_line, finance_category.metadata, finance_category.created_at, finance_category.updated_at FROM finance_category",
+      "file": "tests/services/test_finance_import.py",
+      "function": "_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category.id, finance_category.owner_user_id, finance_category.organization_id, finance_category.parent_id, finance_category.name, finance_category.slug, finance_category.classification, finance_category.plaid_pfc_primary, finance_category.plaid_pfc_detailed, finance_category.icon, finance_category.color, finance_category.is_system, finance_category.is_archived, finance_category.sort_order, finance_category.tax_line, finance_category.metadata, finance_category.created_at, finance_category.updated_at FROM finance_category ORDER BY finance_category.name",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "all_categories"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category.id, finance_category.owner_user_id, finance_category.organization_id, finance_category.parent_id, finance_category.name, finance_category.slug, finance_category.classification, finance_category.plaid_pfc_primary, finance_category.plaid_pfc_detailed, finance_category.icon, finance_category.color, finance_category.is_system, finance_category.is_archived, finance_category.sort_order, finance_category.tax_line, finance_category.metadata, finance_category.created_at, finance_category.updated_at FROM finance_category WHERE finance_category.id IN (__[POSTCOMPILE_id_1])",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "category_names_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category.id, finance_category.owner_user_id, finance_category.organization_id, finance_category.parent_id, finance_category.name, finance_category.slug, finance_category.classification, finance_category.plaid_pfc_primary, finance_category.plaid_pfc_detailed, finance_category.icon, finance_category.color, finance_category.is_system, finance_category.is_archived, finance_category.sort_order, finance_category.tax_line, finance_category.metadata, finance_category.created_at, finance_category.updated_at FROM finance_category WHERE finance_category.slug = :slug_1 AND finance_category.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "category_by_slug_global"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category.name, sum(finance_transaction.amount) AS sum_1 FROM finance_transaction JOIN finance_category ON finance_transaction.category_id = finance_category.id WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS false GROUP BY finance_category.name",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "category_spend_totals"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category.name, sum(finance_transaction_split.amount) AS sum_1 FROM finance_transaction_split JOIN finance_transaction ON finance_transaction.id = finance_transaction_split.parent_transaction_id JOIN finance_category ON finance_transaction_split.category_id = finance_category.id WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS true GROUP BY finance_category.name",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "category_spend_totals"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category_alias.id, finance_category_alias.owner_user_id, finance_category_alias.category_id, finance_category_alias.alias_text, finance_category_alias.normalized_alias, finance_category_alias.source, finance_category_alias.created_at FROM finance_category_alias WHERE finance_category_alias.normalized_alias = :normalized_alias_1 AND finance_category_alias.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "alias_by_normalized_global"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_category_alias.normalized_alias, finance_category_alias.category_id FROM finance_category_alias WHERE finance_category_alias.normalized_alias IN (__[POSTCOMPILE_normalized_alias_1]) ORDER BY finance_category_alias.owner_user_id DESC",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "category_alias_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_connection.id, finance_connection.owner_user_id, finance_connection.organization_id, finance_connection.institution_id, finance_connection.provider, finance_connection.connection_type, finance_connection.provider_item_id, finance_connection.label, finance_connection.environment, finance_connection.access_token_encrypted, finance_connection.api_key_encrypted, finance_connection.api_secret_encrypted, finance_connection.api_passphrase_encrypted, finance_connection.refresh_token_encrypted, finance_connection.wallet_address, finance_connection.wallet_chain, finance_connection.capabilities, finance_connection.status, finance_connection.status_detail, finance_connection.last_error_code, finance_connection.needs_user_action, finance_connection.sync_cursor, finance_connection.days_requested, finance_connection.consent_expiration_at, finance_connection.last_successful_sync_at, finance_connection.last_sync_attempt_at, finance_connection.removed_at, finance_connection.deleted_at, finance_connection.metadata, finance_connection.created_at, finance_connection.updated_at FROM finance_connection WHERE finance_connection.deleted_at IS NULL AND finance_connection.provider = :provider_1 AND finance_connection.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/adapters/providers/queries.py",
+      "function": "connections_for_owner"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_connection.id, finance_connection.owner_user_id, finance_connection.organization_id, finance_connection.institution_id, finance_connection.provider, finance_connection.connection_type, finance_connection.provider_item_id, finance_connection.label, finance_connection.environment, finance_connection.access_token_encrypted, finance_connection.api_key_encrypted, finance_connection.api_secret_encrypted, finance_connection.api_passphrase_encrypted, finance_connection.refresh_token_encrypted, finance_connection.wallet_address, finance_connection.wallet_chain, finance_connection.capabilities, finance_connection.status, finance_connection.status_detail, finance_connection.last_error_code, finance_connection.needs_user_action, finance_connection.sync_cursor, finance_connection.days_requested, finance_connection.consent_expiration_at, finance_connection.last_successful_sync_at, finance_connection.last_sync_attempt_at, finance_connection.removed_at, finance_connection.deleted_at, finance_connection.metadata, finance_connection.created_at, finance_connection.updated_at FROM finance_connection WHERE finance_connection.id = :id_1 AND finance_connection.deleted_at IS NULL AND finance_connection.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/adapters/providers/queries.py",
+      "function": "connection_by_id_live"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_connection.id, finance_connection.owner_user_id, finance_connection.organization_id, finance_connection.institution_id, finance_connection.provider, finance_connection.connection_type, finance_connection.provider_item_id, finance_connection.label, finance_connection.environment, finance_connection.access_token_encrypted, finance_connection.api_key_encrypted, finance_connection.api_secret_encrypted, finance_connection.api_passphrase_encrypted, finance_connection.refresh_token_encrypted, finance_connection.wallet_address, finance_connection.wallet_chain, finance_connection.capabilities, finance_connection.status, finance_connection.status_detail, finance_connection.last_error_code, finance_connection.needs_user_action, finance_connection.sync_cursor, finance_connection.days_requested, finance_connection.consent_expiration_at, finance_connection.last_successful_sync_at, finance_connection.last_sync_attempt_at, finance_connection.removed_at, finance_connection.deleted_at, finance_connection.metadata, finance_connection.created_at, finance_connection.updated_at FROM finance_connection WHERE finance_connection.provider = :provider_1 AND finance_connection.provider_item_id = :provider_item_id_1",
+      "file": "app/services/finance/adapters/providers/queries.py",
+      "function": "connection_by_provider_item"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_connection.id, finance_connection.owner_user_id, finance_connection.organization_id, finance_connection.institution_id, finance_connection.provider, finance_connection.connection_type, finance_connection.provider_item_id, finance_connection.label, finance_connection.environment, finance_connection.access_token_encrypted, finance_connection.api_key_encrypted, finance_connection.api_secret_encrypted, finance_connection.api_passphrase_encrypted, finance_connection.refresh_token_encrypted, finance_connection.wallet_address, finance_connection.wallet_chain, finance_connection.capabilities, finance_connection.status, finance_connection.status_detail, finance_connection.last_error_code, finance_connection.needs_user_action, finance_connection.sync_cursor, finance_connection.days_requested, finance_connection.consent_expiration_at, finance_connection.last_successful_sync_at, finance_connection.last_sync_attempt_at, finance_connection.removed_at, finance_connection.deleted_at, finance_connection.metadata, finance_connection.created_at, finance_connection.updated_at FROM finance_connection WHERE finance_connection.provider = :provider_1 AND finance_connection.provider_item_id = :provider_item_id_1 AND finance_connection.deleted_at IS NULL",
+      "file": "app/services/finance/adapters/providers/queries.py",
+      "function": "connection_by_provider_item"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_currency.id, finance_currency.code, finance_currency.name, finance_currency.symbol, finance_currency.decimals, finance_currency.kind, finance_currency.is_active, finance_currency.created_at, finance_currency.updated_at FROM finance_currency WHERE finance_currency.code = :code_1",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "currency_by_code"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_currency.id, finance_currency.code, finance_currency.name, finance_currency.symbol, finance_currency.decimals, finance_currency.kind, finance_currency.is_active, finance_currency.created_at, finance_currency.updated_at FROM finance_currency WHERE finance_currency.code = :code_1",
+      "file": "app/services/finance/seeds/seed.py",
+      "function": "seed_finance_tables"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_holding.id, finance_holding.owner_user_id, finance_holding.organization_id, finance_holding.account_id, finance_holding.security_id, finance_holding.as_of_date, finance_holding.quantity_e8, finance_holding.cost_basis, finance_holding.average_cost, finance_holding.price, finance_holding.price_scale, finance_holding.institution_value, finance_holding.vested_quantity_e8, finance_holding.currency, finance_holding.source, finance_holding.deleted_at, finance_holding.metadata, finance_holding.created_at, finance_holding.updated_at FROM finance_holding JOIN finance_account ON finance_account.id = finance_holding.account_id WHERE finance_holding.deleted_at IS NULL AND finance_account.deleted_at IS NULL AND finance_holding.account_id = :account_id_1 ORDER BY finance_holding.as_of_date",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "live_holdings_joined"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_holding.id, finance_holding.owner_user_id, finance_holding.organization_id, finance_holding.account_id, finance_holding.security_id, finance_holding.as_of_date, finance_holding.quantity_e8, finance_holding.cost_basis, finance_holding.average_cost, finance_holding.price, finance_holding.price_scale, finance_holding.institution_value, finance_holding.vested_quantity_e8, finance_holding.currency, finance_holding.source, finance_holding.deleted_at, finance_holding.metadata, finance_holding.created_at, finance_holding.updated_at FROM finance_holding JOIN finance_account ON finance_account.id = finance_holding.account_id WHERE finance_holding.deleted_at IS NULL AND finance_account.deleted_at IS NULL AND finance_holding.owner_user_id = :owner_user_id_1 AND finance_holding.account_id = :account_id_1 ORDER BY finance_holding.as_of_date",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "live_holdings_joined"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_holding.id, finance_holding.owner_user_id, finance_holding.organization_id, finance_holding.account_id, finance_holding.security_id, finance_holding.as_of_date, finance_holding.quantity_e8, finance_holding.cost_basis, finance_holding.average_cost, finance_holding.price, finance_holding.price_scale, finance_holding.institution_value, finance_holding.vested_quantity_e8, finance_holding.currency, finance_holding.source, finance_holding.deleted_at, finance_holding.metadata, finance_holding.created_at, finance_holding.updated_at FROM finance_holding JOIN finance_account ON finance_account.id = finance_holding.account_id WHERE finance_holding.deleted_at IS NULL AND finance_account.deleted_at IS NULL AND finance_holding.owner_user_id = :owner_user_id_1 ORDER BY finance_holding.as_of_date",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "live_holdings_joined"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_holding.id, finance_holding.owner_user_id, finance_holding.organization_id, finance_holding.account_id, finance_holding.security_id, finance_holding.as_of_date, finance_holding.quantity_e8, finance_holding.cost_basis, finance_holding.average_cost, finance_holding.price, finance_holding.price_scale, finance_holding.institution_value, finance_holding.vested_quantity_e8, finance_holding.currency, finance_holding.source, finance_holding.deleted_at, finance_holding.metadata, finance_holding.created_at, finance_holding.updated_at FROM finance_holding WHERE finance_holding.account_id = :account_id_1 AND finance_holding.security_id = :security_id_1 AND finance_holding.as_of_date = :as_of_date_1",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "holding_by_key"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_holding.security_id, finance_holding.account_id, finance_holding.quantity_e8 FROM finance_holding WHERE finance_holding.account_id IN (__[POSTCOMPILE_account_id_1])",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "holding_quantities"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_icon.id, finance_icon.domain, finance_icon.icon_b64, finance_icon.fetched_at FROM finance_icon WHERE finance_icon.domain IN (__[POSTCOMPILE_domain_1])",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "icons_by_domains"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_import_batch.id, finance_import_batch.owner_user_id, finance_import_batch.organization_id, finance_import_batch.connection_id, finance_import_batch.account_id, finance_import_batch.import_profile_id, finance_import_batch.source_type, finance_import_batch.file_name, finance_import_batch.file_sha256, finance_import_batch.sync_cursor_before, finance_import_batch.sync_cursor_after, finance_import_batch.rows_total, finance_import_batch.rows_inserted, finance_import_batch.rows_updated, finance_import_batch.rows_duplicate, finance_import_batch.rows_error, finance_import_batch.status, finance_import_batch.error, finance_import_batch.started_at, finance_import_batch.finished_at, finance_import_batch.created_at, finance_import_batch.updated_at FROM finance_import_batch",
+      "file": "tests/services/test_finance_import.py",
+      "function": "_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_import_batch.id, finance_import_batch.owner_user_id, finance_import_batch.organization_id, finance_import_batch.connection_id, finance_import_batch.account_id, finance_import_batch.import_profile_id, finance_import_batch.source_type, finance_import_batch.file_name, finance_import_batch.file_sha256, finance_import_batch.sync_cursor_before, finance_import_batch.sync_cursor_after, finance_import_batch.rows_total, finance_import_batch.rows_inserted, finance_import_batch.rows_updated, finance_import_batch.rows_duplicate, finance_import_batch.rows_error, finance_import_batch.status, finance_import_batch.error, finance_import_batch.started_at, finance_import_batch.finished_at, finance_import_batch.created_at, finance_import_batch.updated_at FROM finance_import_batch WHERE finance_import_batch.owner_user_id = :owner_user_id_1 AND finance_import_batch.file_sha256 = :file_sha256_1",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "prior_batch"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_import_batch.id, finance_import_batch.owner_user_id, finance_import_batch.organization_id, finance_import_batch.connection_id, finance_import_batch.account_id, finance_import_batch.import_profile_id, finance_import_batch.source_type, finance_import_batch.file_name, finance_import_batch.file_sha256, finance_import_batch.sync_cursor_before, finance_import_batch.sync_cursor_after, finance_import_batch.rows_total, finance_import_batch.rows_inserted, finance_import_batch.rows_updated, finance_import_batch.rows_duplicate, finance_import_batch.rows_error, finance_import_batch.status, finance_import_batch.error, finance_import_batch.started_at, finance_import_batch.finished_at, finance_import_batch.created_at, finance_import_batch.updated_at FROM finance_import_batch WHERE finance_import_batch.source_type = :source_type_1",
+      "file": "tests/services/test_finance_plaid.py",
+      "function": "_batches"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_import_profile.id, finance_import_profile.owner_user_id, finance_import_profile.organization_id, finance_import_profile.institution_id, finance_import_profile.name, finance_import_profile.source_format, finance_import_profile.header_signature, finance_import_profile.column_mapping, finance_import_profile.date_format, finance_import_profile.amount_sign_convention, finance_import_profile.decimal_separator, finance_import_profile.thousands_separator, finance_import_profile.currency, finance_import_profile.is_system, finance_import_profile.deleted_at, finance_import_profile.created_at, finance_import_profile.updated_at FROM finance_import_profile",
+      "file": "tests/services/test_finance_reference_seed.py",
+      "function": "test_seeding_twice_changes_nothing"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_import_profile.id, finance_import_profile.owner_user_id, finance_import_profile.organization_id, finance_import_profile.institution_id, finance_import_profile.name, finance_import_profile.source_format, finance_import_profile.header_signature, finance_import_profile.column_mapping, finance_import_profile.date_format, finance_import_profile.amount_sign_convention, finance_import_profile.decimal_separator, finance_import_profile.thousands_separator, finance_import_profile.currency, finance_import_profile.is_system, finance_import_profile.deleted_at, finance_import_profile.created_at, finance_import_profile.updated_at FROM finance_import_profile WHERE finance_import_profile.owner_user_id IS NULL AND finance_import_profile.name = :name_1",
+      "file": "app/services/finance/seeds/seed.py",
+      "function": "seed_finance_tables"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_import_profile.id, finance_import_profile.owner_user_id, finance_import_profile.organization_id, finance_import_profile.institution_id, finance_import_profile.name, finance_import_profile.source_format, finance_import_profile.header_signature, finance_import_profile.column_mapping, finance_import_profile.date_format, finance_import_profile.amount_sign_convention, finance_import_profile.decimal_separator, finance_import_profile.thousands_separator, finance_import_profile.currency, finance_import_profile.is_system, finance_import_profile.deleted_at, finance_import_profile.created_at, finance_import_profile.updated_at FROM finance_import_profile WHERE finance_import_profile.source_format = :source_format_1 AND finance_import_profile.deleted_at IS NULL",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "csv_profiles"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_insight.id FROM finance_insight WHERE finance_insight.owner_user_id = :owner_user_id_1 AND finance_insight.dedup_key = :dedup_key_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "insight_exists"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_insight.id, finance_insight.owner_user_id, finance_insight.organization_id, finance_insight.insight_type, finance_insight.severity, finance_insight.title, finance_insight.body, finance_insight.related_account_id, finance_insight.related_transaction_id, finance_insight.related_category_id, finance_insight.related_stream_id, finance_insight.detected_amount, finance_insight.currency, finance_insight.dedup_key, finance_insight.period_start, finance_insight.period_end, finance_insight.data, finance_insight.status, finance_insight.is_read, finance_insight.dismissed_at, finance_insight.metadata, finance_insight.created_at, finance_insight.updated_at FROM finance_insight WHERE finance_insight.insight_type = :insight_type_1",
+      "file": "tests/services/test_finance_insights.py",
+      "function": "_insights_of"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_insight.id, finance_insight.owner_user_id, finance_insight.organization_id, finance_insight.insight_type, finance_insight.severity, finance_insight.title, finance_insight.body, finance_insight.related_account_id, finance_insight.related_transaction_id, finance_insight.related_category_id, finance_insight.related_stream_id, finance_insight.detected_amount, finance_insight.currency, finance_insight.dedup_key, finance_insight.period_start, finance_insight.period_end, finance_insight.data, finance_insight.status, finance_insight.is_read, finance_insight.dismissed_at, finance_insight.metadata, finance_insight.created_at, finance_insight.updated_at FROM finance_insight WHERE finance_insight.insight_type = :insight_type_1",
+      "file": "tests/services/test_finance_insights.py",
+      "function": "test_dismiss_survives_rerun"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_insight.id, finance_insight.owner_user_id, finance_insight.organization_id, finance_insight.insight_type, finance_insight.severity, finance_insight.title, finance_insight.body, finance_insight.related_account_id, finance_insight.related_transaction_id, finance_insight.related_category_id, finance_insight.related_stream_id, finance_insight.detected_amount, finance_insight.currency, finance_insight.dedup_key, finance_insight.period_start, finance_insight.period_end, finance_insight.data, finance_insight.status, finance_insight.is_read, finance_insight.dismissed_at, finance_insight.metadata, finance_insight.created_at, finance_insight.updated_at FROM finance_insight WHERE finance_insight.owner_user_id = :owner_user_id_1 AND finance_insight.insight_type = :insight_type_1 AND finance_insight.related_stream_id = :related_stream_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "insight_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_insight.id, finance_insight.owner_user_id, finance_insight.organization_id, finance_insight.insight_type, finance_insight.severity, finance_insight.title, finance_insight.body, finance_insight.related_account_id, finance_insight.related_transaction_id, finance_insight.related_category_id, finance_insight.related_stream_id, finance_insight.detected_amount, finance_insight.currency, finance_insight.dedup_key, finance_insight.period_start, finance_insight.period_end, finance_insight.data, finance_insight.status, finance_insight.is_read, finance_insight.dismissed_at, finance_insight.metadata, finance_insight.created_at, finance_insight.updated_at FROM finance_insight WHERE finance_insight.owner_user_id = :owner_user_id_1 AND finance_insight.insight_type = :insight_type_1 AND finance_insight.related_stream_id IS NOT NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "insight_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_insight.id, finance_insight.owner_user_id, finance_insight.organization_id, finance_insight.insight_type, finance_insight.severity, finance_insight.title, finance_insight.body, finance_insight.related_account_id, finance_insight.related_transaction_id, finance_insight.related_category_id, finance_insight.related_stream_id, finance_insight.detected_amount, finance_insight.currency, finance_insight.dedup_key, finance_insight.period_start, finance_insight.period_end, finance_insight.data, finance_insight.status, finance_insight.is_read, finance_insight.dismissed_at, finance_insight.metadata, finance_insight.created_at, finance_insight.updated_at FROM finance_insight WHERE finance_insight.related_stream_id IN (__[POSTCOMPILE_related_stream_id_1])",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "insight_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_liability_detail.id, finance_liability_detail.owner_user_id, finance_liability_detail.account_id, finance_liability_detail.liability_type, finance_liability_detail.last_statement_balance, finance_liability_detail.last_statement_issue_date, finance_liability_detail.last_payment_amount, finance_liability_detail.last_payment_date, finance_liability_detail.minimum_payment_amount, finance_liability_detail.next_payment_due_date, finance_liability_detail.origination_date, finance_liability_detail.origination_principal, finance_liability_detail.outstanding_balance, finance_liability_detail.interest_rate_bps, finance_liability_detail.ytd_interest_paid, finance_liability_detail.ytd_principal_paid, finance_liability_detail.loan_term_months, finance_liability_detail.is_overdue, finance_liability_detail.secured_by_account_id, finance_liability_detail.lien_position, finance_liability_detail.aprs, finance_liability_detail.currency, finance_liability_detail.raw, finance_liability_detail.created_at, finance_liability_detail.updated_at FROM finance_liability_detail",
+      "file": "tests/services/test_finance_plaid.py",
+      "function": "_liability_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_liability_detail.id, finance_liability_detail.owner_user_id, finance_liability_detail.account_id, finance_liability_detail.liability_type, finance_liability_detail.last_statement_balance, finance_liability_detail.last_statement_issue_date, finance_liability_detail.last_payment_amount, finance_liability_detail.last_payment_date, finance_liability_detail.minimum_payment_amount, finance_liability_detail.next_payment_due_date, finance_liability_detail.origination_date, finance_liability_detail.origination_principal, finance_liability_detail.outstanding_balance, finance_liability_detail.interest_rate_bps, finance_liability_detail.ytd_interest_paid, finance_liability_detail.ytd_principal_paid, finance_liability_detail.loan_term_months, finance_liability_detail.is_overdue, finance_liability_detail.secured_by_account_id, finance_liability_detail.lien_position, finance_liability_detail.aprs, finance_liability_detail.currency, finance_liability_detail.raw, finance_liability_detail.created_at, finance_liability_detail.updated_at FROM finance_liability_detail WHERE finance_liability_detail.account_id IN (__[POSTCOMPILE_account_id_1])",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "liability_details_by_account"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_merchant.id, finance_merchant.owner_user_id, finance_merchant.organization_id, finance_merchant.name, finance_merchant.normalized_name, finance_merchant.source, finance_merchant.provider_merchant_id, finance_merchant.logo_url, finance_merchant.website_url, finance_merchant.default_category_id, finance_merchant.service_type, finance_merchant.deleted_at, finance_merchant.created_at, finance_merchant.updated_at FROM finance_merchant WHERE finance_merchant.id IN (__[POSTCOMPILE_id_1])",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "merchant_names_by_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_merchant.id, finance_merchant.owner_user_id, finance_merchant.organization_id, finance_merchant.name, finance_merchant.normalized_name, finance_merchant.source, finance_merchant.provider_merchant_id, finance_merchant.logo_url, finance_merchant.website_url, finance_merchant.default_category_id, finance_merchant.service_type, finance_merchant.deleted_at, finance_merchant.created_at, finance_merchant.updated_at FROM finance_merchant WHERE finance_merchant.normalized_name = :normalized_name_1 AND finance_merchant.deleted_at IS NULL AND finance_merchant.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "merchant_by_normalized"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_merchant.id, finance_merchant.owner_user_id, finance_merchant.organization_id, finance_merchant.name, finance_merchant.normalized_name, finance_merchant.source, finance_merchant.provider_merchant_id, finance_merchant.logo_url, finance_merchant.website_url, finance_merchant.default_category_id, finance_merchant.service_type, finance_merchant.deleted_at, finance_merchant.created_at, finance_merchant.updated_at FROM finance_merchant WHERE finance_merchant.normalized_name = :normalized_name_1 AND finance_merchant.deleted_at IS NULL AND finance_merchant.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "merchant_by_normalized"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_net_worth_snapshot.id, finance_net_worth_snapshot.owner_user_id, finance_net_worth_snapshot.organization_id, finance_net_worth_snapshot.as_of_date, finance_net_worth_snapshot.total_assets_amount, finance_net_worth_snapshot.total_liabilities_amount, finance_net_worth_snapshot.net_worth_amount, finance_net_worth_snapshot.cash_amount, finance_net_worth_snapshot.investments_amount, finance_net_worth_snapshot.other_assets_amount, finance_net_worth_snapshot.currency, finance_net_worth_snapshot.breakdown, finance_net_worth_snapshot.is_estimated FROM finance_net_worth_snapshot",
+      "file": "tests/services/test_finance_demo_seed.py",
+      "function": "test_clear_repairs_the_net_worth_history"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_net_worth_snapshot.id, finance_net_worth_snapshot.owner_user_id, finance_net_worth_snapshot.organization_id, finance_net_worth_snapshot.as_of_date, finance_net_worth_snapshot.total_assets_amount, finance_net_worth_snapshot.total_liabilities_amount, finance_net_worth_snapshot.net_worth_amount, finance_net_worth_snapshot.cash_amount, finance_net_worth_snapshot.investments_amount, finance_net_worth_snapshot.other_assets_amount, finance_net_worth_snapshot.currency, finance_net_worth_snapshot.breakdown, finance_net_worth_snapshot.is_estimated FROM finance_net_worth_snapshot WHERE finance_net_worth_snapshot.currency = :currency_1 AND finance_net_worth_snapshot.as_of_date >= :as_of_date_1 AND finance_net_worth_snapshot.as_of_date <= :as_of_date_2 AND finance_net_worth_snapshot.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "net_worth_snapshots_between"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_pending_change.id, finance_pending_change.owner_user_id, finance_pending_change.change_type, finance_pending_change.payload, finance_pending_change.proposed_by_agent, finance_pending_change.conversation_id, finance_pending_change.batch_id, finance_pending_change.status, finance_pending_change.result, finance_pending_change.created_at, finance_pending_change.updated_at, finance_pending_change.resolved_at FROM finance_pending_change WHERE finance_pending_change.batch_id = :batch_id_1 AND finance_pending_change.owner_user_id = :owner_user_id_1 ORDER BY finance_pending_change.id",
+      "file": "app/services/finance/domains/writes/queries.py",
+      "function": "batch_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_pending_change.id, finance_pending_change.owner_user_id, finance_pending_change.change_type, finance_pending_change.payload, finance_pending_change.proposed_by_agent, finance_pending_change.conversation_id, finance_pending_change.batch_id, finance_pending_change.status, finance_pending_change.result, finance_pending_change.created_at, finance_pending_change.updated_at, finance_pending_change.resolved_at FROM finance_pending_change WHERE finance_pending_change.id = :id_1",
+      "file": "app/services/finance/domains/writes/queries.py",
+      "function": "get_change"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_pending_change.id, finance_pending_change.owner_user_id, finance_pending_change.change_type, finance_pending_change.payload, finance_pending_change.proposed_by_agent, finance_pending_change.conversation_id, finance_pending_change.batch_id, finance_pending_change.status, finance_pending_change.result, finance_pending_change.created_at, finance_pending_change.updated_at, finance_pending_change.resolved_at FROM finance_pending_change WHERE finance_pending_change.status = :status_1 AND finance_pending_change.owner_user_id = :owner_user_id_1 ORDER BY finance_pending_change.id DESC",
+      "file": "app/services/finance/domains/writes/queries.py",
+      "function": "list_changes"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_pending_change.id, finance_pending_change.owner_user_id, finance_pending_change.change_type, finance_pending_change.payload, finance_pending_change.proposed_by_agent, finance_pending_change.conversation_id, finance_pending_change.batch_id, finance_pending_change.status, finance_pending_change.result, finance_pending_change.created_at, finance_pending_change.updated_at, finance_pending_change.resolved_at FROM finance_pending_change WHERE finance_pending_change.status = :status_1 ORDER BY finance_pending_change.id DESC",
+      "file": "app/services/finance/domains/writes/queries.py",
+      "function": "list_changes"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id FROM finance_recurring_stream WHERE (finance_recurring_stream.is_user_confirmed IS true OR finance_recurring_stream.source = :source_1) AND finance_recurring_stream.deleted_at IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "confirmed_stream_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.direction = :direction_1 AND finance_recurring_stream.is_subscription IS true AND finance_recurring_stream.is_muted IS false AND (finance_recurring_stream.paused_until IS NULL OR finance_recurring_stream.paused_until <= :paused_until_1)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_ids_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_category.name FROM finance_recurring_stream JOIN finance_category ON finance_category.id = finance_recurring_stream.category_id WHERE finance_recurring_stream.id IN (__[POSTCOMPILE_id_1])",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "stream_stored_category_names"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream",
+      "file": "tests/services/test_finance_stream_regimes.py",
+      "function": "_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.account_id IN (__[POSTCOMPILE_account_id_1])",
+      "file": "app/services/finance/seeds/demo_seed.py",
+      "function": "_count_derived"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.deleted_at IS NULL",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "all_live_streams"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.deleted_at IS NULL",
+      "file": "tests/services/_finance_factories.py",
+      "function": "live_streams"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.name = :name_1",
+      "file": "tests/services/_finance_factories.py",
+      "function": "declare_bill"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.status != :status_1 AND finance_recurring_stream.owner_user_id = :owner_user_id_1 ORDER BY finance_recurring_stream.next_expected_date",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "active_streams"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.status != :status_1 ORDER BY finance_recurring_stream.next_expected_date",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "active_streams"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.id = :id_1",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "stream_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.id = :id_1 AND finance_recurring_stream.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "stream_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.id IN (__[POSTCOMPILE_id_1])",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "streams_by_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.name = :name_1",
+      "file": "tests/services/test_finance_query_batching.py",
+      "function": "_confirmed_uncategorized_stream"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND (finance_recurring_stream.is_user_confirmed IS true OR finance_recurring_stream.source = :source_1)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.account_id = :account_id_1 AND finance_recurring_stream.direction = :direction_1 AND finance_recurring_stream.normalized_payee = :normalized_payee_1 AND finance_recurring_stream.provider_stream_id IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "local_stream_by_key"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.account_id = :account_id_1 AND finance_recurring_stream.direction = :direction_1 AND finance_recurring_stream.provider_stream_id IS NULL AND finance_recurring_stream.deleted_at IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "sibling_streams_raw"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.account_id = :account_id_1 AND finance_recurring_stream.direction = :direction_1 AND finance_recurring_stream.source = :source_1 AND finance_recurring_stream.is_user_confirmed IS false AND finance_recurring_stream.provider_stream_id IS NULL AND (finance_recurring_stream.is_muted IS true OR finance_recurring_stream.deleted_at IS NOT NULL)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.deleted_at IS NULL",
+      "file": "app/services/finance/seeds/demo_seed.py",
+      "function": "seed_demo"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.direction = :direction_1 AND finance_recurring_stream.is_subscription IS false AND finance_recurring_stream.source = :source_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "promotable_streams"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.status = :status_1 AND finance_recurring_stream.is_active IS true AND finance_recurring_stream.is_muted IS false AND (finance_recurring_stream.paused_until IS NULL OR finance_recurring_stream.paused_until <= :paused_until_1) AND finance_recurring_stream.next_expected_date IS NOT NULL AND (finance_recurring_stream.account_id IS NULL OR finance_recurring_stream.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_2))",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.status = :status_1 AND finance_recurring_stream.is_active IS true AND finance_recurring_stream.is_muted IS false AND (finance_recurring_stream.paused_until IS NULL OR finance_recurring_stream.paused_until <= :paused_until_1) AND finance_recurring_stream.next_expected_date IS NOT NULL AND (finance_recurring_stream.account_id IS NULL OR finance_recurring_stream.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id IS NULL))",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.deleted_at IS NULL AND finance_recurring_stream.status = :status_1 AND finance_recurring_stream.is_muted IS false AND (finance_recurring_stream.paused_until IS NULL OR finance_recurring_stream.paused_until <= :paused_until_1) AND finance_recurring_stream.amount_is_variable IS false AND finance_recurring_stream.direction = :direction_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.source = :source_1 AND finance_recurring_stream.is_user_confirmed IS false AND finance_recurring_stream.provider_stream_id IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_recurring_stream.id, finance_recurring_stream.owner_user_id, finance_recurring_stream.subject_id, finance_recurring_stream.organization_id, finance_recurring_stream.account_id, finance_recurring_stream.merchant_id, finance_recurring_stream.category_id, finance_recurring_stream.connection_id, finance_recurring_stream.provider_stream_id, finance_recurring_stream.name, finance_recurring_stream.normalized_payee, finance_recurring_stream.direction, finance_recurring_stream.frequency, finance_recurring_stream.average_amount, finance_recurring_stream.last_amount, finance_recurring_stream.expected_amount, finance_recurring_stream.amount_is_variable, finance_recurring_stream.amount_tolerance_bps, finance_recurring_stream.currency, finance_recurring_stream.first_date, finance_recurring_stream.last_date, finance_recurring_stream.next_expected_date, finance_recurring_stream.occurrence_count, finance_recurring_stream.status, finance_recurring_stream.confidence, finance_recurring_stream.is_subscription, finance_recurring_stream.is_active, finance_recurring_stream.is_user_confirmed, finance_recurring_stream.is_muted, finance_recurring_stream.paused_until, finance_recurring_stream.service_type, finance_recurring_stream.source, finance_recurring_stream.deleted_at, finance_recurring_stream.metadata, finance_recurring_stream.created_at, finance_recurring_stream.updated_at FROM finance_recurring_stream WHERE finance_recurring_stream.owner_user_id = :owner_user_id_1 AND finance_recurring_stream.source = :source_1 AND finance_recurring_stream.is_user_confirmed IS false AND finance_recurring_stream.provider_stream_id IS NULL AND (finance_recurring_stream.id NOT IN (__[POSTCOMPILE_id_1]))",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_security.id, finance_security.provider, finance_security.provider_security_id, finance_security.figi, finance_security.cusip, finance_security.isin, finance_security.sedol, finance_security.ticker, finance_security.name, finance_security.security_type, finance_security.exchange_mic, finance_security.exchange_operating_mic, finance_security.country_code, finance_security.currency, finance_security.is_cash_equivalent, finance_security.is_crypto, finance_security.coingecko_id, finance_security.onchain_contract, finance_security.onchain_chain, finance_security.close_price, finance_security.price_scale, finance_security.close_price_as_of, finance_security.metadata, finance_security.created_at, finance_security.updated_at FROM finance_security WHERE finance_security.cusip = :cusip_1",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "security_by_identifier"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_security.id, finance_security.provider, finance_security.provider_security_id, finance_security.figi, finance_security.cusip, finance_security.isin, finance_security.sedol, finance_security.ticker, finance_security.name, finance_security.security_type, finance_security.exchange_mic, finance_security.exchange_operating_mic, finance_security.country_code, finance_security.currency, finance_security.is_cash_equivalent, finance_security.is_crypto, finance_security.coingecko_id, finance_security.onchain_contract, finance_security.onchain_chain, finance_security.close_price, finance_security.price_scale, finance_security.close_price_as_of, finance_security.metadata, finance_security.created_at, finance_security.updated_at FROM finance_security WHERE finance_security.figi = :figi_1",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "security_by_identifier"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_security.id, finance_security.provider, finance_security.provider_security_id, finance_security.figi, finance_security.cusip, finance_security.isin, finance_security.sedol, finance_security.ticker, finance_security.name, finance_security.security_type, finance_security.exchange_mic, finance_security.exchange_operating_mic, finance_security.country_code, finance_security.currency, finance_security.is_cash_equivalent, finance_security.is_crypto, finance_security.coingecko_id, finance_security.onchain_contract, finance_security.onchain_chain, finance_security.close_price, finance_security.price_scale, finance_security.close_price_as_of, finance_security.metadata, finance_security.created_at, finance_security.updated_at FROM finance_security WHERE finance_security.id IN (__[POSTCOMPILE_id_1])",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "securities_by_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_security.id, finance_security.provider, finance_security.provider_security_id, finance_security.figi, finance_security.cusip, finance_security.isin, finance_security.sedol, finance_security.ticker, finance_security.name, finance_security.security_type, finance_security.exchange_mic, finance_security.exchange_operating_mic, finance_security.country_code, finance_security.currency, finance_security.is_cash_equivalent, finance_security.is_crypto, finance_security.coingecko_id, finance_security.onchain_contract, finance_security.onchain_chain, finance_security.close_price, finance_security.price_scale, finance_security.close_price_as_of, finance_security.metadata, finance_security.created_at, finance_security.updated_at FROM finance_security WHERE finance_security.provider = :provider_1 AND finance_security.provider_security_id = :provider_security_id_1",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "security_by_provider_ref"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_security.id, finance_security.provider, finance_security.provider_security_id, finance_security.figi, finance_security.cusip, finance_security.isin, finance_security.sedol, finance_security.ticker, finance_security.name, finance_security.security_type, finance_security.exchange_mic, finance_security.exchange_operating_mic, finance_security.country_code, finance_security.currency, finance_security.is_cash_equivalent, finance_security.is_crypto, finance_security.coingecko_id, finance_security.onchain_contract, finance_security.onchain_chain, finance_security.close_price, finance_security.price_scale, finance_security.close_price_as_of, finance_security.metadata, finance_security.created_at, finance_security.updated_at FROM finance_security WHERE finance_security.ticker = :ticker_1",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "security_by_ticker"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_security.ticker FROM finance_security WHERE finance_security.name = :name_1 ORDER BY finance_security.id",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "security_ticker_by_name"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_security_price.id, finance_security_price.security_id, finance_security_price.price_date, finance_security_price.close_price, finance_security_price.price_scale, finance_security_price.currency, finance_security_price.source FROM finance_security_price WHERE finance_security_price.security_id = :security_id_1 AND finance_security_price.price_date = :price_date_1 AND finance_security_price.source = :source_1",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "security_price_by_key"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_tag.id, finance_tag.owner_user_id, finance_tag.organization_id, finance_tag.name, finance_tag.normalized_name, finance_tag.color, finance_tag.deleted_at, finance_tag.created_at, finance_tag.updated_at FROM finance_tag WHERE finance_tag.owner_user_id = :owner_user_id_1 AND finance_tag.normalized_name = :normalized_name_1 AND finance_tag.deleted_at IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "tag_by_normalized_name"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_trade.account_id, finance_trade.trade_date, finance_trade.security_id, finance_trade.quantity_e8, finance_trade.price, finance_trade.price_scale FROM finance_trade WHERE finance_trade.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_trade.security_id IS NOT NULL ORDER BY finance_trade.account_id, finance_trade.trade_date",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "priced_trade_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_trade.id, finance_trade.owner_user_id, finance_trade.organization_id, finance_trade.account_id, finance_trade.security_id, finance_trade.transaction_id, finance_trade.connection_id, finance_trade.import_batch_id, finance_trade.source, finance_trade.external_id, finance_trade.external_id_source, finance_trade.import_hash, finance_trade.type, finance_trade.subtype, finance_trade.quantity_e8, finance_trade.price, finance_trade.price_scale, finance_trade.amount, finance_trade.raw_amount, finance_trade.fees, finance_trade.currency, finance_trade.trade_date, finance_trade.settle_date, finance_trade.datetime, finance_trade.name, finance_trade.pending, finance_trade.raw_payload, finance_trade.is_removed, finance_trade.deleted_at, finance_trade.metadata, finance_trade.created_at, finance_trade.updated_at FROM finance_trade WHERE finance_trade.account_id = :account_id_1 AND finance_trade.source = :source_1 AND finance_trade.external_id = :external_id_1 AND finance_trade.deleted_at IS NULL",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "trade_by_external_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_trade.id, finance_trade.owner_user_id, finance_trade.organization_id, finance_trade.account_id, finance_trade.security_id, finance_trade.transaction_id, finance_trade.connection_id, finance_trade.import_batch_id, finance_trade.source, finance_trade.external_id, finance_trade.external_id_source, finance_trade.import_hash, finance_trade.type, finance_trade.subtype, finance_trade.quantity_e8, finance_trade.price, finance_trade.price_scale, finance_trade.amount, finance_trade.raw_amount, finance_trade.fees, finance_trade.currency, finance_trade.trade_date, finance_trade.settle_date, finance_trade.datetime, finance_trade.name, finance_trade.pending, finance_trade.raw_payload, finance_trade.is_removed, finance_trade.deleted_at, finance_trade.metadata, finance_trade.created_at, finance_trade.updated_at FROM finance_trade WHERE finance_trade.owner_user_id = :owner_user_id_1 AND finance_trade.deleted_at IS NULL AND finance_trade.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) ORDER BY finance_trade.trade_date DESC, finance_trade.id DESC LIMIT :param_1",
+      "file": "app/services/finance/domains/investments/queries.py",
+      "function": "trades_feed"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.account_id, coalesce(sum(finance_transaction.amount), :coalesce_2) AS coalesce_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) GROUP BY finance_transaction.account_id",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "transaction_totals_by_account"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.account_id, coalesce(sum(finance_transaction.amount), :coalesce_2) AS coalesce_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) GROUP BY finance_transaction.account_id",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "transaction_totals_by_account"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.account_id, finance_transaction.date, sum(finance_transaction.amount) AS sum_1 FROM finance_transaction WHERE finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 GROUP BY finance_transaction.account_id, finance_transaction.date ORDER BY finance_transaction.account_id, finance_transaction.date",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "daily_register_deltas"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.account_id, sum(finance_transaction.amount) AS sum_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date <= :date_2 AND finance_transaction.is_transfer IS false AND finance_transaction.owner_user_id = :owner_user_id_1 GROUP BY finance_transaction.account_id",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "outflow_by_account_in_window"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.account_id, sum(finance_transaction.amount) AS sum_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date <= :date_2 AND finance_transaction.is_transfer IS false GROUP BY finance_transaction.account_id",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "outflow_by_account_in_window"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, count(*) AS hits FROM finance_transaction WHERE finance_transaction.recurring_stream_id = :recurring_stream_id_1 AND finance_transaction.category_id IS NOT NULL AND finance_transaction.deleted_at IS NULL GROUP BY finance_transaction.category_id ORDER BY count(*) DESC LIMIT :param_1",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "stream_member_category_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, finance_transaction.date, finance_transaction.amount FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.is_transfer IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.recurring_stream_id IS NULL AND (finance_transaction.external_id_source IS NULL OR finance_transaction.external_id_source != :external_id_source_1) AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "category_dated_amounts_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, finance_transaction.date, finance_transaction.amount FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.is_transfer IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.recurring_stream_id IS NULL AND (finance_transaction.external_id_source IS NULL OR finance_transaction.external_id_source != :external_id_source_1) AND finance_transaction.owner_user_id = :owner_user_id_1 AND (finance_transaction.category_id IS NULL OR (finance_transaction.category_id NOT IN (__[POSTCOMPILE_category_id_1])))",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "category_dated_amounts_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, finance_transaction.date, finance_transaction.amount FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.is_transfer IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.recurring_stream_id IS NULL AND (finance_transaction.external_id_source IS NULL OR finance_transaction.external_id_source != :external_id_source_1) AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1])",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "category_dated_amounts_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, finance_transaction.merchant_name, finance_transaction.original_description, finance_transaction.name, finance_transaction.amount, finance_transaction.recurring_stream_id FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS false",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "outflow_tuples"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, finance_transaction.merchant_name, finance_transaction.original_description, finance_transaction.name, finance_transaction.amount, finance_transaction.recurring_stream_id FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.is_split IS false",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "outflow_tuples"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, finance_transaction.merchant_name, finance_transaction.original_description, finance_transaction.name, finance_transaction.amount, finance_transaction.recurring_stream_id FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS false",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "outflow_tuples"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, min(finance_transaction.date) AS min_1 FROM finance_transaction WHERE finance_transaction.category_id IN (__[POSTCOMPILE_category_id_1]) AND finance_transaction.deleted_at IS NULL AND finance_transaction.amount < :amount_1 AND finance_transaction.is_transfer IS false GROUP BY finance_transaction.category_id",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "category_first_spend"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.category_id, sum(finance_transaction.amount) AS sum_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS false AND finance_transaction.category_id IN (__[POSTCOMPILE_category_id_1]) GROUP BY finance_transaction.category_id",
+      "file": "app/services/finance/domains/planning/queries.py",
+      "function": "spend_by_category"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id FROM finance_transaction WHERE finance_transaction.account_id = :account_id_1 AND finance_transaction.deleted_at IS NULL AND coalesce(finance_transaction.external_id_source, :coalesce_1) != :coalesce_2 LIMIT :param_1",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "has_nonreconcile_register"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id FROM finance_transaction WHERE finance_transaction.recurring_stream_id = :recurring_stream_id_1 AND finance_transaction.id IN (__[POSTCOMPILE_id_1])",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "any_member_linked"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id FROM finance_transaction WHERE finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND finance_transaction.deleted_at IS NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "member_ids_of_streams"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction",
+      "file": "tests/services/test_finance_demo_seed.py",
+      "function": "_transactions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction",
+      "file": "tests/services/test_finance_import.py",
+      "function": "_count"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id = :account_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.import_hash = :import_hash_1",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "dedup_match"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id = :account_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.source = :source_1 AND finance_transaction.external_id = :external_id_1",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "dedup_match"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id = :account_id_1 AND finance_transaction.external_id_source = :external_id_source_1 AND finance_transaction.date = :date_1 AND finance_transaction.deleted_at IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "reconcile_adjustment_on"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1])",
+      "file": "app/services/finance/seeds/demo_seed.py",
+      "function": "_delete_demo_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.deleted_at IS NOT NULL",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "deleted_transactions_for_accounts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.deleted_at IS NULL",
+      "file": "app/services/finance/adapters/importers/queries.py",
+      "function": "live_transactions_for_accounts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.deleted_at IS NULL AND finance_transaction.is_transfer IS false AND finance_transaction.merchant_id IS NULL",
+      "file": "app/services/finance/seeds/demo_seed.py",
+      "function": "_name_payees"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.source = :source_1 AND finance_transaction.deleted_at IS NULL",
+      "file": "app/services/finance/adapters/providers/queries.py",
+      "function": "provider_rows_for_accounts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND (finance_transaction.recurring_stream_id IS NULL OR NOT (EXISTS (SELECT finance_recurring_stream.id FROM finance_recurring_stream WHERE finance_recurring_stream.id = finance_transaction.recurring_stream_id AND finance_recurring_stream.deleted_at IS NULL))) AND finance_transaction.amount < :amount_1 AND finance_transaction.owner_user_id = :owner_user_id_1 AND abs(finance_transaction.amount) BETWEEN :abs_1 AND :abs_2 AND finance_transaction.date BETWEEN :date_1 AND :date_2 ORDER BY finance_transaction.date DESC LIMIT :param_1",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "candidate_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND (finance_transaction.recurring_stream_id IS NULL OR NOT (EXISTS (SELECT finance_recurring_stream.id FROM finance_recurring_stream WHERE finance_recurring_stream.id = finance_transaction.recurring_stream_id AND finance_recurring_stream.deleted_at IS NULL))) AND finance_transaction.amount < :amount_1 AND finance_transaction.owner_user_id IS NULL AND abs(finance_transaction.amount) BETWEEN :abs_1 AND :abs_2 AND finance_transaction.date BETWEEN :date_1 AND :date_2 ORDER BY finance_transaction.date DESC LIMIT :param_1",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "candidate_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_transfer IS false AND finance_transaction.owner_user_id = :owner_user_id_1 AND (lower(finance_transaction.name) LIKE lower(:name_1) OR lower(finance_transaction.merchant_name) LIKE lower(:merchant_name_1) OR lower(finance_transaction.original_description) LIKE lower(:original_description_1) OR lower(finance_transaction.memo) LIKE lower(:memo_1) OR finance_transaction.merchant_id IN (SELECT finance_merchant.id FROM finance_merchant WHERE lower(finance_merchant.name) LIKE lower(:name_2)) OR finance_transaction.category_id IN (SELECT finance_category.id FROM finance_category WHERE lower(finance_category.name) LIKE lower(:name_3)) OR finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE lower(finance_account.name) LIKE lower(:name_4)) OR abs(finance_transaction.amount) = :abs_1) ORDER BY finance_transaction.date DESC, finance_transaction.id DESC LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transactions_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_transfer IS false AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.account_id = :account_id_1 ORDER BY finance_transaction.date DESC, finance_transaction.id DESC LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transactions_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_transfer IS false AND finance_transaction.owner_user_id = :owner_user_id_1 ORDER BY finance_transaction.date DESC, finance_transaction.id DESC LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transactions_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.category_id IS NOT NULL AND (finance_transaction.category_id NOT IN (SELECT finance_category.id FROM finance_category WHERE lower(finance_category.name) IN (__[POSTCOMPILE_lower_1]))) AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/categories.py",
+      "function": "categorized_history"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.is_split IS false AND (finance_transaction.category_id IS NULL OR finance_transaction.category_id IN (SELECT finance_category.id FROM finance_category WHERE lower(finance_category.name) IN (__[POSTCOMPILE_lower_1]))) AND finance_transaction.owner_user_id = :owner_user_id_1 ORDER BY finance_transaction.date DESC",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "uncategorized_page"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.is_transfer IS false AND finance_transaction.amount != :amount_1 AND finance_transaction.owner_user_id = :owner_user_id_1 AND (lower(finance_transaction.name) LIKE lower(:name_1) OR lower(finance_transaction.original_description) LIKE lower(:original_description_1) OR lower(finance_transaction.name) LIKE lower(:name_2) OR lower(finance_transaction.original_description) LIKE lower(:original_description_2) OR lower(finance_transaction.name) LIKE lower(:name_3) OR lower(finance_transaction.original_description) LIKE lower(:original_description_3) OR lower(finance_transaction.name) LIKE lower(:name_4) OR lower(finance_transaction.original_description) LIKE lower(:original_description_4) OR lower(finance_transaction.name) LIKE lower(:name_5) OR lower(finance_transaction.original_description) LIKE lower(:original_description_5))",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.is_transfer IS false AND finance_transaction.amount != :amount_1 AND finance_transaction.owner_user_id IS NULL AND (lower(finance_transaction.name) LIKE lower(:name_1) OR lower(finance_transaction.original_description) LIKE lower(:original_description_1) OR lower(finance_transaction.name) LIKE lower(:name_2) OR lower(finance_transaction.original_description) LIKE lower(:original_description_2) OR lower(finance_transaction.name) LIKE lower(:name_3) OR lower(finance_transaction.original_description) LIKE lower(:original_description_3) OR lower(finance_transaction.name) LIKE lower(:name_4) OR lower(finance_transaction.original_description) LIKE lower(:original_description_4) OR lower(finance_transaction.name) LIKE lower(:name_5) OR lower(finance_transaction.original_description) LIKE lower(:original_description_5))",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.is_transfer IS false AND finance_transaction.transfer_group_id IS NULL AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.is_transfer IS false AND finance_transaction.transfer_group_id IS NULL AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.date >= :date_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.is_transfer IS false AND finance_transaction.transfer_group_id IS NULL AND finance_transaction.category_id IN (SELECT finance_category.id FROM finance_category WHERE finance_category.classification = :classification_1) AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.is_transfer IS false AND finance_transaction.transfer_group_id IS NULL AND finance_transaction.category_id IN (SELECT finance_category.id FROM finance_category WHERE finance_category.classification = :classification_1) AND finance_transaction.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.transfer_group_id IS NULL AND finance_transaction.amount < :amount_1 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.transfer_group_id IS NULL AND finance_transaction.amount > :amount_1 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.transfer_group_id IS NULL AND finance_transaction.amount > :amount_1 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.is_transfer IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.category_id IS NOT NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "categorized_outflow_history"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.merchant_id IS NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "payeeless_transactions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.external_id_source = :external_id_source_1 AND finance_transaction.deleted_at IS NULL",
+      "file": "tests/services/test_finance_reconcile.py",
+      "function": "test_reconcile_is_idempotent_per_date"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.id = :id_1 AND finance_transaction.deleted_at IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transaction_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.id = :id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "transaction_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.id IN (__[POSTCOMPILE_id_1]) AND finance_transaction.deleted_at IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "live_transactions_by_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.id IN (__[POSTCOMPILE_id_1]) AND finance_transaction.deleted_at IS NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.id IN (__[POSTCOMPILE_id_1]) AND finance_transaction.deleted_at IS NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "live_transactions_by_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND (finance_transaction.is_transfer IS false AND finance_transaction.excluded_from_reports IS false OR (EXISTS (SELECT finance_transfer.id FROM finance_transfer JOIN finance_account ON finance_account.id = (SELECT finance_transaction.account_id FROM finance_transaction WHERE finance_transaction.id = finance_transfer.to_transaction_id) WHERE finance_transfer.from_transaction_id = finance_transaction.id AND finance_transfer.status = :status_1 AND finance_account.classification = :classification_1))) AND finance_transaction.status = :status_2",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND (finance_transaction.is_transfer IS false AND finance_transaction.excluded_from_reports IS false OR (EXISTS (SELECT finance_transfer.id FROM finance_transfer JOIN finance_account ON finance_account.id = (SELECT finance_transaction.account_id FROM finance_transaction WHERE finance_transaction.id = finance_transfer.to_transaction_id) WHERE finance_transfer.from_transaction_id = finance_transaction.id AND finance_transfer.status = :status_1 AND finance_account.classification = :classification_1))) AND finance_transaction.status = :status_2 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1])",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_2) AND finance_transaction.date >= :date_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.category_id IS NOT NULL AND finance_transaction.date >= :date_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_2)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND finance_transaction.date >= :date_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_2)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.is_transfer IS false AND finance_transaction.recurring_stream_id IS NULL AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id = :owner_user_id_2)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id IS NULL AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND (finance_transaction.is_transfer IS false AND finance_transaction.excluded_from_reports IS false OR (EXISTS (SELECT finance_transfer.id FROM finance_transfer JOIN finance_account ON finance_account.id = (SELECT finance_transaction.account_id FROM finance_transaction WHERE finance_transaction.id = finance_transfer.to_transaction_id) WHERE finance_transfer.from_transaction_id = finance_transaction.id AND finance_transfer.status = :status_1 AND finance_account.classification = :classification_1))) AND finance_transaction.status = :status_2 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1])",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id IS NULL AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id IS NULL) AND finance_transaction.date >= :date_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id IS NULL AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.category_id IS NOT NULL AND finance_transaction.date >= :date_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id IS NULL)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id IS NULL AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND finance_transaction.date >= :date_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id IS NULL)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.owner_user_id IS NULL AND finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.is_transfer IS false AND finance_transaction.recurring_stream_id IS NULL AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL AND finance_account.owner_user_id IS NULL)",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.recurring_stream_id = :recurring_stream_id_1",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "stream_members"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1])",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "transaction_rows_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.source = :source_1",
+      "file": "tests/services/test_finance_plaid.py",
+      "function": "_plaid_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.merchant_id, count(finance_transaction.id) AS count_1, sum(finance_transaction.amount) AS sum_1, max(finance_transaction.date) AS max_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.merchant_id IS NOT NULL AND finance_transaction.owner_user_id = :owner_user_id_1 GROUP BY finance_transaction.merchant_id",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "merchant_usage_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.merchant_id, count(finance_transaction.id) AS count_1, sum(finance_transaction.amount) AS sum_1, max(finance_transaction.date) AS max_1 FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.merchant_id IS NOT NULL GROUP BY finance_transaction.merchant_id",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "merchant_usage_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.recurring_stream_id FROM finance_transaction WHERE finance_transaction.recurring_stream_id IS NOT NULL AND finance_transaction.deleted_at IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "linked_stream_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.recurring_stream_id, finance_category.name FROM finance_transaction JOIN finance_category ON finance_category.id = finance_transaction.category_id WHERE finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.deleted_at IS NULL AND finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND finance_transaction.category_id IS NOT NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "stream_member_categories"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.recurring_stream_id, finance_category.name, count(*) AS hits FROM finance_transaction JOIN finance_category ON finance_category.id = finance_transaction.category_id WHERE finance_transaction.recurring_stream_id IN (__[POSTCOMPILE_recurring_stream_id_1]) AND finance_transaction.deleted_at IS NULL GROUP BY finance_transaction.recurring_stream_id, finance_category.name",
+      "file": "app/services/finance/domains/planning/recurring/queries.py",
+      "function": "stream_member_category_votes"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction_split.category_id, finance_transaction.merchant_name, finance_transaction.original_description, finance_transaction.name, finance_transaction_split.amount, finance_transaction.recurring_stream_id FROM finance_transaction_split JOIN finance_transaction ON finance_transaction.id = finance_transaction_split.parent_transaction_id WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.account_id IN (__[POSTCOMPILE_account_id_1]) AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS true",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "outflow_tuples"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction_split.category_id, finance_transaction.merchant_name, finance_transaction.original_description, finance_transaction.name, finance_transaction_split.amount, finance_transaction.recurring_stream_id FROM finance_transaction_split JOIN finance_transaction ON finance_transaction.id = finance_transaction_split.parent_transaction_id WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.is_split IS true",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "outflow_tuples"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction_split.category_id, finance_transaction.merchant_name, finance_transaction.original_description, finance_transaction.name, finance_transaction_split.amount, finance_transaction.recurring_stream_id FROM finance_transaction_split JOIN finance_transaction ON finance_transaction.id = finance_transaction_split.parent_transaction_id WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS true",
+      "file": "app/services/finance/domains/planning/budgets/queries.py",
+      "function": "outflow_tuples"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction_split.category_id, sum(finance_transaction_split.amount) AS sum_1 FROM finance_transaction_split JOIN finance_transaction ON finance_transaction.id = finance_transaction_split.parent_transaction_id WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.dedup_status != :dedup_status_1 AND finance_transaction.excluded_from_reports IS false AND finance_transaction.account_id IN (SELECT finance_account.id FROM finance_account WHERE finance_account.deleted_at IS NULL) AND finance_transaction.amount < :amount_1 AND finance_transaction.date >= :date_1 AND finance_transaction.date < :date_2 AND finance_transaction.owner_user_id = :owner_user_id_1 AND finance_transaction.is_split IS true AND finance_transaction_split.category_id IN (__[POSTCOMPILE_category_id_1]) GROUP BY finance_transaction_split.category_id",
+      "file": "app/services/finance/domains/planning/queries.py",
+      "function": "spend_by_category"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction_split.id, finance_transaction_split.owner_user_id, finance_transaction_split.parent_transaction_id, finance_transaction_split.category_id, finance_transaction_split.merchant_id, finance_transaction_split.amount, finance_transaction_split.currency, finance_transaction_split.memo, finance_transaction_split.sort_order, finance_transaction_split.note FROM finance_transaction_split WHERE finance_transaction_split.parent_transaction_id IN (__[POSTCOMPILE_parent_transaction_id_1]) ORDER BY finance_transaction_split.parent_transaction_id, finance_transaction_split.sort_order",
+      "file": "app/services/finance/domains/ledger/queries/splits.py",
+      "function": "splits_for_parents"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction_tag.transaction_id FROM finance_transaction_tag WHERE finance_transaction_tag.tag_id = :tag_id_1 AND finance_transaction_tag.transaction_id IN (__[POSTCOMPILE_transaction_id_1])",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "tagged_transaction_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction_tag.transaction_id, finance_tag.id, finance_tag.owner_user_id, finance_tag.organization_id, finance_tag.name, finance_tag.normalized_name, finance_tag.color, finance_tag.deleted_at, finance_tag.created_at, finance_tag.updated_at FROM finance_transaction_tag JOIN finance_tag ON finance_tag.id = finance_transaction_tag.tag_id WHERE finance_transaction_tag.transaction_id IN (__[POSTCOMPILE_transaction_id_1]) AND finance_tag.deleted_at IS NULL ORDER BY finance_tag.name",
+      "file": "app/services/finance/domains/ledger/queries/transactions.py",
+      "function": "tags_by_transaction"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transfer.from_transaction_id FROM finance_transfer WHERE finance_transfer.from_transaction_id IS NOT NULL AND finance_transfer.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "claimed_leg_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transfer.from_transaction_id FROM finance_transfer WHERE finance_transfer.from_transaction_id IS NOT NULL AND finance_transfer.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "claimed_leg_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transfer.id, finance_transfer.owner_user_id, finance_transfer.organization_id, finance_transfer.from_account_id, finance_transfer.to_account_id, finance_transfer.from_transaction_id, finance_transfer.to_transaction_id, finance_transfer.amount, finance_transfer.currency, finance_transfer.transfer_date, finance_transfer.transfer_group_key, finance_transfer.is_credit_card_payment, finance_transfer.match_method, finance_transfer.confidence, finance_transfer.status FROM finance_transfer WHERE finance_transfer.from_account_id IN (__[POSTCOMPILE_from_account_id_1]) OR finance_transfer.to_account_id IN (__[POSTCOMPILE_to_account_id_1])",
+      "file": "app/services/finance/seeds/demo_seed.py",
+      "function": "_count_derived"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transfer.to_transaction_id FROM finance_transfer WHERE finance_transfer.to_transaction_id IS NOT NULL AND finance_transfer.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "claimed_leg_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transfer.to_transaction_id FROM finance_transfer WHERE finance_transfer.to_transaction_id IS NOT NULL AND finance_transfer.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/detection/queries.py",
+      "function": "claimed_leg_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_valuation.id, finance_valuation.owner_user_id, finance_valuation.organization_id, finance_valuation.account_id, finance_valuation.as_of_date, finance_valuation.value, finance_valuation.currency, finance_valuation.source, finance_valuation.source_ref, finance_valuation.is_estimate, finance_valuation.fetched_at, finance_valuation.is_stale, finance_valuation.stale_after_days, finance_valuation.note, finance_valuation.metadata, finance_valuation.created_at, finance_valuation.updated_at FROM finance_valuation WHERE finance_valuation.account_id = :account_id_1 AND finance_valuation.as_of_date = :as_of_date_1 AND finance_valuation.source = :source_1",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "valuation_by_key"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_valuation.id, finance_valuation.owner_user_id, finance_valuation.organization_id, finance_valuation.account_id, finance_valuation.as_of_date, finance_valuation.value, finance_valuation.currency, finance_valuation.source, finance_valuation.source_ref, finance_valuation.is_estimate, finance_valuation.fetched_at, finance_valuation.is_stale, finance_valuation.stale_after_days, finance_valuation.note, finance_valuation.metadata, finance_valuation.created_at, finance_valuation.updated_at FROM finance_valuation WHERE finance_valuation.account_id = :account_id_1 AND finance_valuation.source = :source_1 ORDER BY finance_valuation.as_of_date DESC LIMIT :param_1",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "latest_valuation_row"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_valuation.id, finance_valuation.owner_user_id, finance_valuation.organization_id, finance_valuation.account_id, finance_valuation.as_of_date, finance_valuation.value, finance_valuation.currency, finance_valuation.source, finance_valuation.source_ref, finance_valuation.is_estimate, finance_valuation.fetched_at, finance_valuation.is_stale, finance_valuation.stale_after_days, finance_valuation.note, finance_valuation.metadata, finance_valuation.created_at, finance_valuation.updated_at FROM finance_valuation WHERE finance_valuation.account_id = :account_id_1 ORDER BY finance_valuation.as_of_date",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "valuations_for_account"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_valuation.id, finance_valuation.owner_user_id, finance_valuation.organization_id, finance_valuation.account_id, finance_valuation.as_of_date, finance_valuation.value, finance_valuation.currency, finance_valuation.source, finance_valuation.source_ref, finance_valuation.is_estimate, finance_valuation.fetched_at, finance_valuation.is_stale, finance_valuation.stale_after_days, finance_valuation.note, finance_valuation.metadata, finance_valuation.created_at, finance_valuation.updated_at FROM finance_valuation WHERE finance_valuation.account_id = :account_id_1 ORDER BY finance_valuation.as_of_date DESC LIMIT :param_1",
+      "file": "app/services/finance/domains/ledger/queries/accounts.py",
+      "function": "latest_valuation_row"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_valuation.id, finance_valuation.owner_user_id, finance_valuation.organization_id, finance_valuation.account_id, finance_valuation.as_of_date, finance_valuation.value, finance_valuation.currency, finance_valuation.source, finance_valuation.source_ref, finance_valuation.is_estimate, finance_valuation.fetched_at, finance_valuation.is_stale, finance_valuation.stale_after_days, finance_valuation.note, finance_valuation.metadata, finance_valuation.created_at, finance_valuation.updated_at FROM finance_valuation WHERE finance_valuation.account_id IN (__[POSTCOMPILE_account_id_1]) ORDER BY finance_valuation.account_id, finance_valuation.as_of_date",
+      "file": "app/services/finance/domains/ledger/queries/networth.py",
+      "function": "valuations_for_accounts"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_event.id, insight_event.date, insight_event.event_type, insight_event.description, insight_event.metadata, insight_event.origin, insight_event.created_at FROM insight_event WHERE insight_event.event_type IN (__[POSTCOMPILE_event_type_1])",
+      "file": "app/services/insights/queries/events.py",
+      "function": "events_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_event.id, insight_event.date, insight_event.event_type, insight_event.description, insight_event.metadata, insight_event.origin, insight_event.project_id, insight_event.created_by_user_id, insight_event.created_at FROM insight_event WHERE insight_event.event_type IN (__[POSTCOMPILE_event_type_1]) AND insight_event.project_id = :project_id_1",
+      "file": "app/services/insights/queries/events.py",
+      "function": "events_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_metric.id, insight_metric.date, insight_metric.metric_type_id, insight_metric.project_id, insight_metric.value, insight_metric.period, insight_metric.metadata, insight_metric.created_at FROM insight_metric JOIN insight_metric_type ON insight_metric.metric_type_id = insight_metric_type.id JOIN insight_source ON insight_metric_type.source_id = insight_source.id WHERE insight_source.key = :key_1 AND insight_metric_type.key = :key_2 AND insight_metric.date >= :date_1",
+      "file": "tests/services/test_goal_service.py",
+      "function": "spy_exec"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_metric.id, insight_metric.date, insight_metric.metric_type_id, insight_metric.project_id, insight_metric.value, insight_metric.period, insight_metric.metadata, insight_metric.created_at FROM insight_metric WHERE insight_metric.metric_type_id = :metric_type_id_1 AND insight_metric.date = :date_1 AND insight_metric.period = :period_1 AND insight_metric.project_id = :project_id_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "metric_on"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_metric.id, insight_metric.date, insight_metric.metric_type_id, insight_metric.project_id, insight_metric.value, insight_metric.period, insight_metric.metadata, insight_metric.created_at FROM insight_metric WHERE insight_metric.metric_type_id IN (__[POSTCOMPILE_metric_type_id_1]) AND insight_metric.period = :period_1 AND insight_metric.project_id = :project_id_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "metrics_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_metric.id, insight_metric.date, insight_metric.metric_type_id, insight_metric.value, insight_metric.period, insight_metric.metadata, insight_metric.created_at FROM insight_metric WHERE insight_metric.metric_type_id = :metric_type_id_1 AND insight_metric.date = :date_1 AND insight_metric.period = :period_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "metric_on"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_metric.id, insight_metric.date, insight_metric.metric_type_id, insight_metric.value, insight_metric.period, insight_metric.metadata, insight_metric.created_at FROM insight_metric WHERE insight_metric.metric_type_id IN (__[POSTCOMPILE_metric_type_id_1]) AND insight_metric.period = :period_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "metrics_where"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_metric_type.id, insight_metric_type.source_id, insight_metric_type.key, insight_metric_type.display_name, insight_metric_type.unit, insight_metric_type.metadata, insight_metric_type.created_at FROM insight_metric_type WHERE insight_metric_type.key = :key_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "metric_type_by_key"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_metric_type.id, insight_metric_type.source_id, insight_metric_type.key, insight_metric_type.display_name, insight_metric_type.unit, insight_metric_type.metadata, insight_metric_type.created_at FROM insight_metric_type WHERE insight_metric_type.key = :key_1 AND insight_metric_type.source_id = :source_id_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "metric_type_by_key"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_record.id, insight_record.metric_type_id, insight_record.value, insight_record.date_achieved, insight_record.previous_value, insight_record.previous_date, insight_record.context, insight_record.metadata, insight_record.updated_at, insight_record.created_at FROM insight_record WHERE insight_record.metric_type_id = :metric_type_id_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "record_for_type"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_source.id, insight_source.key, insight_source.display_name, insight_source.collection_interval_hours, insight_source.requires_auth, insight_source.enabled, insight_source.last_collected_at, insight_source.metadata, insight_source.created_at FROM insight_source WHERE insight_source.enabled = true ORDER BY insight_source.id",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "sources"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT insight_source.id, insight_source.key, insight_source.display_name, insight_source.collection_interval_hours, insight_source.requires_auth, insight_source.enabled, insight_source.last_collected_at, insight_source.metadata, insight_source.created_at FROM insight_source WHERE insight_source.key = :key_1",
+      "file": "app/services/insights/queries/metrics.py",
+      "function": "source_by_key"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT job_execution.id, job_execution.job_id, job_execution.job_name, job_execution.scheduled_run_time, job_execution.started_at, job_execution.finished_at, job_execution.duration_ms, job_execution.status, job_execution.error_message, job_execution.traceback FROM job_execution WHERE job_execution.job_id = :job_id_1 ORDER BY job_execution.started_at DESC LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/scheduler/scheduled_task_manager.py",
+      "function": "list_executions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT large_language_model.id, large_language_model.model_id, large_language_model.title, large_language_model.description, large_language_model.context_window, large_language_model.training_data, large_language_model.streamable, large_language_model.enabled, large_language_model.color, large_language_model.icon_path, large_language_model.license, large_language_model.source_url, large_language_model.released_on, large_language_model.family, large_language_model.served_by_org_id, large_language_model.made_by_org_id FROM large_language_model",
+      "file": "app/services/ai/domains/llm/etl/queries.py",
+      "function": "all_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT large_language_model.id, large_language_model.model_id, large_language_model.title, large_language_model.description, large_language_model.context_window, large_language_model.training_data, large_language_model.streamable, large_language_model.enabled, large_language_model.color, large_language_model.icon_path, large_language_model.license, large_language_model.source_url, large_language_model.released_on, large_language_model.family, large_language_model.served_by_org_id, large_language_model.made_by_org_id FROM large_language_model WHERE large_language_model.model_id = :model_id_1",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "latest_price_for_model"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT large_language_model.id, large_language_model.model_id, large_language_model.title, large_language_model.description, large_language_model.context_window, large_language_model.training_data, large_language_model.streamable, large_language_model.enabled, large_language_model.color, large_language_model.icon_path, large_language_model.license, large_language_model.source_url, large_language_model.released_on, large_language_model.family, large_language_model.served_by_org_id, large_language_model.made_by_org_id FROM large_language_model WHERE large_language_model.model_id = :model_id_1",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "llm_by_model_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT large_language_model.id, large_language_model.model_id, large_language_model.title, large_language_model.description, large_language_model.context_window, large_language_model.training_data, large_language_model.streamable, large_language_model.enabled, large_language_model.color, large_language_model.icon_path, large_language_model.license, large_language_model.source_url, large_language_model.released_on, large_language_model.family, large_language_model.served_by_org_id, large_language_model.made_by_org_id FROM large_language_model WHERE large_language_model.served_by_org_id IN (__[POSTCOMPILE_served_by_org_id_1])",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "models_served_by"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_active_selection.id, llm_active_selection.owner_user_id, llm_active_selection.model_id, llm_active_selection.provider, llm_active_selection.updated_at FROM llm_active_selection WHERE llm_active_selection.owner_user_id = :owner_user_id_1",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "active_selection"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_active_selection.id, llm_active_selection.owner_user_id, llm_active_selection.model_id, llm_active_selection.provider, llm_active_selection.updated_at FROM llm_active_selection WHERE llm_active_selection.owner_user_id IS NULL",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "active_selection"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_deployment.id, llm_deployment.llm_id, llm_deployment.org_id, llm_deployment.speed, llm_deployment.intelligence, llm_deployment.reasoning, llm_deployment.output_max_tokens, llm_deployment.function_calling, llm_deployment.input_cache, llm_deployment.structured_output FROM llm_deployment",
+      "file": "app/services/ai/domains/llm/etl/queries.py",
+      "function": "all_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_deployment.llm_id AS llm_deployment_llm_id, llm_deployment.id AS llm_deployment_id, llm_deployment.org_id AS llm_deployment_org_id, llm_deployment.speed AS llm_deployment_speed, llm_deployment.intelligence AS llm_deployment_intelligence, llm_deployment.reasoning AS llm_deployment_reasoning, llm_deployment.output_max_tokens AS llm_deployment_output_max_tokens, llm_deployment.function_calling AS llm_deployment_function_calling, llm_deployment.input_cache AS llm_deployment_input_cache, llm_deployment.structured_output AS llm_deployment_structured_output FROM llm_deployment WHERE llm_deployment.llm_id IN (__[POSTCOMPILE_primary_keys])",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "models_served_by"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_modality.id, llm_modality.llm_id, llm_modality.modality, llm_modality.direction FROM llm_modality",
+      "file": "app/services/ai/domains/llm/etl/queries.py",
+      "function": "all_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_modality.llm_id AS llm_modality_llm_id, llm_modality.id AS llm_modality_id, llm_modality.modality AS llm_modality_modality, llm_modality.direction AS llm_modality_direction FROM llm_modality WHERE llm_modality.llm_id IN (__[POSTCOMPILE_primary_keys])",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "models_served_by"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_org.id AS llm_org_id, llm_org.slug AS llm_org_slug, llm_org.name AS llm_org_name, llm_org.description AS llm_org_description, llm_org.homepage AS llm_org_homepage, llm_org.icon_b64 AS llm_org_icon_b64, llm_org.color AS llm_org_color, llm_org.icon_path AS llm_org_icon_path, llm_org.api_base AS llm_org_api_base, llm_org.auth_method AS llm_org_auth_method, llm_org.source AS llm_org_source, llm_org.created_at AS llm_org_created_at, llm_org.updated_at AS llm_org_updated_at FROM llm_org WHERE llm_org.id IN (__[POSTCOMPILE_primary_keys])",
+      "file": "tests/services/ai/test_llm_service.py",
+      "function": "all"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_org.id, llm_org.slug, llm_org.name, llm_org.description, llm_org.homepage, llm_org.icon_b64, llm_org.color, llm_org.icon_path, llm_org.api_base, llm_org.auth_method, llm_org.source, llm_org.created_at, llm_org.updated_at FROM llm_org",
+      "file": "app/services/ai/domains/llm/etl/queries.py",
+      "function": "all_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_org.id, llm_org.slug, llm_org.name, llm_org.description, llm_org.homepage, llm_org.icon_b64, llm_org.color, llm_org.icon_path, llm_org.api_base, llm_org.auth_method, llm_org.source, llm_org.created_at, llm_org.updated_at FROM llm_org WHERE llm_org.name IN (__[POSTCOMPILE_name_1])",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "orgs_named"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_price.id, llm_price.org_id, llm_price.llm_id, llm_price.input_cost_per_token, llm_price.output_cost_per_token, llm_price.cache_input_cost_per_token, llm_price.effective_date FROM llm_price",
+      "file": "app/services/ai/domains/llm/etl/queries.py",
+      "function": "all_rows"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_price.id, llm_price.org_id, llm_price.llm_id, llm_price.input_cost_per_token, llm_price.output_cost_per_token, llm_price.cache_input_cost_per_token, llm_price.effective_date FROM llm_price WHERE llm_price.llm_id = :llm_id_1 ORDER BY llm_price.effective_date DESC",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "latest_price_for_model"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_price.id, llm_price.org_id, llm_price.llm_id, llm_price.input_cost_per_token, llm_price.output_cost_per_token, llm_price.cache_input_cost_per_token, llm_price.effective_date FROM llm_price WHERE llm_price.llm_id IN (__[POSTCOMPILE_llm_id_1]) ORDER BY llm_price.llm_id, llm_price.effective_date DESC",
+      "file": "tests/services/ai/test_llm_service.py",
+      "function": "exec"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_price.llm_id AS llm_price_llm_id, llm_price.id AS llm_price_id, llm_price.org_id AS llm_price_org_id, llm_price.input_cost_per_token AS llm_price_input_cost_per_token, llm_price.output_cost_per_token AS llm_price_output_cost_per_token, llm_price.cache_input_cost_per_token AS llm_price_cache_input_cost_per_token, llm_price.effective_date AS llm_price_effective_date FROM llm_price WHERE llm_price.llm_id IN (__[POSTCOMPILE_primary_keys])",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "models_served_by"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_usage.model_id, coalesce(large_language_model.title, llm_usage.model_id) AS title, coalesce(llm_org.name, :coalesce_1) AS vendor, coalesce(llm_org.color, :coalesce_2) AS vendor_color, count(llm_usage.id) AS requests, coalesce(sum(llm_usage.input_tokens + llm_usage.output_tokens), :coalesce_3) AS tokens, coalesce(sum(llm_usage.total_cost), :coalesce_4) AS cost FROM llm_usage LEFT OUTER JOIN large_language_model ON llm_usage.model_id = large_language_model.model_id LEFT OUTER JOIN llm_org ON large_language_model.served_by_org_id = llm_org.id GROUP BY llm_usage.model_id, large_language_model.title, llm_org.name, llm_org.color ORDER BY count(llm_usage.id) DESC",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "usage_by_model"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT llm_usage.timestamp, llm_usage.model_id, llm_usage.input_tokens, llm_usage.output_tokens, llm_usage.total_cost, llm_usage.success, llm_usage.action FROM llm_usage ORDER BY llm_usage.timestamp DESC LIMIT :param_1",
+      "file": "app/services/ai/domains/llm/queries.py",
+      "function": "recent_usage"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT max(conversation_message.timestamp) AS max_1 FROM conversation_message WHERE conversation_message.conversation_id = :conversation_id_1",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "latest_message_timestamp"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT memory_module.id, memory_module.slug, memory_module.name, memory_module.description, memory_module.category, memory_module.prompt_content, memory_module.fetch_function, memory_module.context_key, memory_module.supports_days_back, memory_module.default_days_back, memory_module.priority, memory_module.token_estimate, memory_module.is_active, memory_module.created_at, memory_module.updated_at FROM memory_module WHERE memory_module.slug = :slug_1",
+      "file": "app/services/ai/domains/chat/queries.py",
+      "function": "memory_module_by_slug"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT org_invite.id, org_invite.organization_id, org_invite.email, org_invite.role, org_invite.invited_by, org_invite.status, org_invite.token, org_invite.created_at, org_invite.expires_at FROM org_invite WHERE org_invite.organization_id = :organization_id_1 AND org_invite.email = :email_1 AND org_invite.status = :status_1",
+      "file": "app/services/auth/invites.py",
+      "function": "_get_pending_invite"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization.name, organization.slug, organization.description, organization.is_active, organization.id, organization.created_at, organization.updated_at, organization.deleted_at FROM organization WHERE organization.id = :id_1",
+      "file": "app/services/auth/orgs.py",
+      "function": "hard_delete_org"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization.name, organization.slug, organization.description, organization.is_active, organization.id, organization.created_at, organization.updated_at, organization.deleted_at FROM organization WHERE organization.id = :id_1",
+      "file": "app/services/auth/orgs.py",
+      "function": "restore_org"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization.name, organization.slug, organization.description, organization.is_active, organization.id, organization.created_at, organization.updated_at, organization.deleted_at FROM organization WHERE organization.id = :id_1",
+      "file": "tests/services/test_org_integration.py",
+      "function": "_org_deleted_at"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization.name, organization.slug, organization.description, organization.is_active, organization.id, organization.created_at, organization.updated_at, organization.deleted_at FROM organization WHERE organization.id = :id_1 AND organization.deleted_at IS NULL",
+      "file": "app/services/auth/orgs.py",
+      "function": "get_org_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization.name, organization.slug, organization.description, organization.is_active, organization.id, organization.created_at, organization.updated_at, organization.deleted_at FROM organization WHERE organization.slug = :slug_1",
+      "file": "tests/_test_org.py",
+      "function": "ensure_org_for_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization_member.id, organization_member.organization_id, organization_member.user_id, organization_member.role, organization_member.joined_at FROM organization_member WHERE organization_member.organization_id = :organization_id_1",
+      "file": "app/services/auth/memberships.py",
+      "function": "list_org_members"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization_member.id, organization_member.organization_id, organization_member.user_id, organization_member.role, organization_member.joined_at FROM organization_member WHERE organization_member.organization_id = :organization_id_1 AND organization_member.user_id = :user_id_1",
+      "file": "app/components/backend/api/insights.py",
+      "function": "create_project"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization_member.id, organization_member.organization_id, organization_member.user_id, organization_member.role, organization_member.joined_at FROM organization_member WHERE organization_member.organization_id = :organization_id_1 AND organization_member.user_id = :user_id_1",
+      "file": "app/services/auth/memberships.py",
+      "function": "get_member"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization_member.organization_id FROM organization_member JOIN organization ON organization.id = organization_member.organization_id WHERE organization_member.user_id = :user_id_1 AND organization_member.role = :role_1 AND organization.deleted_at IS NULL",
+      "file": "app/services/auth/users.py",
+      "function": "orphaned_sole_owner_org_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT organization_member.organization_id, count(*) AS count_1 FROM organization_member WHERE organization_member.organization_id IN (__[POSTCOMPILE_organization_id_1]) GROUP BY organization_member.organization_id",
+      "file": "app/services/auth/users.py",
+      "function": "orphaned_sole_owner_org_ids"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_customer.id FROM payment_customer WHERE payment_customer.user_id = :user_id_1",
+      "file": "app/services/payment/service.py",
+      "function": "_customer_ids_for_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_customer.id, payment_customer.user_id, payment_customer.provider_id, payment_customer.provider_customer_id, payment_customer.email, payment_customer.metadata, payment_customer.created_at FROM payment_customer WHERE payment_customer.user_id = :user_id_1",
+      "file": "app/services/payment/service.py",
+      "function": "_ensure_customer_for_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_dispute.id, payment_dispute.transaction_id, payment_dispute.provider_dispute_id, payment_dispute.status, payment_dispute.reason, payment_dispute.amount, payment_dispute.currency, payment_dispute.evidence_due_by, payment_dispute.event_type, payment_dispute.metadata, payment_dispute.created_at, payment_dispute.updated_at FROM payment_dispute ORDER BY payment_dispute.created_at DESC",
+      "file": "app/services/payment/service.py",
+      "function": "get_disputes"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_dispute.id, payment_dispute.transaction_id, payment_dispute.provider_dispute_id, payment_dispute.status, payment_dispute.reason, payment_dispute.amount, payment_dispute.currency, payment_dispute.evidence_due_by, payment_dispute.event_type, payment_dispute.metadata, payment_dispute.created_at, payment_dispute.updated_at FROM payment_dispute WHERE payment_dispute.id = :id_1 AND payment_dispute.transaction_id IN (__[POSTCOMPILE_transaction_id_1])",
+      "file": "app/services/payment/service.py",
+      "function": "get_dispute_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_dispute.id, payment_dispute.transaction_id, payment_dispute.provider_dispute_id, payment_dispute.status, payment_dispute.reason, payment_dispute.amount, payment_dispute.currency, payment_dispute.evidence_due_by, payment_dispute.event_type, payment_dispute.metadata, payment_dispute.created_at, payment_dispute.updated_at FROM payment_dispute WHERE payment_dispute.provider_dispute_id = :provider_dispute_id_1",
+      "file": "app/services/payment/service.py",
+      "function": "_handle_dispute_event"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_dispute.id, payment_dispute.transaction_id, payment_dispute.provider_dispute_id, payment_dispute.status, payment_dispute.reason, payment_dispute.amount, payment_dispute.currency, payment_dispute.evidence_due_by, payment_dispute.event_type, payment_dispute.metadata, payment_dispute.created_at, payment_dispute.updated_at FROM payment_dispute WHERE payment_dispute.provider_dispute_id = :provider_dispute_id_1",
+      "file": "app/services/payment/service.py",
+      "function": "_handle_early_fraud_warning"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_dispute.id, payment_dispute.transaction_id, payment_dispute.provider_dispute_id, payment_dispute.status, payment_dispute.reason, payment_dispute.amount, payment_dispute.currency, payment_dispute.evidence_due_by, payment_dispute.event_type, payment_dispute.metadata, payment_dispute.created_at, payment_dispute.updated_at FROM payment_dispute WHERE payment_dispute.transaction_id IN (__[POSTCOMPILE_transaction_id_1]) ORDER BY payment_dispute.created_at DESC",
+      "file": "app/services/payment/service.py",
+      "function": "get_disputes"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_provider.id, payment_provider.key, payment_provider.display_name, payment_provider.enabled, payment_provider.is_test_mode, payment_provider.metadata, payment_provider.created_at FROM payment_provider WHERE payment_provider.key = :key_1",
+      "file": "app/services/payment/service.py",
+      "function": "get_or_create_provider"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_subscription.id, payment_subscription.customer_id, payment_subscription.provider_subscription_id, payment_subscription.plan_name, payment_subscription.status, payment_subscription.current_period_start, payment_subscription.current_period_end, payment_subscription.cancel_at_period_end, payment_subscription.metadata, payment_subscription.created_at, payment_subscription.updated_at FROM payment_subscription ORDER BY payment_subscription.created_at DESC",
+      "file": "app/services/payment/service.py",
+      "function": "get_subscriptions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_subscription.id, payment_subscription.customer_id, payment_subscription.provider_subscription_id, payment_subscription.plan_name, payment_subscription.status, payment_subscription.current_period_start, payment_subscription.current_period_end, payment_subscription.cancel_at_period_end, payment_subscription.metadata, payment_subscription.created_at, payment_subscription.updated_at FROM payment_subscription WHERE payment_subscription.customer_id IN (__[POSTCOMPILE_customer_id_1]) ORDER BY payment_subscription.created_at DESC",
+      "file": "app/services/payment/service.py",
+      "function": "get_subscriptions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_transaction.id FROM payment_transaction WHERE payment_transaction.customer_id IN (__[POSTCOMPILE_customer_id_1])",
+      "file": "app/services/payment/service.py",
+      "function": "_transaction_ids_for_customers"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_transaction.id, payment_transaction.provider_id, payment_transaction.customer_id, payment_transaction.provider_transaction_id, payment_transaction.type, payment_transaction.status, payment_transaction.amount, payment_transaction.currency, payment_transaction.description, payment_transaction.metadata, payment_transaction.created_at, payment_transaction.updated_at FROM payment_transaction ORDER BY payment_transaction.created_at DESC LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/payment/service.py",
+      "function": "get_transactions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_transaction.id, payment_transaction.provider_id, payment_transaction.customer_id, payment_transaction.provider_transaction_id, payment_transaction.type, payment_transaction.status, payment_transaction.amount, payment_transaction.currency, payment_transaction.description, payment_transaction.metadata, payment_transaction.created_at, payment_transaction.updated_at FROM payment_transaction WHERE payment_transaction.customer_id IN (__[POSTCOMPILE_customer_id_1]) ORDER BY payment_transaction.created_at DESC LIMIT :param_1 OFFSET :param_2",
+      "file": "app/services/payment/service.py",
+      "function": "get_transactions"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_transaction.id, payment_transaction.provider_id, payment_transaction.customer_id, payment_transaction.provider_transaction_id, payment_transaction.type, payment_transaction.status, payment_transaction.amount, payment_transaction.currency, payment_transaction.description, payment_transaction.metadata, payment_transaction.created_at, payment_transaction.updated_at FROM payment_transaction WHERE payment_transaction.id = :id_1",
+      "file": "app/services/payment/service.py",
+      "function": "get_transaction_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_transaction.id, payment_transaction.provider_id, payment_transaction.customer_id, payment_transaction.provider_transaction_id, payment_transaction.type, payment_transaction.status, payment_transaction.amount, payment_transaction.currency, payment_transaction.description, payment_transaction.metadata, payment_transaction.created_at, payment_transaction.updated_at FROM payment_transaction WHERE payment_transaction.id = :id_1 AND payment_transaction.customer_id IN (__[POSTCOMPILE_customer_id_1])",
+      "file": "app/services/payment/service.py",
+      "function": "get_transaction_by_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_transaction.id, payment_transaction.provider_id, payment_transaction.customer_id, payment_transaction.provider_transaction_id, payment_transaction.type, payment_transaction.status, payment_transaction.amount, payment_transaction.currency, payment_transaction.description, payment_transaction.metadata, payment_transaction.created_at, payment_transaction.updated_at FROM payment_transaction WHERE payment_transaction.provider_transaction_id = :provider_transaction_id_1",
+      "file": "app/services/payment/service.py",
+      "function": "_find_transaction_by_charge_id"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT payment_transaction.id, payment_transaction.provider_id, payment_transaction.customer_id, payment_transaction.provider_transaction_id, payment_transaction.type, payment_transaction.status, payment_transaction.amount, payment_transaction.currency, payment_transaction.description, payment_transaction.metadata, payment_transaction.created_at, payment_transaction.updated_at FROM payment_transaction WHERE payment_transaction.provider_transaction_id = :provider_transaction_id_1",
+      "file": "app/services/payment/service.py",
+      "function": "_handle_checkout_completed"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT project.id, project.slug, project.name, project.owner_user_id, project.organization_id, project.github_owner, project.github_repo, project.github_token, project.pypi_package, project.plausible_site, project.plausible_api_key, project.reddit_subreddits, project.created_at, project.updated_at FROM project LIMIT :param_1",
+      "file": "tests/services/test_insight_service.py",
+      "function": "_ensure_project"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT project.id, project.slug, project.name, project.owner_user_id, project.organization_id, project.github_owner, project.github_repo, project.github_token, project.pypi_package, project.plausible_site, project.plausible_api_key, project.reddit_subreddits, project.created_at, project.updated_at FROM project LIMIT :param_1",
+      "file": "tests/services/test_query_service.py",
+      "function": "_ensure_project"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT project.id, project.slug, project.name, project.owner_user_id, project.organization_id, project.github_owner, project.github_repo, project.github_token, project.pypi_package, project.plausible_site, project.plausible_api_key, project.reddit_subreddits, project.created_at, project.updated_at FROM project WHERE project.slug = :slug_1 AND project.owner_user_id = :owner_user_id_1",
+      "file": "app/services/insights/queries/projects.py",
+      "function": "project_by_slug"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT refresh_token.token AS refresh_token_token, refresh_token.user_id AS refresh_token_user_id, refresh_token.family_id AS refresh_token_family_id, refresh_token.expires_at AS refresh_token_expires_at, refresh_token.revoked_at AS refresh_token_revoked_at, refresh_token.created_at AS refresh_token_created_at, refresh_token.source AS refresh_token_source, refresh_token.user_agent AS refresh_token_user_agent, refresh_token.ip AS refresh_token_ip, refresh_token.last_used_at AS refresh_token_last_used_at FROM refresh_token WHERE refresh_token.token = :pk_1",
+      "file": "app/components/backend/api/auth/router.py",
+      "function": "_current_session_family"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT refresh_token.token AS refresh_token_token, refresh_token.user_id AS refresh_token_user_id, refresh_token.family_id AS refresh_token_family_id, refresh_token.expires_at AS refresh_token_expires_at, refresh_token.revoked_at AS refresh_token_revoked_at, refresh_token.created_at AS refresh_token_created_at, refresh_token.source AS refresh_token_source, refresh_token.user_agent AS refresh_token_user_agent, refresh_token.ip AS refresh_token_ip, refresh_token.last_used_at AS refresh_token_last_used_at FROM refresh_token WHERE refresh_token.token = :pk_1",
+      "file": "app/services/auth/refresh_tokens.py",
+      "function": "revoke"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT refresh_token.token AS refresh_token_token, refresh_token.user_id AS refresh_token_user_id, refresh_token.family_id AS refresh_token_family_id, refresh_token.expires_at AS refresh_token_expires_at, refresh_token.revoked_at AS refresh_token_revoked_at, refresh_token.created_at AS refresh_token_created_at, refresh_token.source AS refresh_token_source, refresh_token.user_agent AS refresh_token_user_agent, refresh_token.ip AS refresh_token_ip, refresh_token.last_used_at AS refresh_token_last_used_at FROM refresh_token WHERE refresh_token.token = :pk_1",
+      "file": "app/services/auth/refresh_tokens.py",
+      "function": "rotate"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT refresh_token.token, refresh_token.user_id, refresh_token.family_id, refresh_token.expires_at, refresh_token.revoked_at, refresh_token.created_at, refresh_token.source, refresh_token.user_agent, refresh_token.ip, refresh_token.last_used_at FROM refresh_token WHERE refresh_token.user_id = :user_id_1 AND refresh_token.revoked_at IS NULL AND refresh_token.expires_at > :expires_at_1",
+      "file": "app/services/auth/refresh_tokens.py",
+      "function": "list_active_for_user"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT tool.name FROM tool",
+      "file": "app/services/ai/fixtures/agent_fixtures.py",
+      "function": "load_agent_fixtures"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1089.

## What ships to generated projects
- `queryspy>=0.4.1` in the dev extra, gated on `include_database`; never a runtime dep. Inert on a plain `pytest` run.
- `make check-queries` (+ poe twin): `pytest --queryspy-strict`, on demand.
- Three query fixes, each with a guard test using queryspy's own assertions:
  - `get_or_create_currency` memoizes per session in `Session.info`. Guarded by `cached in db`: provider sync wraps each connection in a SAVEPOINT, and a rollback expunges the instance. The sweep caught this (one bank failing made the healthy bank sync nothing); regression test opens a nested transaction and rolls it back.
  - `get_user_by_id` uses `Session.get()` so the identity map answers repeat reads within a request.
  - 41 `refresh()`-after-write calls removed (auth, insights, blog, ai). No model has a `server_default` and the session factory sets `expire_on_commit=False`, so each was a SELECT per created row for values already in memory.

## The gate (framework CI only)
`run_quality_checks` adds `--queryspy-strict --queryspy-baseline=tests/fixtures/queryspy-baseline.json` to the pytest step it already runs, when the stack ships queryspy. One baseline (364 entries) serves all 14 database stacks: entries key on `(kind, label, file, function)` with paths relative to the generated project, and a stale entry is reported, never enforced. Verified strict-with-baseline on `auth`, `finance` (2124 passed) and `everything` (2000 passed); an injected N+1 fails.

## What the sweep actually found
Across 14 stacks: 0 `lazy_load`, 27 `column_load`, 346 `repeated_statement`. Every app-code `column_load` was the `refresh()` pattern above and is fixed; the 18 that remain are tests deliberately re-reading a row a service updated. `tests/core/test_queryspy_adoption.py` ratchets app-code `column_load` at 0.

The `repeated_statement` residue is mostly not app bugs: the test fixture hands one `AsyncSession` to every request in a test, so two requests that each legitimately look up the same user read as one repeated statement, and the detector keys on SQL text without bound parameters, so `get(a)` + `get(b)` look identical. Switching the fixture to per-request sessions removed ~40% of findings but broke 44 tests; not worth it for a linter.