### PR TITLE
Add a small, injectable GraphQL client to the template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@
 
 ### Changed
 
+- **`app/core/graphql.py`: a small, injectable GraphQL client.** Nothing in
+  a generated project spoke GraphQL before, and the first consumer needs to
+  (GitHub's REST stargazer list cannot enumerate past 40k stars; the GraphQL
+  connection can). `GraphQLClient(endpoint, headers=, timeout=, transport=)`
+  owns one connection pool and a single `query()`, and turns the two things
+  every caller gets wrong into typed errors: a `200` that carries an
+  `errors` array raises `GraphQLError`, and any `httpx` failure raises
+  `GraphQLHTTPError` instead of leaking the transport's exception types.
+  `transport` is the seam - tests pass `httpx.MockTransport` and never
+  monkeypatch `httpx`. Endpoint-agnostic on purpose; an API-specific
+  client subclasses it. REST callers are deliberately untouched.
 - **A scaffolded plugin pins the aegis-stack that made it.** The scaffold
   emitted an unpinned `aegis-stack` dependency, so `pip install
   aegis-stack-<name>` could resolve an older aegis-stack whose `PluginSpec`

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/graphql.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/graphql.py
@@ -1,0 +1,106 @@
+"""A small GraphQL-over-HTTP client.
+
+GraphQL is one POST shape - ``{"query", "variables"}`` to a single
+endpoint - so this stays deliberately thin: it owns the connection pool,
+the request framing, and the two things every caller would otherwise get
+wrong. A server reports resolver failures with a **200** and an
+``errors`` array, and a transport failure surfaces as an ``httpx``
+exception type callers should not have to know about. Both become typed
+errors here.
+
+Endpoint-agnostic on purpose. An API-specific client (GitHub, ...)
+subclasses this and supplies the endpoint, auth headers, and whatever
+paging or rate-limit behaviour that API needs.
+
+``transport`` is the injection seam: tests pass ``httpx.MockTransport``
+and never monkeypatch ``httpx``; production passes nothing.
+"""
+
+from __future__ import annotations
+
+from types import TracebackType
+from typing import Any
+
+import httpx
+
+
+class GraphQLError(Exception):
+    """The server answered, but the response carried an ``errors`` array."""
+
+    def __init__(self, errors: list[dict[str, Any]]) -> None:
+        self.errors = errors
+        messages = "; ".join(str(e.get("message", e)) for e in errors) or "unknown"
+        super().__init__(f"GraphQL error: {messages}")
+
+
+class GraphQLHTTPError(Exception):
+    """The request never produced a GraphQL response.
+
+    ``status`` is the HTTP status for a non-2xx reply and ``None`` when the
+    transport itself failed (connection refused, timeout). ``body`` is the
+    response text or the transport error message.
+    """
+
+    def __init__(self, status: int | None, body: str) -> None:
+        self.status = status
+        self.body = body
+        where = f"HTTP {status}" if status is not None else "transport error"
+        super().__init__(f"GraphQL request failed ({where}): {body[:200]}")
+
+
+class GraphQLClient:
+    """One endpoint, one connection pool, one ``query()``."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        headers: dict[str, str] | None = None,
+        timeout: float = 30.0,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.endpoint = endpoint
+        self._http = httpx.AsyncClient(
+            headers=headers or {},
+            timeout=timeout,
+            transport=transport,
+        )
+
+    async def query(
+        self, query: str, variables: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """POST ``query`` and return its ``data``.
+
+        Always sends ``variables`` as an object: a missing key is accepted
+        everywhere, but ``null`` is rejected by some servers.
+        """
+        try:
+            response = await self._http.post(
+                self.endpoint,
+                json={"query": query, "variables": variables or {}},
+            )
+        except httpx.HTTPError as exc:
+            raise GraphQLHTTPError(None, str(exc)) from exc
+
+        if response.status_code // 100 != 2:
+            raise GraphQLHTTPError(response.status_code, response.text)
+
+        payload = response.json()
+        errors = payload.get("errors")
+        if errors:
+            raise GraphQLError(errors)
+        return payload.get("data") or {}
+
+    async def aclose(self) -> None:
+        await self._http.aclose()
+
+    async def __aenter__(self) -> GraphQLClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        await self.aclose()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/core/test_graphql_client.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/core/test_graphql_client.py
@@ -1,0 +1,122 @@
+"""``GraphQLClient``: the wire shape, the error mapping, and the seam.
+
+Everything here runs against ``httpx.MockTransport`` - no network. That
+transport injection is the point of the class: a consumer test hands in a
+fake and never monkeypatches ``httpx``.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from app.core.graphql import GraphQLClient, GraphQLError, GraphQLHTTPError
+
+
+def _transport(handler):
+    return httpx.MockTransport(handler)
+
+
+async def test_posts_query_and_variables_and_returns_data() -> None:
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["url"] = str(request.url)
+        seen["body"] = json.loads(request.content)
+        seen["auth"] = request.headers.get("authorization")
+        return httpx.Response(200, json={"data": {"viewer": {"login": "octocat"}}})
+
+    async with GraphQLClient(
+        "https://example.test/graphql",
+        headers={"Authorization": "Bearer t"},
+        transport=_transport(handler),
+    ) as client:
+        data = await client.query("query { viewer { login } }", {"n": 1})
+
+    assert data == {"viewer": {"login": "octocat"}}
+    assert seen["method"] == "POST"
+    assert seen["url"] == "https://example.test/graphql"
+    assert seen["body"] == {
+        "query": "query { viewer { login } }",
+        "variables": {"n": 1},
+    }
+    assert seen["auth"] == "Bearer t"
+
+
+async def test_omitted_variables_send_an_empty_object() -> None:
+    """GraphQL servers accept a missing ``variables`` key, but some reject
+    ``null``; always send an object so the client never has to think."""
+    seen: dict = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(200, json={"data": {}})
+
+    async with GraphQLClient("https://x/graphql", transport=_transport(handler)) as c:
+        await c.query("{ ok }")
+
+    assert seen["body"]["variables"] == {}
+
+
+async def test_errors_array_raises_even_on_200() -> None:
+    """GraphQL reports resolver failures with a 200 and an ``errors`` array.
+    Without this every caller would have to remember to check."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json={
+                "data": None,
+                "errors": [{"message": "Field 'nope' doesn't exist", "path": ["nope"]}],
+            },
+        )
+
+    async with GraphQLClient("https://x/graphql", transport=_transport(handler)) as c:
+        with pytest.raises(GraphQLError) as exc:
+            await c.query("{ nope }")
+
+    assert "nope" in str(exc.value)
+    assert exc.value.errors[0]["path"] == ["nope"]
+
+
+async def test_non_2xx_raises_http_error_with_status_and_body() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(502, text="bad gateway")
+
+    async with GraphQLClient("https://x/graphql", transport=_transport(handler)) as c:
+        with pytest.raises(GraphQLHTTPError) as exc:
+            await c.query("{ ok }")
+
+    assert exc.value.status == 502
+    assert "bad gateway" in exc.value.body
+    # Callers catch the client's own type, never httpx's.
+    assert not isinstance(exc.value, httpx.HTTPError)
+
+
+async def test_transport_failure_is_wrapped_not_leaked() -> None:
+    def handler(_: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("refused")
+
+    async with GraphQLClient("https://x/graphql", transport=_transport(handler)) as c:
+        with pytest.raises(GraphQLHTTPError) as exc:
+            await c.query("{ ok }")
+
+    assert exc.value.status is None
+    assert "refused" in exc.value.body
+
+
+async def test_reuses_one_connection_pool_across_calls() -> None:
+    """One ``AsyncClient`` per instance, not per call - the whole reason
+    to hold a client object rather than a function."""
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"data": {}})
+
+    client = GraphQLClient("https://x/graphql", transport=_transport(handler))
+    async with client:
+        first = client._http
+        await client.query("{ a }")
+        await client.query("{ b }")
+        assert client._http is first


### PR DESCRIPTION
Closes #1101.

## Why

Nothing in a generated project spoke GraphQL, and the first consumer needs to. GitHub's REST stargazer list caps offset pagination at 400 pages, so repos past 40k stars return `422`, and their *newest* stars live on exactly the pages that can't be reached. The GraphQL `stargazers` connection has no such cap. That's lbedner/aegis-pulse#97, which this unblocks via lbedner/aegis-pulse#192.

## Scope: GraphQL only, on purpose

GraphQL over HTTP is one POST shape, so this is deliberately thin — one endpoint, one connection pool, one `query()`. The template's many ad-hoc `httpx.AsyncClient(...)` REST constructions are a real but separate cleanup and are **not** touched here.

## What it gets right so callers don't have to

- **`200` + `errors` array → `GraphQLError`.** GraphQL reports resolver failures with a success status. Without this every caller has to remember to check the array; most wouldn't.
- **Any `httpx` failure → `GraphQLHTTPError`** (with `status` for non-2xx, `None` for a dead transport). Callers catch the client's own type and never learn `httpx`'s exception hierarchy.
- **`transport` is the injection seam.** Tests pass `httpx.MockTransport`; production passes nothing. The whole test file runs against that seam with no network and no monkeypatching.
- **`variables` always sent as an object.** A missing key is accepted everywhere; `null` is rejected by some servers.
- **Endpoint-agnostic.** An API-specific client subclasses it and adds endpoint, auth, paging, rate limits.

```python
async with GraphQLClient("https://api.github.com/graphql",
                         headers={"Authorization": f"Bearer {token}"}) as gql:
    data = await gql.query(QUERY, {"owner": "lbedner", "name": "aegis-stack"})
```

## Tests

6, all against `MockTransport`: wire shape (method, URL, body, auth header), empty-variables default, the `200`-with-errors case, non-2xx mapping, transport-failure wrapping, and pool reuse across calls.

Verified by copying both files into a rendered project (`my-app`) and running there — the template's own suite can't import `app.core`. 6/6 passed; nothing left behind in `my-app`. Template-side: ruff, `ty`, size budget, tree hygiene, ownership, manifest and render tests all green.

Plain `.py` in `app/core/`, so it ships to every stack unconditionally; `httpx` is already a base dependency.
