### PR TITLE
A Postgres project's test suite runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@
   differ on: a published plugin resolves by version and carries an install
   command, a source-only one carries its repository link and pins nothing.
 
+### Fixed
+
+- **A Postgres project's test suite runs.** Every project's tests run on
+  SQLite (``tests/conftest.py`` points ``DATABASE_URL`` at a throwaway
+  file), but three things only worked on a SQLite project: the async URL
+  converter in ``app/core/db.py`` did not know ``sqlite://`` (so
+  ``create_async_engine`` got a sync driver and nothing collected), the
+  test guard redirected only the async session factory (so a sync
+  ``db_session()`` lookup after a write hit a database with no tables:
+  Postgres migrations open with ``CREATE SCHEMA``, which SQLite rejects), and
+  the SQLite busy-timeout test skipped on dialect rather than on whether the
+  project wires the knob. The CI matrix generates no Postgres project, so
+  nothing caught it. A generated test now asserts the sync and async
+  app-owned sessions share one database.
+
 ## [0.11.1] - 2026-09-10
 
 ### Changed

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/db.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/db.py.jinja
@@ -130,13 +130,17 @@ engine = create_engine(
 
 # Create async engine for non-blocking operations
 def _get_async_database_url(database_url: str) -> str:
-    """Convert sync database URL to async version."""
-{% if database_engine == "sqlite" %}
+    """Convert sync database URL to async version.
+
+    SQLite is handled whatever engine this project runs on: the test suite
+    points ``DATABASE_URL`` at a throwaway SQLite file before this module
+    builds its engines, so a Postgres project's tests run on SQLite too.
+    """
     if database_url.startswith("sqlite:///"):
         return database_url.replace("sqlite:///", "sqlite+aiosqlite:///")
     elif database_url.startswith("sqlite://"):
         return database_url.replace("sqlite://", "sqlite+aiosqlite://")
-{% else %}
+{% if database_engine != "sqlite" %}
     if database_url.startswith("postgresql://"):
         database_url = database_url.replace(
             "postgresql://", "postgresql+asyncpg://"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
@@ -34,6 +34,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.orm import sessionmaker
 from sqlmodel import Session, SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 {% endif %}
@@ -323,6 +324,39 @@ def _no_production_database(app_owned_engine, monkeypatch):
             app_owned_engine, class_=AsyncSession, expire_on_commit=False
         ),
     )
