### PR TITLE
Add deploy-exec: run a one-off command on a deployment, scriptably

### DIFF
--- a/aegis/__main__.py
+++ b/aegis/__main__.py
@@ -20,6 +20,7 @@ from .commands.deploy import (
     deploy_backups_command,
     deploy_cd_setup_command,
     deploy_command,
+    deploy_exec_command,
     deploy_init_command,
     deploy_logs_command,
     deploy_restart_command,
@@ -152,6 +153,10 @@ app.command(name="deploy-status")(deploy_status_command)
 app.command(name="deploy-stop")(deploy_stop_command)
 app.command(name="deploy-restart")(deploy_restart_command)
 app.command(name="deploy-shell")(deploy_shell_command)
+app.command(
+    name="deploy-exec",
+    context_settings={"allow_interspersed_args": False},
+)(deploy_exec_command)
 
 
 # R5: mount plugin-provided sub-apps under `aegis <plugin> ...`.

--- a/aegis/commands/deploy.py
+++ b/aegis/commands/deploy.py
@@ -1566,6 +1566,57 @@ def deploy_shell_command(
     )
 
 
+def deploy_exec_command(
+    command: list[str] = typer.Argument(
+        ..., help=lazy_t("deploy.help_arg_exec_command"), metavar="-- COMMAND..."
+    ),
+    service: str = typer.Option(
+        "webserver", "--service", "-s", help=lazy_t("deploy.help_opt_shell_service")
+    ),
+    project_path: str | None = typer.Option(
+        None, "--project-path", help=lazy_t("common.help_project_path")
+    ),
+) -> None:
+    """
+    Run a one-off command in a deployed container, non-interactively.
+
+    The scriptable sibling of ``deploy-shell``: streams output live and
+    exits with the command's own status, so it composes with ``set -e``
+    and CI. Put ``--`` before the command so its flags are not parsed as
+    this CLI's.
+
+    Examples:\\n
+        - aegis deploy-exec -- alembic current\\n
+        - aegis deploy-exec --service worker-system -- myapp jobs list\\n
+    """
+    config = _load_deploy_config(project_path)
+    if not config:
+        brand.error(t("deploy.no_config"), err=True)
+        raise typer.Exit(1)
+
+    if not command:
+        brand.error(t("deploy.exec_no_command"), err=True)
+        raise typer.Exit(1)
+
+    host = config["server"]["host"]
+    user = config["server"]["user"]
+    deploy_path = config["server"]["path"]
+
+    # -T: no TTY. The point of this command is to be pipeable and
+    # scriptable, and a TTY would corrupt piped output. Each argument is
+    # quoted individually so a command containing spaces, quotes or globs
+    # reaches the container exactly as typed.
+    remote = (
+        f"{_compose_prefix(deploy_path)} exec -T {shlex.quote(service)} "
+        + " ".join(shlex.quote(part) for part in command)
+    )
+    # No capture: stdout/stderr stream straight through to the caller.
+    result = subprocess.run(["ssh", f"{user}@{host}", remote])
+    # Propagate rather than swallow, so `set -e` and CI see the failure.
+    if result.returncode != 0:
+        raise typer.Exit(result.returncode)
+
+
 # ─────────────────────────── deploy-cd-setup ───────────────────────────
 
 

--- a/aegis/i18n/locales/de.py
+++ b/aegis/i18n/locales/de.py
@@ -953,6 +953,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "Logausgabe live mitlesen",
     "deploy.help_opt_logs_service": "Logs nur für einen bestimmten Service anzeigen",
     "deploy.help_opt_shell_service": "Service, mit dem die Verbindung hergestellt wird",
+    "deploy.help_arg_exec_command": "Befehl, der im Container ausgeführt wird (nach --).",
+    "deploy.exec_no_command": "Kein Befehl angegeben. Nach -- schreiben, z. B.: aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "GitHub-Repo als owner/name (Standardwert: automatisch aus git remote origin)",
     "deploy.help_opt_gh_tags": "Deploy-Workflow auch bei Push auf v*-Tags auslösen",
     "deploy.help_opt_gh_overwrite": "Vorhandene GitHub-Secrets und deploy.yml-Workflow überschreiben",

--- a/aegis/i18n/locales/en.py
+++ b/aegis/i18n/locales/en.py
@@ -998,6 +998,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "Follow log output",
     "deploy.help_opt_logs_service": "Show logs for specific service",
     "deploy.help_opt_shell_service": "Service to connect to",
+    "deploy.help_arg_exec_command": "Command to run inside the container (after --).",
+    "deploy.exec_no_command": "No command given. Put it after --, e.g. aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": (
         "GitHub repo as owner/name (default: auto-detect from git remote origin)"
     ),

--- a/aegis/i18n/locales/es.py
+++ b/aegis/i18n/locales/es.py
@@ -957,6 +957,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "Seguir la salida de los logs en tiempo real",
     "deploy.help_opt_logs_service": "Mostrar los logs de un servicio en concreto",
     "deploy.help_opt_shell_service": "Servicio al que conectarse",
+    "deploy.help_arg_exec_command": "Comando a ejecutar dentro del contenedor (después de --).",
+    "deploy.exec_no_command": "No se indicó ningún comando. Escríbelo después de --, p. ej.: aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "Repositorio de GitHub como owner/name (por defecto: detectar automáticamente desde git remote origin)",
     "deploy.help_opt_gh_tags": "Disparar también el workflow de despliegue al hacer push de tags v*",
     "deploy.help_opt_gh_overwrite": "Sobrescribir los secretos de GitHub y el workflow deploy.yml existentes",

--- a/aegis/i18n/locales/fr.py
+++ b/aegis/i18n/locales/fr.py
@@ -958,6 +958,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "Suivre la sortie des logs en continu",
     "deploy.help_opt_logs_service": "Afficher uniquement les logs d'un service donné",
     "deploy.help_opt_shell_service": "Service auquel se connecter",
+    "deploy.help_arg_exec_command": "Commande à exécuter dans le conteneur (après --).",
+    "deploy.exec_no_command": "Aucune commande fournie. Placez-la après --, par exemple : aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "Dépôt GitHub au format owner/name (par défaut : détection auto depuis git remote origin)",
     "deploy.help_opt_gh_tags": "Déclencher aussi le workflow de déploiement lors des push sur les tags v*",
     "deploy.help_opt_gh_overwrite": "Écraser les secrets GitHub et le workflow deploy.yml existants",

--- a/aegis/i18n/locales/ja.py
+++ b/aegis/i18n/locales/ja.py
@@ -938,6 +938,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "ログ出力を継続して表示",
     "deploy.help_opt_logs_service": "指定したサービスのログのみ表示",
     "deploy.help_opt_shell_service": "接続先のサービス",
+    "deploy.help_arg_exec_command": "コンテナ内で実行するコマンド（-- の後に記述）。",
+    "deploy.exec_no_command": "コマンドが指定されていません。-- の後に記述してください。例: aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "GitHub リポジトリ（owner/name 形式。デフォルト：git remote origin から自動検出）",
     "deploy.help_opt_gh_tags": "v* タグへの push 時もデプロイワークフローを起動",
     "deploy.help_opt_gh_overwrite": "既存の GitHub Secrets と deploy.yml ワークフローを上書き",

--- a/aegis/i18n/locales/ko.py
+++ b/aegis/i18n/locales/ko.py
@@ -903,6 +903,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "로그 출력을 계속 따라가며 표시",
     "deploy.help_opt_logs_service": "특정 서비스의 로그만 표시",
     "deploy.help_opt_shell_service": "접속할 서비스",
+    "deploy.help_arg_exec_command": "컨테이너 안에서 실행할 명령 (-- 뒤에 작성).",
+    "deploy.exec_no_command": "명령이 없습니다. -- 뒤에 작성하세요. 예: aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "GitHub 저장소 (owner/name 형식, 기본값: git remote origin에서 자동 감지)",
     "deploy.help_opt_gh_tags": "v* 태그 푸시 시에도 배포 워크플로 실행",
     "deploy.help_opt_gh_overwrite": "기존 GitHub Secrets와 deploy.yml 워크플로 덮어쓰기",

--- a/aegis/i18n/locales/ru.py
+++ b/aegis/i18n/locales/ru.py
@@ -920,6 +920,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "Следить за выводом логов в реальном времени",
     "deploy.help_opt_logs_service": "Показать логи только для указанного сервиса",
     "deploy.help_opt_shell_service": "Сервис, к которому подключиться",
+    "deploy.help_arg_exec_command": "Команда для выполнения внутри контейнера (после --).",
+    "deploy.exec_no_command": "Команда не указана. Укажите её после --, например: aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "Репозиторий GitHub в формате owner/name (по умолчанию: автоопределение из git remote origin)",
     "deploy.help_opt_gh_tags": "Запускать workflow деплоя также при push в теги v*",
     "deploy.help_opt_gh_overwrite": "Перезаписать существующие GitHub Secrets и workflow deploy.yml",

--- a/aegis/i18n/locales/zh.py
+++ b/aegis/i18n/locales/zh.py
@@ -790,6 +790,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "持续跟踪日志输出",
     "deploy.help_opt_logs_service": "仅显示指定服务的日志",
     "deploy.help_opt_shell_service": "要连接的服务",
+    "deploy.help_arg_exec_command": "在容器内运行的命令（放在 -- 之后）。",
+    "deploy.exec_no_command": "未提供命令。请写在 -- 之后，例如：aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "GitHub 仓库，格式为 owner/name（默认：从 git remote origin 自动识别）",
     "deploy.help_opt_gh_tags": "推送 v* 标签时也触发部署工作流",
     "deploy.help_opt_gh_overwrite": "覆盖已有的 GitHub secrets 和 deploy.yml 工作流",

--- a/aegis/i18n/locales/zh_hant.py
+++ b/aegis/i18n/locales/zh_hant.py
@@ -790,6 +790,8 @@ MESSAGES: dict[str, str] = {
     "deploy.help_opt_logs_follow": "持續追蹤日誌輸出",
     "deploy.help_opt_logs_service": "僅顯示指定服務的日誌",
     "deploy.help_opt_shell_service": "要連線的服務",
+    "deploy.help_arg_exec_command": "在容器內執行的指令（放在 -- 之後）。",
+    "deploy.exec_no_command": "未提供指令。請寫在 -- 之後，例如：aegis deploy-exec -- alembic current",
     "deploy.help_opt_gh_repo": "GitHub 儲存庫,格式為 owner/name(預設值：從 git remote origin 自動偵測)",
     "deploy.help_opt_gh_tags": "推送 v* 標籤時也觸發部署工作流程",
     "deploy.help_opt_gh_overwrite": "覆寫既有的 GitHub Secrets 與 deploy.yml 工作流程",

--- a/tests/cli/test_deploy_helpers.py
+++ b/tests/cli/test_deploy_helpers.py
@@ -15,6 +15,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
+import typer
 import yaml
 
 from aegis.commands import deploy as deploy_mod
@@ -279,3 +280,81 @@ def test_rollback_skips_db_restore_for_neon(
     assert ok is True
     assert not any("psql" in c for c in calls), "neon rollback must not run psql"
     assert not any("db_backup.sql" in c for c in calls)
+
+
+class TestDeployExec:
+    """``deploy-exec`` is the scriptable sibling of ``deploy-shell``: its
+    whole value is that callers stop hand-assembling the compose-file
+    chain (omitting it silently drops the prod overrides) and that a
+    failing remote command fails the local one."""
+
+    @staticmethod
+    def _capture(monkeypatch: pytest.MonkeyPatch, returncode: int = 0) -> dict:
+        seen: dict = {}
+
+        def fake_run(argv, *args, **kwargs):
+            seen["argv"] = argv
+            seen["captured"] = bool(kwargs.get("capture_output"))
+            return subprocess.CompletedProcess(argv, returncode)
+
+        monkeypatch.setattr(deploy_mod.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            deploy_mod,
+            "_load_deploy_config",
+            lambda _p: {
+                "server": {"host": "h", "user": "u", "path": "/opt/app"},
+            },
+        )
+        return seen
+
+    def test_sends_the_full_prod_compose_chain(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = self._capture(monkeypatch)
+        deploy_mod.deploy_exec_command(
+            command=["alembic", "current"], service="webserver"
+        )
+
+        remote = seen["argv"][-1]
+        assert "docker-compose.yml" in remote
+        assert "docker-compose.prod.yml" in remote
+        assert "--profile prod" in remote
+        # -T, not a TTY: output has to stay pipeable.
+        assert "exec -T webserver" in remote
+        assert remote.endswith("alembic current")
+
+    def test_quotes_each_argument(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An argument with spaces must arrive as one argument, not several."""
+        seen = self._capture(monkeypatch)
+        deploy_mod.deploy_exec_command(
+            command=["echo", "two words"], service="webserver"
+        )
+
+        assert "'two words'" in seen["argv"][-1]
+
+    def test_streams_rather_than_captures(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen = self._capture(monkeypatch)
+        deploy_mod.deploy_exec_command(command=["ls"], service="webserver")
+
+        assert seen["captured"] is False
+
+    def test_propagates_the_remote_exit_code(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without this, a failed migration would look like a success to
+        ``set -e`` and to CI."""
+        self._capture(monkeypatch, returncode=3)
+        with pytest.raises(typer.Exit) as exc:
+            deploy_mod.deploy_exec_command(command=["false"], service="webserver")
+        assert exc.value.exit_code == 3
+
+    def test_success_does_not_raise(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._capture(monkeypatch, returncode=0)
+        deploy_mod.deploy_exec_command(command=["true"], service="webserver")
+
+    def test_rejects_an_empty_command(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        self._capture(monkeypatch)
+        with pytest.raises(typer.Exit):
+            deploy_mod.deploy_exec_command(command=[], service="webserver")


### PR DESCRIPTION
Closes lbedner/aegis-pulse#72.

## The problem isn't verbosity

`deploy-shell` opens an interactive shell, so it can't be piped, put in a runbook, or run from CI. The alternative was hand-writing the whole remote invocation:

```bash
ssh user@host 'cd /opt/app && docker compose \
  -f docker-compose.yml -f docker-compose.prod.yml --profile prod \
  exec -T webserver <cmd>'
```

Forget the compose-file chain and the command runs against a container assembled **without the prod overrides** — the same footgun the deploy paths already take care to avoid. Every ad-hoc operator command was a chance to get it wrong by hand. That's the actual cost, not the typing.

## The command

```bash
aegis deploy-exec -- alembic current
aegis deploy-exec --service worker-system -- myapp jobs list
```

Reads host, path and compose chain from `.aegis/deploy.yml`, like every other deploy verb.

Details that matter:

- **`exec -T`**, not a TTY — the point is pipeable output.
- **Each argument shell-quoted individually**, so spaces and globs survive the trip as one argument.
- **Streams rather than captures**, so long-running commands show progress.
- **Re-raises the remote exit code.** Without it a failed migration looks like success to `set -e` and CI.
- **`allow_interspersed_args=False`**, so flags after `--` belong to the remote command rather than being parsed by this CLI.

## Tests

6 covering what would actually break: the full prod compose chain is present, `-T` is used, arguments with spaces stay single arguments, output isn't captured, a non-zero remote status propagates, and an empty command is rejected.

70 pass across deploy helpers, i18n parity and the module budget; 27 more across CLI wiring. New i18n keys added to all 9 locales.

## Note

Filed against aegis-pulse but implemented here — the ticket asks for `uvx aegis-stack deploy-exec`, and `deploy-shell` lives in this repo.
