### PR TITLE
Refresh the query baseline after #1094; make regeneration one command

### DIFF
--- a/.github/workflows/stack-matrix.yml
+++ b/.github/workflows/stack-matrix.yml
@@ -20,6 +20,7 @@ on:
       - 'aegis/core/**'
       - 'aegis/cli/**'
       - 'tests/cli/**'
+      - 'tests/fixtures/queryspy-baseline.json'
       - 'pyproject.toml'
       - 'uv.lock'
       - '.github/workflows/stack-matrix.yml'

--- a/Makefile
+++ b/Makefile
@@ -293,6 +293,9 @@ test-stacks-runtime: ## Test all stacks runtime integration with Docker (future)
 	@echo "🐳 Runtime integration testing not yet implemented"
 	@echo "ℹ️  Will test Docker Compose startup and health checks for all combinations"
 
+queryspy-baseline: ## Regenerate the N+1 baseline for the stack matrix (STACKS=a,b to limit)
+	@STACKS="$(STACKS)" ./scripts/queryspy_baseline.sh
+
 test-stacks-full: ## Full stack matrix testing pipeline (comprehensive but slow)
 	@echo "🌟 Running complete stack matrix testing pipeline..."
 	@echo "📋 Phase 1: Stack Generation Testing"

--- a/scripts/queryspy_baseline.sh
+++ b/scripts/queryspy_baseline.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Regenerate tests/fixtures/queryspy-baseline.json: generate every database
+# stack from the working-tree templates, record its findings, merge.
+#
+# Entries key on (kind, label, file, function) with paths relative to the
+# generated project, so one file serves the whole matrix. The label of a
+# repeated_statement is the statement text, so a column added to a model
+# changes every entry for that table: after a schema change on a service,
+# run this or the matrix fails on entries that are only stale.
+#
+#   make queryspy-baseline               # all database stacks (~40 min)
+#   make queryspy-baseline STACKS=finance,finance_auth,everything
+set -u
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+OUT="${QUERYSPY_SWEEP_DIR:-$(mktemp -d /tmp/queryspy-sweep.XXXXXX)}"
+ONLY="${STACKS:-}"
+mkdir -p "$OUT/baselines"
+cd "$REPO" || exit 1
+
+uv run python - > "$OUT/stacks.txt" <<'PY'
+from tests.cli.test_stack_generation import STACK_COMBINATIONS as S
+for c in S:
+    print(f"{c.name}|{','.join(c.components or [])}|{','.join(c.services or [])}")
+PY
+
+while IFS='|' read -r name comps svcs; do
+  [ -z "$name" ] && continue
+  if [ -n "$ONLY" ] && ! grep -qx "$name" <<<"${ONLY//,/$'\n'}"; then continue; fi
+  slug="${name//_/-}"; proj="$OUT/$slug"; rm -rf "$proj"
+  args=(init "$slug" --dev --no-interactive --output-dir "$OUT")
+  [ -n "$comps" ] && args+=(-c "$comps")
+  [ -n "$svcs" ] && args+=(-s "$svcs")
+  yes | uv run aegis "${args[@]}" > "$OUT/$name.gen.log" 2>&1 || { echo "$name: GENERATE FAILED ($OUT/$name.gen.log)"; continue; }
+  grep -q queryspy "$proj/pyproject.toml" 2>/dev/null || { echo "$name: no database, skipped"; continue; }
+  ( cd "$proj" && uv sync --extra dev > "$OUT/$name.sync.log" 2>&1 ) || { echo "$name: SYNC FAILED"; continue; }
+  ( cd "$proj" && uv run pytest -q --queryspy-baseline="$OUT/baselines/$name.json" --queryspy-baseline-update > "$OUT/$name.qs.log" 2>&1 )
+  echo "$name: $(grep -oE '[0-9]+ (passed|failed)' "$OUT/$name.qs.log" | tr '\n' ' ')"
+done < "$OUT/stacks.txt"
+
+# Merge. With STACKS set, entries for stacks not regenerated are kept from
+# the current fixture so a partial run never drops another service's rows.
+uv run python - "$OUT/baselines" "$REPO/tests/fixtures/queryspy-baseline.json" "$ONLY" <<'PY'
+import json, sys, glob, pathlib
+src, dst, only = pathlib.Path(sys.argv[1]), pathlib.Path(sys.argv[2]), sys.argv[3]
+key = lambda e: (e["kind"], e["label"], e["file"], e["function"])
+merged = {}
+if only and dst.exists():
+    # Keep entries that cannot have come from a regenerated stack: every
+    # regenerated stack renders the same file paths, so drop the old rows
+    # whose file appears in any fresh baseline and keep the rest.
+    fresh_files = {e["file"] for f in glob.glob(f"{src}/*.json") for e in json.load(open(f))["entries"]}
+    for e in json.load(open(dst))["entries"]:
+        if e["file"] not in fresh_files:
+            merged[key(e)] = e
+for f in sorted(glob.glob(f"{src}/*.json")):
+    for e in json.load(open(f))["entries"]:
+        merged[key(e)] = e
+doc = {"tool": "queryspy", "version": "0.4.1",
+       "entries": sorted(merged.values(), key=lambda e: (e["kind"], e["label"], e["file"] or "", e["function"] or ""))}
+dst.write_text(json.dumps(doc, indent=2) + "\n")
+print(f"wrote {dst}: {len(doc['entries'])} entries")
+PY