+    # The sync factory too: ``db_session()`` is what service code like
+    # ``get_conversation()`` opens for itself. A sync engine on the SAME
+    # file, with the same schema attachments, so both factories see one
+    # database - the one ``app_owned_engine`` already ran ``create_all`` on.
+    # Left uncovered, a Postgres project fails "no such table" on the first
+    # sync lookup: its startup migrations begin with CREATE SCHEMA, which
+    # SQLite rejects, so nothing else ever creates tables for that path.
+    owned_db = Path(app_owned_engine.url.database)
+    schema_names = {
+        table.schema for table in SQLModel.metadata.tables.values() if table.schema
+    }
+    sync_engine = create_engine(
+        f"sqlite:///{owned_db}", echo=False, connect_args={"check_same_thread": False}
+    )
+
+    @event.listens_for(sync_engine, "connect")
+    def attach_schemas_sync(dbapi_connection: Any, connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        for schema_name in schema_names:
+            cursor.execute(
+                f"ATTACH DATABASE '{owned_db.parent / (schema_name + '.sqlite')}' "
+                f"AS {schema_name}"
+            )
+        cursor.close()
+
+    monkeypatch.setattr(
+        db_module,
+        "SessionLocal",
+        sessionmaker(bind=sync_engine, class_=Session, expire_on_commit=False),
+    )
+    yield
+    sync_engine.dispose()
 
 
 @pytest.fixture(scope="session")

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
@@ -897,7 +897,9 @@ class TestWithdraw:
 
         from app.core import db as app_db
 
-        if app_db.async_engine.dialect.name != "sqlite":
+        # Every project's tests run on SQLite, so the dialect says nothing
+        # about the project; the knob is only wired on a SQLite project.
+        if getattr(app_db, "SQLITE_BUSY_TIMEOUT_MS", None) is None:
             pytest.skip("busy_timeout is a SQLite knob")
         async with app_db.async_engine.connect() as conn:
             timeout = (await conn.execute(text("PRAGMA busy_timeout"))).scalar()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_app_owned_sessions.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_app_owned_sessions.py
@@ -1,0 +1,32 @@
+"""Every session the app opens for itself lands in the app-owned test database.
+
+``_no_production_database`` redirects the module-level session factories in
+``app.core.db`` so startup hooks, background tasks and service code that open
+their own session never touch the database in ``DATABASE_URL``. The sync
+factory must be covered as well as the async one: ``db_session()`` is what
+``get_conversation()`` and friends use, and on a Postgres project nothing
+else creates tables for it (startup migrations begin with ``CREATE SCHEMA``,
+which SQLite rejects), so an uncovered sync path fails with "no such table"
+on the first lookup a route makes after a write.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Skip before touching SQLAlchemy: a stack without a database ships neither.
+db_module = pytest.importorskip("app.core.db", reason="no database in this stack")
+
+from sqlalchemy import inspect  # noqa: E402
+from sqlmodel import SQLModel  # noqa: E402
+
+
+def test_sync_and_async_app_owned_sessions_share_one_database(
+    app_owned_engine,
+) -> None:
+    with db_module.db_session(autocommit=False) as session:
+        bind = session.get_bind()
+        assert bind.url.database == app_owned_engine.url.database
+        present = set(inspect(bind).get_table_names())
+    expected = {t.name for t in SQLModel.metadata.tables.values() if t.schema is None}
+    assert expected <= present, sorted(expected - present)

--- a/tests/core/test_db_template_async_url.py
+++ b/tests/core/test_db_template_async_url.py
@@ -1,0 +1,47 @@
+"""The async URL converter in ``app/core/db.py`` must accept a SQLite URL
+whatever engine the project chose.
+
+The generated test suite points ``DATABASE_URL`` at a throwaway SQLite file
+at import time, before ``app.core.db`` builds its engines, so the suite of
+a Postgres project runs on SQLite like every other. A converter that only
+knows ``postgresql://`` hands ``create_async_engine`` a sync ``sqlite://``
+URL and the whole suite fails to collect. The CI matrix never generates a
+Postgres project (it would need a server), so nothing else catches this.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from aegis.core.component_files import get_copier_defaults, get_template_path
+
+
+def _converter(engine: str) -> Any:
+    env = Environment(
+        loader=FileSystemLoader(str(get_template_path())), keep_trailing_newline=True
+    )
+    ctx = {**get_copier_defaults(), "include_database": True, "database_engine": engine}
+    source = env.get_template("{{ project_slug }}/app/core/db.py.jinja").render(ctx)
+    tree = ast.parse(source)
+    fn = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_get_async_database_url"
+    )
+    ns: dict[str, Any] = {}
+    exec(compile(ast.Module(body=[fn], type_ignores=[]), "db.py", "exec"), ns)
+    return ns["_get_async_database_url"]
+
+
+@pytest.mark.parametrize("engine", ["sqlite", "postgres"])
+def test_sqlite_url_becomes_aiosqlite_for_every_engine(engine: str) -> None:
+    convert = _converter(engine)
+    assert convert("sqlite:////tmp/x/app.db") == "sqlite+aiosqlite:////tmp/x/app.db"
+
+
+def test_postgres_url_becomes_asyncpg_for_a_postgres_project() -> None:
+    convert = _converter("postgres")
+    assert convert("postgresql://u:p@h/db") == "postgresql+asyncpg://u:p@h/db"


### PR DESCRIPTION
Found while landing the health-checks branch into my-app (a Postgres project): once my-app's test conftest matched the template, four `test_ai_endpoints` tests 500'd with `no such table: conversation`, and before that nothing collected at all.

Every project's tests run on SQLite (`tests/conftest.py` sets `DATABASE_URL` to a throwaway file at import). Three things only worked when the project itself was SQLite:

1. `app/core/db.py`: `_get_async_database_url` only converted `postgresql://`, so a Postgres project's `create_async_engine` received the sync `pysqlite` driver and the suite failed to collect. SQLite conversion is now unconditional; `tests/core/test_db_template_async_url.py` renders both engines and checks the converter.
2. `tests/conftest.py`: `_no_production_database` redirected `AsyncSessionLocal` only. A sync `db_session()` (what `get_conversation()` uses after a chat) reached the app's real engine, where a Postgres project has no tables because its startup migrations begin with `CREATE SCHEMA`. A sync engine on the same app-owned file, with the same schema attachments, now covers `SessionLocal`. Generated `tests/test_app_owned_sessions.py` asserts both factories share one database and it holds every non-schema table.
3. `test_sqlite_waits_for_a_busy_writer` skipped on dialect (always sqlite under test) rather than on whether the project wires the knob.

Verified on my-app (Postgres, `ai,documents,finance`): 3241 passed, 0 failed. On a fresh SQLite `everything` stack: 2053 passed. The CI matrix has no Postgres project, so this PR's own CI only proves nothing regressed for SQLite stacks; the Postgres evidence is the my-app run.