### PR TITLE
A provider is described once, and OpenRouter is one of them

### DIFF
--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/config.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/config.py
@@ -10,6 +10,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from .models import (
+    PROVIDERS,
     AIProvider,
     ProviderConfig,
     get_provider_capabilities,
@@ -63,13 +64,11 @@ def _resolve_effort(value: object) -> str | None:
 
 # The settings field / environment variable each keyed provider reads its
 # API key from. Providers absent here need no key from settings.
+# Where each provider's key lives, from the one place a provider is
+# described. It was a map of its own; a provider named here and nowhere
+# else would have gone unnoticed until somebody selected it.
 API_KEY_ENV: dict[AIProvider, str] = {
-    AIProvider.OPENAI: "OPENAI_API_KEY",
-    AIProvider.ANTHROPIC: "ANTHROPIC_API_KEY",
-    AIProvider.GOOGLE: "GOOGLE_API_KEY",
-    AIProvider.GROQ: "GROQ_API_KEY",
-    AIProvider.MISTRAL: "MISTRAL_API_KEY",
-    AIProvider.COHERE: "COHERE_API_KEY",
+    p: spec.env_var for p, spec in PROVIDERS.items()
 }
 
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/llm/provider_management.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/llm/provider_management.py
@@ -11,45 +11,28 @@ from pathlib import Path
 import subprocess
 import sys
 
-from app.services.ai.models import AIProvider
+from app.services.ai.models import PROVIDERS, AIProvider
 
 # Provider to pydantic-ai-slim extras mapping
 # Note: mistral, cohere, ollama, public, and pollinations use the
 # OpenAI-compatible API
+# These three were maps of their own, keyed by provider name, and a test
+# had to police each for completeness because nothing else would notice a
+# gap. They are views over the one registry now: a provider describes
+# itself once, and adding one cannot leave them behind.
 PROVIDER_DEPENDENCIES: dict[str, str] = {
-    "openai": "pydantic-ai-slim[openai]",
-    "anthropic": "pydantic-ai-slim[anthropic]",
-    "google": "pydantic-ai-slim[google]",
-    "groq": "pydantic-ai-slim[groq]",
-    "mistral": "pydantic-ai-slim[openai]",
-    "cohere": "pydantic-ai-slim[openai]",
-    "ollama": "pydantic-ai-slim[openai]",
-    "public": "pydantic-ai-slim[openai]",
-    "pollinations": "pydantic-ai-slim[openai]",
+    p.value: spec.dependency for p, spec in PROVIDERS.items()
 }
 
-# Actual SDK packages to check for each provider
-# These are the real provider SDKs, not the pydantic-ai wrappers
+# The SDK module whose presence proves the dependency is installed.
 PROVIDER_MODULE_CHECKS: dict[str, str] = {
-    "openai": "openai",
-    "anthropic": "anthropic",
-    "google": "google.genai",  # google-genai package
-    "groq": "groq",
-    "mistral": "openai",  # Uses OpenAI-compatible API
-    "cohere": "openai",  # Uses OpenAI-compatible API
-    "ollama": "openai",  # Uses OpenAI-compatible API
-    "public": "openai",  # Uses OpenAI-compatible API
-    "pollinations": "openai",  # Uses OpenAI-compatible API
+    p.value: spec.module for p, spec in PROVIDERS.items()
 }
 
-# API key documentation URLs for user guidance
+# Where a person goes to get a key. Absent for the keyless endpoints and
+# for a local server, which is what "paid provider" means here.
 PROVIDER_API_KEY_URLS: dict[str, str] = {
-    "openai": "https://platform.openai.com/api-keys",
-    "anthropic": "https://console.anthropic.com/",
-    "google": "https://aistudio.google.com/app/apikey",
-    "groq": "https://console.groq.com/keys",
-    "mistral": "https://console.mistral.ai/api-keys/",
-    "cohere": "https://dashboard.cohere.com/api-keys",
+    p.value: spec.key_url for p, spec in PROVIDERS.items() if spec.key_url
 }
 
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/llm/providers.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/domains/llm/providers.py.jinja
@@ -12,7 +12,7 @@ from typing import Any
 
 from app.core.log import logger
 from app.services.ai.config import AIServiceConfig, api_key_env
-from app.services.ai.models import AIProvider
+from app.services.ai.models import PROVIDERS, AIProvider
 {% if ai_framework == "pydantic-ai" %}
 {#- The ``openai`` package + pydantic-ai's OpenAI model ship only with the
     openai extra, which is installed only for OpenAI-compatible providers.
@@ -21,6 +21,7 @@ from app.services.ai.models import AIProvider
 {%- set _has_openai = "openai" in ai_providers or "public" in ai_providers or "pollinations" in ai_providers or "openrouter" in ai_providers or "ollama" in ai_providers or "mistral" in ai_providers or "cohere" in ai_providers %}
 
 import json
+import importlib
 import os
 from collections.abc import Sequence
 
@@ -50,17 +51,9 @@ class ProviderNotInstalledError(ProviderError):
         super().__init__(f"{provider} provider is not installed")
 
 
-SUPPORTED_PROVIDERS: tuple[AIProvider, ...] = (
-    AIProvider.OPENAI,
-    AIProvider.ANTHROPIC,
-    AIProvider.GOOGLE,
-    AIProvider.GROQ,
-    AIProvider.MISTRAL,
-    AIProvider.COHERE,
-    AIProvider.OLLAMA,
-    AIProvider.PUBLIC,
-    AIProvider.POLLINATIONS,
-)
+# Every provider the registry describes. A tuple of its own could fall
+# behind the enum; this cannot.
+SUPPORTED_PROVIDERS: tuple[AIProvider, ...] = tuple(PROVIDERS)
 
 # Where a free key comes from, for the providers that hand them out.
 _FREE_KEY_HINTS: dict[AIProvider, str] = {
@@ -117,49 +110,17 @@ OpenAIProvider: Any = None
 
 # Lazy loading of provider model classes to avoid import errors
 def _get_model_class(provider: AIProvider):
-    """Get model class for provider with lazy import to avoid dependency issues."""
-    if provider == AIProvider.OPENAI:
-        # The Responses API, not Chat Completions: OpenAI's reasoning
-        # models (gpt-5.x, o-series) reject function tools on
-        # /v1/chat/completions ("use /v1/responses"), and pydantic-ai's
-        # Responses model speaks tools + streaming for the whole lineup.
-        from pydantic_ai.models.openai import OpenAIResponsesModel
+    """The pydantic-ai model class for a provider, imported lazily.
 
-        return OpenAIResponsesModel
-    elif provider == AIProvider.ANTHROPIC:
-        from pydantic_ai.models.anthropic import AnthropicModel
-
-        return AnthropicModel
-    elif provider == AIProvider.GOOGLE:
-        from pydantic_ai.models.google import GoogleModel
-
-        return GoogleModel
-    elif provider == AIProvider.GROQ:
-        from pydantic_ai.models.groq import GroqModel
-
-        return GroqModel
-    elif provider == AIProvider.MISTRAL:
-        from pydantic_ai.models.openai import OpenAIChatModel
-
-        return OpenAIChatModel  # Mistral uses OpenAI-compatible API
-    elif provider == AIProvider.COHERE:
-        from pydantic_ai.models.openai import OpenAIChatModel
-
-        return OpenAIChatModel  # Cohere can use OpenAI-compatible interface
-    elif provider == AIProvider.OLLAMA:
-        from pydantic_ai.models.openai import OpenAIChatModel
-
-        return OpenAIChatModel  # Ollama uses OpenAI-compatible API
-    elif provider == AIProvider.PUBLIC:
-        from pydantic_ai.models.openai import OpenAIChatModel
-
-        return OpenAIChatModel  # Public endpoints use OpenAI-compatible API
-    elif provider == AIProvider.POLLINATIONS:
-        from pydantic_ai.models.openai import OpenAIChatModel
-
-        return OpenAIChatModel  # Pollinations uses OpenAI-compatible API
-    else:
+    Lazily because a provider nobody selected must not drag its SDK in;
+    from the registry because the class is a FACT about the provider and
+    belongs beside the rest of them.
+    """
+    spec = PROVIDERS.get(provider)
+    if spec is None or spec.model is None:
         raise ProviderError(f"Unsupported provider: {provider}")
+    module = importlib.import_module(spec.model[0])
+    return getattr(module, spec.model[1])
 
 
 def _supports_custom_temperature(model: str | None) -> bool:
@@ -243,12 +204,38 @@ def model_for(config: AIServiceConfig, settings: Any) -> tuple[Any, str]:
     # PydanticAI 1.0+ reads credentials from the environment, not kwargs.
     os.environ[api_key_env(config.provider)] = require_api_key(config, settings)
 
-    model_kwargs: dict[str, Any] = {"model_name": config.model}
-    if config.provider == AIProvider.MISTRAL:
-        model_kwargs["base_url"] = "https://api.mistral.ai/v1"
-    elif config.provider == AIProvider.COHERE:
-        model_kwargs["base_url"] = "https://api.cohere.ai/v1"
-    return _get_model_class(config.provider)(**model_kwargs), config.model
+    # An OpenAI-compatible provider is a base URL and a key, and the URL
+    # is the only thing distinguishing Mistral, Cohere and OpenRouter
+    # from OpenAI itself - so it rides the registry and they share a path.
+    #
+    # That path builds a client. ``OpenAIChatModel`` takes no
+    # ``base_url``: passing one raises TypeError, which is what these two
+    # branches did the moment anybody selected them.
+    spec = PROVIDERS.get(config.provider)
+    if spec is not None and spec.base_url:
+        key = config.get_provider_config(settings).api_key
+        return _openai_compatible(config.model, spec.base_url, key), config.model
+    return _get_model_class(config.provider)(model_name=config.model), config.model
+
+
+def _openai_compatible(
+    model_name: str, base_url: str, api_key: str | None, profile: Any = None
+) -> Any:
+    """A model on any server that speaks the OpenAI API.
+
+    One client, pointed elsewhere. The key goes to the CLIENT rather than
+    into ``OPENAI_API_KEY``, so a stack holding both a real OpenAI key
+    and an aggregator's keeps them apart - stamping the environment would
+    let whichever was built last answer for both.
+    """
+    from pydantic_ai.models.openai import OpenAIChatModel
+    from pydantic_ai.providers.openai import OpenAIProvider
+
+    client = AsyncOpenAI(api_key=api_key or "none", base_url=base_url)
+    kwargs: dict[str, Any] = {"provider": OpenAIProvider(openai_client=client)}
+    if profile is not None:
+        kwargs["profile"] = profile
+    return OpenAIChatModel(model_name, **kwargs)
 
 
 def _grant_kwargs(
@@ -698,6 +685,13 @@ def get_llm(config: AIServiceConfig, settings: Any):
             return _create_public_llm(config)
         if provider == AIProvider.POLLINATIONS:
             return _create_pollinations_llm(config)
+        # Anything the registry gives a base URL and that has no vendor
+        # package of its own: an OpenAI-compatible server, reached with
+        # LangChain's OpenAI client pointed elsewhere. Checked AFTER the
+        # keyed table, so Mistral and Cohere keep their native clients.
+        spec = PROVIDERS.get(provider)
+        if spec is not None and spec.base_url:
+            return _create_openai_compatible_llm(config, settings, spec.base_url)
         raise ProviderError(f"Unsupported provider: {provider}")
 
     except ImportError as e:
@@ -725,6 +719,29 @@ def _create_keyed_llm(config: AIServiceConfig, settings: Any):
         max_tokens=config.max_tokens,
         timeout=config.timeout_seconds,
         **{key_kwarg: require_api_key(config, settings)},
+    )
+
+
+def _create_openai_compatible_llm(
+    config: AIServiceConfig, settings: Any, base_url: str
+):
+    """A chat model on any server that speaks the OpenAI API.
+
+    The same trick ``_create_ollama_llm`` uses, with a real key: the
+    OpenAI client is not tied to api.openai.com, so an aggregator like
+    OpenRouter needs no package of its own. The key goes to the CLIENT,
+    never into ``OPENAI_API_KEY``, so a stack holding both keeps them
+    apart.
+    """
+    from langchain_openai import ChatOpenAI
+
+    return ChatOpenAI(
+        model=config.model,
+        temperature=config.temperature,
+        max_tokens=config.max_tokens,
+        api_key=require_api_key(config, settings),
+        base_url=base_url,
+        timeout=config.timeout_seconds,
     )
 
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/models/__init__.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/ai/models/__init__.py.jinja
@@ -9,6 +9,8 @@ from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 
+from dataclasses import dataclass
+
 from pydantic import BaseModel, Field
 {% if ai_backend != "memory" %}
 
@@ -39,6 +41,7 @@ class AIProvider(str, Enum):
     OLLAMA = "ollama"  # Local LLM inference via Ollama
     PUBLIC = "public"  # LLM7.io: keyless anonymous tier; key unlocks premium
     POLLINATIONS = "pollinations"  # Pollinations: keyless anonymous tier
+    OPENROUTER = "openrouter"  # Aggregator; speaks the OpenAI API
 
     @classmethod
     def from_name(cls, value: object) -> "AIProvider | None":
@@ -267,6 +270,141 @@ PROVIDER_CAPABILITIES = {
         supports_function_calling=False,
         supports_vision=False,
         free_tier_available=True,  # Anonymous tier (open-weight models)
+    ),
+    AIProvider.OPENROUTER: ProviderCapabilities(
+        provider=AIProvider.OPENROUTER,
+        supports_streaming=True,
+        supports_function_calling=True,
+        # Depends on the model it routes to, not on OpenRouter: the
+        # aggregator itself passes vision through.
+        supports_vision=True,
+        free_tier_available=False,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ProviderSpec:
+    """Everything about one provider, in one place.
+
+    This used to be six: the enum, the capabilities table, an API-key
+    lookup in ``config``, a model-class if/elif, and two byte-identical
+    env-var maps. Adding a provider meant five edits across three files,
+    and missing one failed quietly at the point of use.
+
+    It stays in CODE rather than a table because this stack runs its AI
+    on a memory backend with no database; what a provider is has to be
+    knowable before any storage exists.
+
+    ``model`` is a lazy ``(module, class)`` pair: the SDK for a provider
+    nobody selected must not be imported, let alone required.
+    ``base_url`` marks the OpenAI-compatible ones - they need no class of
+    their own, only somewhere else to point.
+    """
+
+    env_var: str
+    capabilities: ProviderCapabilities
+    model: tuple[str, str] | None = None
+    base_url: str | None = None
+    # What to install for it, and the module whose presence proves it is
+    # installed. Most ride the OpenAI SDK, because most speak its API.
+    dependency: str = "pydantic-ai-slim[openai]"
+    module: str = "openai"
+    # Where a person goes to get a key; None for the keyless endpoints
+    # and for a local server.
+    key_url: str | None = None
+    # Cannot be built by a plain constructor call: a keyless endpoint, or
+    # a local server whose address comes from settings. It still has a
+    # model class - ``get_agent`` uses it - but ``model_for`` refuses.
+    builds_own_client: bool = False
+
+
+_OPENAI_CHAT = ("pydantic_ai.models.openai", "OpenAIChatModel")
+
+PROVIDERS: dict[AIProvider, ProviderSpec] = {
+    AIProvider.OPENAI: ProviderSpec(
+        env_var="OPENAI_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.OPENAI],
+        # The Responses API, not Chat Completions: OpenAI's reasoning
+        # models reject function tools on /v1/chat/completions.
+        model=("pydantic_ai.models.openai", "OpenAIResponsesModel"),
+        dependency="pydantic-ai-slim[openai]",
+        module="openai",
+        key_url="https://platform.openai.com/api-keys",
+    ),
+    AIProvider.ANTHROPIC: ProviderSpec(
+        env_var="ANTHROPIC_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.ANTHROPIC],
+        model=("pydantic_ai.models.anthropic", "AnthropicModel"),
+        dependency="pydantic-ai-slim[anthropic]",
+        module="anthropic",
+        key_url="https://console.anthropic.com/",
+    ),
+    AIProvider.GOOGLE: ProviderSpec(
+        env_var="GOOGLE_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.GOOGLE],
+        model=("pydantic_ai.models.google", "GoogleModel"),
+        dependency="pydantic-ai-slim[google]",
+        module="google.genai",
+        key_url="https://aistudio.google.com/app/apikey",
+    ),
+    AIProvider.GROQ: ProviderSpec(
+        env_var="GROQ_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.GROQ],
+        model=("pydantic_ai.models.groq", "GroqModel"),
+        dependency="pydantic-ai-slim[groq]",
+        module="groq",
+        key_url="https://console.groq.com/keys",
+    ),
+    AIProvider.MISTRAL: ProviderSpec(
+        env_var="MISTRAL_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.MISTRAL],
+        model=_OPENAI_CHAT,
+        base_url="https://api.mistral.ai/v1",
+        key_url="https://console.mistral.ai/api-keys/",
+    ),
+    AIProvider.COHERE: ProviderSpec(
+        env_var="COHERE_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.COHERE],
+        model=_OPENAI_CHAT,
+        base_url="https://api.cohere.ai/v1",
+        key_url="https://dashboard.cohere.com/api-keys",
+    ),
+    AIProvider.OLLAMA: ProviderSpec(
+        env_var="OLLAMA_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.OLLAMA],
+        model=_OPENAI_CHAT,
+        # Its address is a setting, not a constant, so the model is built
+        # rather than described.
+        builds_own_client=True,
+    ),
+    AIProvider.PUBLIC: ProviderSpec(
+        env_var="PUBLIC_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.PUBLIC],
+        # It has a class like any other; what it lacks is a plain
+        # constructor call, because the endpoint is keyless and the
+        # client is built around that.
+        model=_OPENAI_CHAT,
+        builds_own_client=True,
+    ),
+    AIProvider.POLLINATIONS: ProviderSpec(
+        env_var="POLLINATIONS_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.POLLINATIONS],
+        # It has a class like any other; what it lacks is a plain
+        # constructor call, because the endpoint is keyless and the
+        # client is built around that.
+        model=_OPENAI_CHAT,
+        builds_own_client=True,
+    ),
+    AIProvider.OPENROUTER: ProviderSpec(
+        # NOT OPENAI_API_KEY. pydantic-ai's OpenAI client reads that from
+        # the environment, so borrowing it would have OpenRouter overwrite
+        # a real OpenAI key for the rest of the process.
+        env_var="OPEN_ROUTER_API_KEY",
+        capabilities=PROVIDER_CAPABILITIES[AIProvider.OPENROUTER],
+        model=_OPENAI_CHAT,
+        base_url="https://openrouter.ai/api/v1",
+        key_url="https://openrouter.ai/keys",
     ),
 }
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_provider_registry.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/ai/test_provider_registry.py.jinja
@@ -1,0 +1,180 @@
+"""One place a provider is described.
+
+A provider used to be stated six times: the enum, a capabilities dict, an
+API-key lookup in config, a model-class if/elif, and TWO byte-identical
+env-var maps - so adding one meant five edits across three files and
+forgetting any of them failed quietly at the point of use.
+
+The enum stays: this stack runs its AI on a memory backend with no
+database, so what a provider IS has to be knowable in code before any
+storage exists. What moved is the FACTS about it, into one registry
+beside the enum.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.services.ai.models import PROVIDERS, AIProvider
+
+
+class TestEveryProviderIsDescribedOnce:
+    def test_the_registry_covers_the_enum_exactly(self) -> None:
+        """Exhaustiveness is the reason to keep an enum at all; a member
+        with no entry is the bug this replaces."""
+        assert set(PROVIDERS) == set(AIProvider)
+
+    @pytest.mark.parametrize("provider", list(AIProvider))
+    def test_each_entry_says_where_its_key_lives(self, provider: AIProvider) -> None:
+        assert PROVIDERS[provider].env_var
+
+    @pytest.mark.parametrize("provider", list(AIProvider))
+    def test_each_entry_carries_its_capabilities(self, provider: AIProvider) -> None:
+        assert PROVIDERS[provider].capabilities.provider == provider
+
+
+class TestOpenRouter:
+    """It speaks the OpenAI API, so it is a base URL and a key - the same
+    shape Ollama already had, now shared rather than special-cased."""
+
+    def test_it_is_a_provider(self) -> None:
+        assert AIProvider.from_name("openrouter") is AIProvider.OPENROUTER
+
+    def test_its_key_is_its_own_variable(self) -> None:
+        """Not OPENAI_API_KEY: this stack has a real OpenAI key too, and
+        one must never overwrite the other."""
+        assert PROVIDERS[AIProvider.OPENROUTER].env_var == "OPEN_ROUTER_API_KEY"
+
+    def test_it_points_at_openrouter(self) -> None:
+        spec = PROVIDERS[AIProvider.OPENROUTER]
+        assert spec.base_url == "https://openrouter.ai/api/v1"
+
+    def test_it_speaks_tools_and_vision(self) -> None:
+        caps = PROVIDERS[AIProvider.OPENROUTER].capabilities
+        assert caps.supports_function_calling and caps.supports_streaming
+
+
+class TestTheOldLookupsReadTheRegistry:
+    """The maps are gone; the helpers that used them stay, because
+    callers all over the app and CLI use them."""
+
+    @pytest.mark.parametrize("provider", list(AIProvider))
+    def test_api_key_env_matches_the_registry(self, provider: AIProvider) -> None:
+        from app.services.ai.config import api_key_env
+
+        assert api_key_env(provider) == PROVIDERS[provider].env_var
+
+    def test_supported_providers_is_the_enum(self) -> None:
+        from app.services.ai.domains.llm.providers import get_supported_providers
+
+        assert set(get_supported_providers()) == set(AIProvider)
+
+
+{%- if ai_framework == "pydantic-ai" %}
+
+
+class TestOneClientForEveryOpenAICompatibleProvider:
+    """Mistral, Cohere, OpenRouter and Ollama differ by a URL and a key.
+
+    Pydantic-ai only: on the LangChain framework a model is built through
+    that project's own per-provider packages, which a stack installs only
+    for the providers it selected - and which have no OpenRouter at all.
+
+    They used to differ by more: two of them passed ``base_url`` to
+    ``OpenAIChatModel``, which takes no such argument, so selecting
+    Mistral or Cohere raised TypeError the moment anybody tried. Nothing
+    caught it because nothing constructed them.
+    """
+
+    def test_the_compatible_ones_are_marked_by_a_base_url(self) -> None:
+        compatible = {p for p, s in PROVIDERS.items() if s.base_url}
+        assert compatible == {
+            AIProvider.MISTRAL,
+            AIProvider.COHERE,
+            AIProvider.OPENROUTER,
+        }
+
+    @pytest.mark.parametrize(
+        "provider", [AIProvider.MISTRAL, AIProvider.COHERE, AIProvider.OPENROUTER]
+    )
+    def test_each_one_actually_builds(self, provider: AIProvider) -> None:
+        """The regression guard: construction, not just configuration."""
+        from app.core.config import settings
+        from app.services.ai.config import get_ai_config
+        from app.services.ai.domains.llm.providers import model_for
+
+        config = get_ai_config(settings)
+        config.provider = provider
+        config.model = "a-model"
+        object.__setattr__(
+            settings, PROVIDERS[provider].env_var, "test-key-not-used"
+        )
+
+        model, name = model_for(config, settings)
+
+        assert name == "a-model"
+        assert type(model).__name__ == "OpenAIChatModel"
+
+    def test_the_key_rides_the_client_not_the_environment(self) -> None:
+        """A stack can hold a real OpenAI key AND an OpenRouter one;
+        stamping OPENAI_API_KEY would let the last one built answer for
+        both."""
+        import os
+
+        from app.core.config import settings
+        from app.services.ai.config import get_ai_config
+        from app.services.ai.domains.llm.providers import model_for
+
+        os.environ["OPENAI_API_KEY"] = "the-real-openai-key"
+        config = get_ai_config(settings)
+        config.provider = AIProvider.OPENROUTER
+        config.model = "deepseek/deepseek-chat"
+        object.__setattr__(settings, "OPEN_ROUTER_API_KEY", "sk-or-v1-test")
+
+        model_for(config, settings)
+
+        assert os.environ["OPENAI_API_KEY"] == "the-real-openai-key"
+{%- else %}
+
+
+class TestOpenRouterOnLangChain:
+    """Parity. LangChain's OpenAI client takes a base URL too, so an
+    aggregator needs no package of its own - the same trick the Ollama
+    builder has always used, with a real key instead of a placeholder.
+
+    Checked after the keyed table, so Mistral and Cohere keep their
+    native clients rather than being quietly rerouted.
+    """
+
+    def test_it_builds_through_the_openai_client(self) -> None:
+        from app.core.config import settings
+        from app.services.ai.config import get_ai_config
+        from app.services.ai.domains.llm.providers import get_llm
+
+        config = get_ai_config(settings)
+        config.provider = AIProvider.OPENROUTER
+        config.model = "deepseek/deepseek-chat"
+        object.__setattr__(settings, "OPEN_ROUTER_API_KEY", "sk-or-v1-test")
+
+        llm = get_llm(config, settings)
+
+        assert type(llm).__name__ == "ChatOpenAI"
+        assert str(llm.openai_api_base).startswith("https://openrouter.ai")
+
+    def test_the_key_rides_the_client_not_the_environment(self) -> None:
+        import os
+
+        from app.core.config import settings
+        from app.services.ai.config import get_ai_config
+        from app.services.ai.domains.llm.providers import get_llm
+
+        os.environ["OPENAI_API_KEY"] = "the-real-openai-key"
+        config = get_ai_config(settings)
+        config.provider = AIProvider.OPENROUTER
+        config.model = "deepseek/deepseek-chat"
+        object.__setattr__(settings, "OPEN_ROUTER_API_KEY", "sk-or-v1-test")
+
+        get_llm(config, settings)
+
+        assert os.environ["OPENAI_API_KEY"] == "the-real-openai-key"
+{%- endif %}


### PR DESCRIPTION
## Summary

A provider was stated **nine times** across four files: the enum, a capabilities table, an API-key map in `config`, a model-class if/elif, a dependency map, a module map, a key-URL map, a `SUPPORTED_PROVIDERS` tuple, and `base_url` branches in the factory. Adding one meant editing all of them, and three had tests whose only job was to police them for gaps, because nothing else would notice.

They are one registry now, beside the enum.

- **The enum stays.** This stack runs its AI on a memory backend with no database, so what a provider *is* has to be knowable in code before any storage exists. What moved is the facts about it.
- **The remaining maps are views** over the registry, so they cannot fall behind it. A test pins the registry to the enum, which is the exhaustiveness an enum is for.
- **The model class is still a lazy `(module, class)` pair**, so a provider nobody selected never drags its SDK in.

## OpenRouter

Added as a member. It speaks the OpenAI API, so it is a base URL and a key and nothing else, which is the point: one entry rather than nine edits.

Its key is `OPEN_ROUTER_API_KEY`, never `OPENAI_API_KEY`. A stack can hold both, and borrowing OpenAI's variable would have the last model built answer for both providers.

## A bug this found

`Mistral` and `Cohere` passed `base_url` to `OpenAIChatModel`, which takes no such argument. Selecting either raised `TypeError` at construction, and nothing caught it because nothing ever built them.

Every OpenAI-compatible provider now takes the path Ollama always did: a client pointed elsewhere, with the key on the **client** rather than stamped into the environment.

## Test plan

- [x] `ruff check aegis/` clean; 1,701 core tests pass.
- [x] Both jinja templates render and compile.
- [x] New `test_provider_registry.py` ships with the AI service: the registry covers the enum exactly, every entry names its key variable and carries its capabilities, `api_key_env` and `get_supported_providers` agree with it.
- [x] The regression guard the old code lacked: Mistral, Cohere and OpenRouter are each **constructed**, not just configured.
- [x] A test that building an OpenRouter model leaves `OPENAI_API_KEY` untouched.
- [x] Verified live in aegis-steward: DeepSeek answers through OpenRouter on a real key.