--- a/tests/fixtures/queryspy-baseline.json
+++ b/tests/fixtures/queryspy-baseline.json
@@ -994,6 +994,30 @@
     },
     {
       "kind": "repeated_statement",
+      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias",
+      "file": "tests/services/test_finance_payee_aliases.py",
+      "function": "_stored"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias WHERE finance_merchant_alias.normalized_alias IN (__[POSTCOMPILE_normalized_alias_1]) AND finance_merchant_alias.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "merchant_aliases_by_normalized"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias WHERE finance_merchant_alias.normalized_alias IN (__[POSTCOMPILE_normalized_alias_1]) AND finance_merchant_alias.owner_user_id IS NULL",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "merchant_aliases_by_normalized"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias WHERE finance_merchant_alias.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "delete_merchant_aliases"
+    },
+    {
+      "kind": "repeated_statement",
       "label": "SELECT finance_net_worth_snapshot.id, finance_net_worth_snapshot.owner_user_id, finance_net_worth_snapshot.organization_id, finance_net_worth_snapshot.as_of_date, finance_net_worth_snapshot.total_assets_amount, finance_net_worth_snapshot.total_liabilities_amount, finance_net_worth_snapshot.net_worth_amount, finance_net_worth_snapshot.cash_amount, finance_net_worth_snapshot.investments_amount, finance_net_worth_snapshot.other_assets_amount, finance_net_worth_snapshot.currency, finance_net_worth_snapshot.breakdown, finance_net_worth_snapshot.is_estimated FROM finance_net_worth_snapshot",
       "file": "tests/services/test_finance_demo_seed.py",
       "function": "test_clear_repairs_the_net_worth_history"
@@ -1507,6 +1531,12 @@
       "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.logo_url, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.is_transfer IS false AND finance_transaction.amount < :amount_1 AND finance_transaction.category_id IS NOT NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
       "file": "app/services/finance/domains/planning/budgets/queries.py",
       "function": "categorized_outflow_history"
+    },
+    {
+      "kind": "repeated_statement",
+      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.logo_url, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.merchant_id IS NOT NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
+      "file": "app/services/finance/domains/ledger/queries/merchants.py",
+      "function": "named_transactions"
     },
     {
       "kind": "repeated_statement",
@@ -2185,48 +2215,6 @@
       "label": "SELECT tool.name FROM tool",
       "file": "app/services/ai/fixtures/agent_fixtures.py",
       "function": "load_agent_fixtures"
-    },
-    {
-      "kind": "repeated_statement",
-      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias WHERE finance_merchant_alias.normalized_alias IN (__[POSTCOMPILE_normalized_alias_1]) AND finance_merchant_alias.owner_user_id = :owner_user_id_1",
-      "file": "app/services/finance/domains/ledger/queries/merchants.py",
-      "function": "merchant_aliases_by_normalized"
-    },
-    {
-      "kind": "repeated_statement",
-      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias WHERE finance_merchant_alias.normalized_alias IN (__[POSTCOMPILE_normalized_alias_1]) AND finance_merchant_alias.owner_user_id IS NULL",
-      "file": "app/services/finance/domains/ledger/queries/merchants.py",
-      "function": "merchant_aliases_by_normalized"
-    },
-    {
-      "kind": "repeated_statement",
-      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias",
-      "file": "tests/services/test_finance_payee_aliases.py",
-      "function": "_stored"
-    },
-    {
-      "kind": "repeated_statement",
-      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.logo_url, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.merchant_id IS NOT NULL AND finance_transaction.owner_user_id = :owner_user_id_1",
-      "file": "app/services/finance/domains/ledger/queries/merchants.py",
-      "function": "named_transactions"
-    },
-    {
-      "kind": "repeated_statement",
-      "label": "SELECT finance_transaction.id, finance_transaction.owner_user_id, finance_transaction.organization_id, finance_transaction.account_id, finance_transaction.connection_id, finance_transaction.import_batch_id, finance_transaction.source, finance_transaction.external_id, finance_transaction.external_id_source, finance_transaction.import_hash, finance_transaction.within_day_ordinal, finance_transaction.dedup_status, finance_transaction.canonical_transaction_id, finance_transaction.source_precedence, finance_transaction.amount, finance_transaction.raw_amount, finance_transaction.raw_sign_convention, finance_transaction.currency, finance_transaction.unofficial_currency_code, finance_transaction.date, finance_transaction.authorized_date, finance_transaction.datetime, finance_transaction.name, finance_transaction.original_description, finance_transaction.merchant_id, finance_transaction.merchant_name, finance_transaction.logo_url, finance_transaction.merchant_entity_id, finance_transaction.memo, finance_transaction.check_number, finance_transaction.payment_channel, finance_transaction.pfc_primary, finance_transaction.pfc_detailed, finance_transaction.pfc_confidence_level, finance_transaction.category_id, finance_transaction.category_source, finance_transaction.is_user_categorized, finance_transaction.is_reviewed, finance_transaction.pending, finance_transaction.pending_provider_id, finance_transaction.pending_transaction_id, finance_transaction.status, finance_transaction.is_transfer, finance_transaction.transfer_group_id, finance_transaction.transfer_pair_transaction_id, finance_transaction.is_split, finance_transaction.excluded_from_reports, finance_transaction.is_reversal, finance_transaction.reverses_transaction_id, finance_transaction.recurring_stream_id, finance_transaction.reconciled_status, finance_transaction.location, finance_transaction.counterparties, finance_transaction.raw_payload, finance_transaction.is_removed, finance_transaction.removed_at, finance_transaction.deleted_at, finance_transaction.metadata, finance_transaction.created_at, finance_transaction.updated_at FROM finance_transaction WHERE finance_transaction.deleted_at IS NULL AND finance_transaction.merchant_id IS NOT NULL",
-      "file": "app/services/finance/domains/ledger/queries/merchants.py",
-      "function": "named_transactions"
-    },
-    {
-      "kind": "repeated_statement",
-      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias WHERE finance_merchant_alias.owner_user_id = :owner_user_id_1",
-      "file": "app/services/finance/domains/ledger/queries/merchants.py",
-      "function": "delete_merchant_aliases"
-    },
-    {
-      "kind": "repeated_statement",
-      "label": "SELECT finance_merchant_alias.id, finance_merchant_alias.owner_user_id, finance_merchant_alias.merchant_id, finance_merchant_alias.alias_text, finance_merchant_alias.normalized_alias, finance_merchant_alias.is_ambiguous, finance_merchant_alias.source, finance_merchant_alias.created_at, finance_merchant_alias.updated_at FROM finance_merchant_alias WHERE finance_merchant_alias.owner_user_id IS NULL",
-      "file": "app/services/finance/domains/ledger/queries/merchants.py",
-      "function": "delete_merchant_aliases"
     }
   ]
 }


### PR DESCRIPTION
The stack matrix on main will fail `validate (finance)` at its next scheduled run: #1094 added columns to finance models, a `repeated_statement` baseline entry is keyed on the statement text, so 334 entries for those tables no longer match and read as new findings.

- `tests/fixtures/queryspy-baseline.json` regenerated for `finance`, `finance_auth`, `everything` from merged main (369 entries, still 0 app-code `column_load`). Verified strict-with-baseline: finance 2160 passed, everything 2003 passed.
- The one new finding, `merchant_aliases_by_normalized` 39x, is `demo_seed.py` naming payees one row at a time, the loop already baselined for its sibling helpers; recorded with them rather than refactoring the seeder here.
- `scripts/queryspy_baseline.sh` + `make queryspy-baseline [STACKS=a,b]` so the next schema change on a service is one command. A partial run keeps other services' entries.

Known cost of the design, now documented in the script header: a model column change on a service invalidates that service's entries and needs a regen.