### PR TITLE
Health checks landed; Postgres-project tests run; slow suites run nightly

### DIFF
--- a/.github/workflows/slow-suites.yml
+++ b/.github/workflows/slow-suites.yml
@@ -1,0 +1,67 @@
+name: Slow Suites
+
+# The PR run deselects ``-m slow``. This job runs everything it leaves
+# behind - the add, add-service, remove and update lifecycle suites, the
+# database runtime tests, plugin conformance - once a night and on demand,
+# so a lifecycle regression or a stale assertion is caught within a day
+# instead of at release time. The stack matrix owns
+# tests/cli/test_stack_validation.py; it is not repeated here.
+#
+# A Postgres service is provided so the postgres-marked runtime tests run
+# for real instead of skipping for want of localhost:5432.
+
+on:
+  schedule:
+    - cron: '30 7 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/slow-suites.yml'
+
+concurrency:
+  group: slow-suites-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  slow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      POSTGRES_TEST_PASSWORD: postgres
+    steps:
+      # Full history and tags: the update integration suite runs `aegis
+      # update` against this checkout as the template, and copier checks
+      # out the target version tag inside it. A shallow clone has no tags,
+      # so the update fails with "pathspec 'vX.Y.Z' did not match".
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run the slow suites
+        run: >
+          uv run pytest -m slow -n auto --dist=loadgroup -v --tb=short
+          --ignore=tests/cli/test_stack_validation.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,24 @@
   `transport` is the seam - tests pass `httpx.MockTransport` and never
   monkeypatch `httpx`. Endpoint-agnostic on purpose; an API-specific
   client subclasses it. REST callers are deliberately untouched.
+- **`/health/` is a liveness probe; component status moved to
+  `/health/detailed`.** The basic endpoint walked every component on each
+  call, and Docker, Traefik and the dashboard all polled it, so an idle
+  stack spent measurable CPU checking itself. `/health/` now answers in
+  constant time with an empty `components` field, and `/health/detailed`
+  reads a shared status cache: one full walk at most every ten seconds no
+  matter how many callers ask (`STATUS_CACHE_TTL_SECONDS`). Idle CPU on a
+  full stack dropped from 13.4% to 0.26%.
+- **The scheduler proves it is alive with a heartbeat file, not an HTTP
+  probe.** `heartbeat.py` touches `/tmp/aegis-scheduler-heartbeat` on a
+  schedule and the compose healthcheck checks its age; the two worker
+  services drop their redundant healthchecks. The Flet frontend keeps one
+  health session per page instead of one per view (`session_health.py`).
+- **`system/health.py` is split by component.** Redis, ingress,
+  observability and Ollama checks live in `health_cache.py`,
+  `health_ingress.py`, `health_observability.py` and `health_ollama.py`,
+  each gated on its component; the module drops from 1456 lines to 714.
+
 - **A scaffolded plugin pins the aegis-stack that made it.** The scaffold
   emitted an unpinned `aegis-stack` dependency, so `pip install
   aegis-stack-<name>` could resolve an older aegis-stack whose `PluginSpec`
@@ -33,6 +51,21 @@
   the directory finds them by, and says what the two listing sections
   differ on: a published plugin resolves by version and carries an install
   command, a source-only one carries its repository link and pins nothing.
+
+### Fixed
+
+- **A Postgres project's test suite runs.** Every project's tests run on
+  SQLite (``tests/conftest.py`` points ``DATABASE_URL`` at a throwaway
+  file), but three things only worked on a SQLite project: the async URL
+  converter in ``app/core/db.py`` did not know ``sqlite://`` (so
+  ``create_async_engine`` got a sync driver and nothing collected), the
+  test guard redirected only the async session factory (so a sync
+  ``db_session()`` lookup after a write hit a database with no tables:
+  Postgres migrations open with ``CREATE SCHEMA``, which SQLite rejects), and
+  the SQLite busy-timeout test skipped on dialect rather than on whether the
+  project wires the knob. The CI matrix generates no Postgres project, so
+  nothing caught it. A generated test now asserts the sync and async
+  app-owned sessions share one database.
 
 ## [0.11.1] - 2026-09-10
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/health.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/api/health.py.jinja
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from typing import Any
 
 from app.services.system import (
@@ -14,26 +15,18 @@ router = APIRouter()
 @router.get("/", response_model=HealthResponse)
 async def health_check() -> HealthResponse:
     """
-    Quick health check endpoint.
+    Liveness probe: constant-time, no component walk.
 
-    Returns basic healthy/unhealthy status for load balancers and monitoring.
+    Returns 200 if the process is alive enough to answer, which is all
+    load balancers and container healthchecks need. Component status
+    lives at /health/detailed.
     """
-    try:
-        system_status = await get_system_status()
-        return HealthResponse(
-            healthy=system_status.overall_healthy,
-            status="healthy" if system_status.overall_healthy else "unhealthy",
-            components=system_status.components,
-            timestamp=system_status.timestamp.isoformat(),
-        )
-    except Exception:
-        # If health checks fail completely, consider unhealthy
-        return HealthResponse(
-            healthy=False,
-            status="unhealthy",
-            components={},
-            timestamp="",
-        )
+    return HealthResponse(
+        healthy=True,
+        status="healthy",
+        components={},
+        timestamp=datetime.now(UTC).isoformat(),
+    )
 
 
 @router.get("/detailed", response_model=DetailedHealthResponse)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/core/session_health.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/core/session_health.py
@@ -1,0 +1,31 @@
+"""Detection for unrecoverable Flet session states.
+
+Flet raises AssertionError from ``_process_remove_command`` when a
+session's server-side control tree has desynced from the client - the
+classic trigger is a tab reconnecting across a webserver restart. The
+session cannot be repaired server-side; only a client reload creates a
+working one. Background loops must stop instead of retrying forever.
+"""
+
+from typing import Any
+
+from app.core.log import logger
+
+
+def is_tree_corruption(exc: BaseException) -> bool:
+    """True when the exception signals a desynced Flet control tree."""
+    return isinstance(exc, AssertionError) and "_process_remove_command" in str(exc)
+
+
+async def handle_corrupt_session(page: Any) -> None:
+    """Steer a desynced session's client to a fresh page load.
+
+    ``launch_url`` with ``_self`` replaces the current page - the one
+    command that still works on a corrupted session because it does not
+    touch the control tree. The caller should stop its loop afterwards.
+    """
+    logger.warning("Session tree corrupt; steering client to reload")
+    try:
+        page.launch_url("/dashboard/", web_window_name="_self")
+    except Exception as e:
+        logger.debug(f"Client reload nudge failed (client must reload manually): {e}")

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/main.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/frontend/main.py.jinja
@@ -43,6 +43,10 @@ from app.components.frontend.controls.views.legacy_dashboard import (
     LegacyDashboardView,
 )
 from app.components.frontend.core import events as frontend_events
+from app.components.frontend.core.session_health import (
+    handle_corrupt_session,
+    is_tree_corruption,
+)
 from app.components.frontend.core.routes import DASHBOARD_ROUTE
 {% if insights_per_user -%}
 from app.components.frontend.controls.buttons import PulseButton
@@ -1074,11 +1078,11 @@ async def setup_dashboard(view: BaseView) -> None:
     async def refresh_dashboard() -> None:
         """Refresh the stunning marketing-grade dashboard."""
         try:
-            # Single /health/ endpoint for all health data. APIClient
-            # returns parsed JSON or ``None`` on any error (logged centrally).
-            data = await api_client.get("/health/")
+            # Health data comes from /health/detailed; /health/ is a bare
+            # liveness probe. APIClient returns parsed JSON or ``None``.
+            data = await api_client.get("/health/detailed")
             if data is None:
-                logger.debug("refresh_dashboard.skipping: /health/ returned None")
+                logger.debug("refresh_dashboard.skipping: no health data")
                 return
             assert isinstance(data, dict), f"unexpected /health/ shape: {type(data)}"
 
@@ -1159,13 +1163,12 @@ async def setup_dashboard(view: BaseView) -> None:
                     raise
 
         except PageDisconnectedException:
+            # Disconnected: no UI can render; propagate so auto_refresh stops.
             logger.debug("Page disconnected during dashboard refresh")
-            # Do NOT call show_error_status here: the page is already disconnected,
-            # so any attempt to update the UI (including showing an error) fails.
-            # Instead, propagate this exception so the auto_refresh loop can handle
-            # the disconnection gracefully and stop further updates.
             raise
         except Exception as e:
+            if is_tree_corruption(e):
+                raise  # unrecoverable session - auto_refresh terminates it
             logger.error(
                 f"Dashboard refresh failed: {e}",
                 exc_info=True,
@@ -1174,7 +1177,6 @@ async def setup_dashboard(view: BaseView) -> None:
                     "function": "refresh_dashboard"
                 }
             )
-            # Show error indicator using safe dashboard method
             await dashboard.show_error_status()
 
     # Register refresh function on page.data for access by any component
@@ -1182,9 +1184,7 @@ async def setup_dashboard(view: BaseView) -> None:
         page.data = {}
     page.data["refresh_dashboard"] = refresh_dashboard
 
-    # Consecutive disconnect checks before declaring page truly dead.
-    # Flet sessions reconnect within a few seconds — this grace period
-    # prevents background tasks from exiting during transient blips.
+    # Grace before declaring the page dead: Flet reconnects within seconds.
     _disconnect_grace_checks = 30  # ~30s at 1s per check
     _consecutive_disconnects = 0
 
@@ -1205,11 +1205,7 @@ async def setup_dashboard(view: BaseView) -> None:
         return True  # Still within grace period
 
     async def auto_refresh() -> None:
-        """Auto-refresh loop. Exits on page disconnect to allow clean shutdown.
-
-        On hot-reload, uvicorn kills the process and starts fresh —
-        flet_main runs again with a new http_client and new tasks.
-        """
+        """Auto-refresh loop. Exits on page disconnect or session corruption."""
         while _is_alive():
             try:
                 await refresh_dashboard()
@@ -1219,6 +1215,9 @@ async def setup_dashboard(view: BaseView) -> None:
                 logger.debug("Page disconnected during refresh, retrying")
                 await asyncio.sleep(5)
             except Exception as e:
+                if is_tree_corruption(e):
+                    await handle_corrupt_session(page)
+                    return
                 logger.error(f"Error in auto-refresh loop: {e}", exc_info=True)
                 await asyncio.sleep(30)
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/scheduler/heartbeat.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/scheduler/heartbeat.py
@@ -1,0 +1,39 @@
+"""Scheduler liveness heartbeat.
+
+An interval job touches a beacon file; the container healthcheck compares
+its mtime against a staleness window. The file path is duplicated in
+docker-compose's scheduler healthcheck command.
+"""
+
+from pathlib import Path
+from typing import Any
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+HEARTBEAT_FILE = Path("/tmp/aegis-scheduler-heartbeat")
+HEARTBEAT_JOB_ID = "scheduler_heartbeat"
+
+
+async def touch_scheduler_heartbeat() -> None:
+    """Liveness beacon proving the scheduler is actually firing jobs."""
+    HEARTBEAT_FILE.touch()
+
+
+def register_heartbeat_job(scheduler: AsyncIOScheduler) -> None:
+    """Register the beacon job on the scheduler."""
+    scheduler.add_job(
+        touch_scheduler_heartbeat,
+        trigger="interval",
+        seconds=15,
+        id=HEARTBEAT_JOB_ID,
+        name="Scheduler Heartbeat",
+        max_instances=1,
+        coalesce=True,
+        replace_existing=True,
+    )
+
+
+def is_heartbeat_event(event: Any) -> bool:
+    """True for job events the execution log should ignore: the heartbeat
+    fires constantly and would flood activity and history."""
+    return bool(getattr(event, "job_id", None) == HEARTBEAT_JOB_ID)

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/scheduler/main.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/scheduler/main.py.jinja
@@ -63,6 +63,7 @@ from app.services.finance.jobs import finance_sync_connections_job
 from app.core.config import settings
 from app.core.log import logger
 from app.services.system import activity
+from .heartbeat import is_heartbeat_event, register_heartbeat_job
 
 {% if scheduler_backend != "memory" %}
 
@@ -218,14 +219,11 @@ def create_scheduler() -> AsyncIOScheduler:
     )
 {% endif %}
 
-    # ========================================================================
-    # JOB SCHEDULE CONFIGURATION
-    #
-    # Code is the source of truth. Every startup re-registers each job
-    # below via ``replace_existing=True``, so editing a trigger here and
-    # redeploying is all that's needed to change the schedule. Runtime
-    # edits to persisted jobs do not survive a restart by design.
-    # ========================================================================
+    # JOB SCHEDULE CONFIGURATION - code is the source of truth. Every startup
+    # re-registers each job below via ``replace_existing=True``, so editing a
+    # trigger here and redeploying changes the schedule; runtime edits to
+    # persisted jobs do not survive a restart by design.
+    register_heartbeat_job(scheduler)
 
 {% if scheduler_backend != "memory" or (include_scheduler and include_database) %}
     scheduler.add_job(
@@ -463,6 +461,8 @@ async def run_scheduler() -> None:
 
     def _on_job_event(event: Any) -> None:
         """Emit activity events (and persist execution history) for jobs."""
+        if is_heartbeat_event(event):
+            return
 {%- if scheduler_backend != "memory" %}
         # JobSubmissionEvent uses `scheduled_run_times` (list); JobExecutionEvent
         # uses `scheduled_run_time` (singular). Normalise to a single value so

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/db.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/db.py.jinja
@@ -130,13 +130,17 @@ engine = create_engine(
 
 # Create async engine for non-blocking operations
 def _get_async_database_url(database_url: str) -> str:
-    """Convert sync database URL to async version."""
-{% if database_engine == "sqlite" %}
+    """Convert sync database URL to async version.
+
+    SQLite is handled whatever engine this project runs on: the test suite
+    points ``DATABASE_URL`` at a throwaway SQLite file before this module
+    builds its engines, so a Postgres project's tests run on SQLite too.
+    """
     if database_url.startswith("sqlite:///"):
         return database_url.replace("sqlite:///", "sqlite+aiosqlite:///")
     elif database_url.startswith("sqlite://"):
         return database_url.replace("sqlite://", "sqlite+aiosqlite://")
-{% else %}
+{% if database_engine != "sqlite" %}
     if database_url.startswith("postgresql://"):
         database_url = database_url.replace(
             "postgresql://", "postgresql+asyncpg://"

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/integrations/main.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/integrations/main.py.jinja
@@ -32,7 +32,7 @@ from app.core.log import logger, setup_logging  # noqa: E402
 from fastapi import Depends, FastAPI, HTTPException  # noqa: E402
 from fastapi.openapi.docs import get_redoc_html, get_swagger_ui_html  # noqa: E402
 from fastapi.openapi.utils import get_openapi  # noqa: E402
-from fastapi.responses import HTMLResponse  # noqa: E402
+from fastapi.responses import HTMLResponse, RedirectResponse  # noqa: E402
 from fastapi.security import HTTPBasic, HTTPBasicCredentials  # noqa: E402
 
 _docs_security = HTTPBasic(auto_error=False)
@@ -172,6 +172,10 @@ def create_integrated_app() -> FastAPI:
         secret_key=settings.SECRET_KEY,
     )
     # Mount Flet at /dashboard to avoid intercepting FastAPI routes like /health
+    @app.get("/", include_in_schema=False)
+    async def root_redirect() -> RedirectResponse:
+        return RedirectResponse(url="/dashboard/")
+
     app.mount("/dashboard", flet_app)
     # Splice the paste-capture script into the dashboard page: pasted
     # images post to /api/v1/pastebox, where consumer surfaces (chat's

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health.py.jinja
@@ -10,7 +10,9 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 import os
 import sys
-from typing import Any{%- if include_redis %}, cast{%- endif %}
+import time
+from typing import Any
+import weakref
 
 import psutil
 
@@ -88,6 +90,34 @@ def propagate_status(child_statuses: list[ComponentStatusType]) -> ComponentStat
 # Cache for system metrics to improve performance
 _system_metrics_cache: dict[str, tuple[ComponentStatus, datetime]] = {}
 
+# One shared walk for every consumer: probes, dashboard sessions, the CLI,
+# and scheduler jobs arriving within the TTL reuse a single collection run
+# instead of each fanning out to every component and service check.
+STATUS_CACHE_TTL_SECONDS = 10.0
+_status_cache: SystemStatus | None = None
+_status_cache_at: float = 0.0
+# Locks are per event loop: asyncio primitives bind to the loop that first
+# awaits them, and test runs create a fresh loop per test.
+_status_locks: weakref.WeakKeyDictionary[
+    asyncio.AbstractEventLoop, asyncio.Lock
+] = weakref.WeakKeyDictionary()
+
+
+def _status_lock() -> asyncio.Lock:
+    loop = asyncio.get_running_loop()
+    lock = _status_locks.get(loop)
+    if lock is None:
+        lock = asyncio.Lock()
+        _status_locks[loop] = lock
+    return lock
+
+
+def invalidate_status_cache() -> None:
+    """Drop the cached system status; the next call runs a fresh walk."""
+    global _status_cache, _status_cache_at
+    _status_cache = None
+    _status_cache_at = 0.0
+
 
 def register_health_check(
     name: str, check_fn: Callable[[], Awaitable[ComponentStatus]]
@@ -100,6 +130,7 @@ def register_health_check(
         check_fn: Async function that returns ComponentStatus or bool
     """
     _health_checks[name] = check_fn
+    invalidate_status_cache()
     logger.info(f"Registered custom health check: {name}")
     # Note: Activity event is emitted by _run_health_check on first check
     # with the actual status (not hardcoded "success")
@@ -116,18 +147,38 @@ def register_service_health_check(
         check_fn: Async function that returns ComponentStatus
     """
     _service_health_checks[name] = check_fn
+    invalidate_status_cache()
     logger.info(f"Registered service health check: {name}")
     # Note: Activity event is emitted by _run_health_check on first check
     # with the actual status (not hardcoded "success")
 
 
-async def get_system_status() -> SystemStatus:
+async def get_system_status(force_refresh: bool = False) -> SystemStatus:
     """
-    Get comprehensive system status.
+    Get comprehensive system status, sharing one walk across callers.
+
+    Results are cached for STATUS_CACHE_TTL_SECONDS; concurrent callers
+    wait on the in-flight walk instead of starting their own.
+
+    Args:
+        force_refresh: Skip the cache and run a fresh walk.
 
     Returns:
         SystemStatus with all component health information organized as Aegis tree
     """
+    global _status_cache, _status_cache_at
+    async with _status_lock():
+        fresh = time.monotonic() - _status_cache_at < STATUS_CACHE_TTL_SECONDS
+        if _status_cache is not None and fresh and not force_refresh:
+            return _status_cache
+        status = await _collect_system_status()
+        _status_cache = status
+        _status_cache_at = time.monotonic()
+        return status
+
+
+async def _collect_system_status() -> SystemStatus:
+    """Run every registered component, service, and metrics check once."""
     start_time = datetime.now(UTC)
 
     # Launch ALL checks concurrently (components + services + metrics)
@@ -642,815 +693,22 @@ async def _check_cpu_usage() -> ComponentStatus:
             response_time_ms=None,
         )
 
-
+# Re-exports: component checks live in sibling modules (one per component,
+# mirroring health_db); existing import sites keep working unchanged.
 {%- if include_redis %}
-
-
-def _decode_slowlog_arg(arg: Any) -> str:
-    """Decode a single SLOWLOG command argument to a readable string."""
-    if isinstance(arg, bytes):
-        return arg.decode("utf-8", errors="replace")
-    if isinstance(arg, str):
-        return arg
-    if isinstance(arg, list | tuple):
-        # redis-py can return args as list of ints (ASCII byte values)
-        try:
-            return bytes(arg).decode("utf-8", errors="replace")
-        except (ValueError, TypeError):
-            return str(arg)
-    return str(arg)
-
-
-def _decode_slowlog_command(command: Any) -> str:
-    """Decode a SLOWLOG command entry to a human-readable string."""
-    if isinstance(command, list | tuple):
-        return " ".join(_decode_slowlog_arg(arg) for arg in command)
-    if isinstance(command, bytes):
-        return command.decode("utf-8", errors="replace")
-    return str(command)
-
-
-async def check_cache_health() -> ComponentStatus:
-    """
-    Check cache connectivity and basic functionality.
-
-    Returns:
-        ComponentStatus indicating cache health
-    """
-    try:
-        import redis
-        import redis.asyncio as aioredis
-
-        # Create Redis connection with timeout
-        redis_url = (
-            settings.redis_url_effective
-            if hasattr(settings, 'redis_url_effective')
-            else settings.REDIS_URL
-        )
-        redis_connection = aioredis.from_url(  # type: ignore[no-untyped-call]
-            redis_url,
-            db=settings.REDIS_DB,
-            socket_timeout=settings.HEALTH_CHECK_TIMEOUT_SECONDS,
-            socket_connect_timeout=settings.HEALTH_CHECK_TIMEOUT_SECONDS,
-        )
-        redis_client: aioredis.Redis = cast(aioredis.Redis, redis_connection)
-
-        start_time = datetime.now(UTC)
-
-        # Test basic connectivity with ping
-        await redis_client.ping()
-
-        # Test basic set/get functionality
-        test_key = "health_check:test"
-        test_value = f"test_{start_time.timestamp()}"
-        await redis_client.set(test_key, test_value, ex=10)  # Expire in 10 seconds
-        retrieved_value = await redis_client.get(test_key)
-
-        # Cleanup test key
-        await redis_client.delete(test_key)
-
-        # Verify test worked
-        if retrieved_value.decode() != test_value:
-            raise Exception("Redis set/get test failed")
-
-        # Get comprehensive Redis info for detailed monitoring
-        # Reuse existing connection instead of creating a second one
-        redis_info_client = redis_client
-
-        # Get multiple INFO sections for comprehensive metrics
-        info = await redis_info_client.info()
-        stats_info = await redis_info_client.info('stats')
-        memory_info = await redis_info_client.info('memory')
-        clients_info = await redis_info_client.info('clients')
-        keyspace_info = await redis_info_client.info('keyspace')
-
-        # Get recent slow query log entries from Redis SLOWLOG
-        slowlog_entries: list[dict[str, Any]] = []
-        try:
-            slowlog = await redis_info_client.slowlog_get(10)
-            slowlog_entries = [
-                {
-                    "id": entry["id"],
-                    "timestamp": entry["start_time"],
-                    # Convert microseconds to ms
-                    "duration_ms": round(entry["duration"] / 1000, 2),
-                    "command": _decode_slowlog_command(entry["command"]),
-                }
-                for entry in slowlog
-            ]
-        except (redis.exceptions.RedisError, AttributeError, KeyError) as e:
-            logger.warning(f"Failed to get SLOWLOG: {e}")
-
-        # Get active client connections
-        active_clients: list[dict[str, str]] = []
-        try:
-            client_list = await redis_info_client.client_list()
-            active_clients = [
-                {
-                    "id": str(client.get("id", "")),
-                    "addr": str(client.get("addr", "")),
-                    "age": str(client.get("age", "0")),
-                    "idle": str(client.get("idle", "0")),
-                    "db": str(client.get("db", "0")),
-                    "cmd": str(client.get("cmd", "")),
-                }
-                for client in client_list
-            ]
-        except (redis.exceptions.RedisError, AttributeError, KeyError) as e:
-            logger.warning(f"Failed to get CLIENT LIST: {e}")
-
-        await redis_info_client.aclose()
-        
-        # Calculate derived metrics
-        keyspace_hits = stats_info.get('keyspace_hits', 0)
-        keyspace_misses = stats_info.get('keyspace_misses', 0)
-        total_keyspace_ops = keyspace_hits + keyspace_misses
-        hit_rate = (keyspace_hits / max(total_keyspace_ops, 1)) * 100
-        
-        # Extract total keys from all databases
-        total_keys = 0
-        keys_with_expiry = 0
-        for key, value in keyspace_info.items():
-            if key.startswith('db'):
-                # Redis info('keyspace') returns nested dict format
-                if isinstance(value, dict):
-                    total_keys += value.get('keys', 0)
-                    keys_with_expiry += value.get('expires', 0)
-        
-        # Memory usage calculations
-        used_memory = memory_info.get('used_memory', 0)
-        used_memory_peak = memory_info.get('used_memory_peak', 0)
-        mem_fragmentation_ratio = memory_info.get('mem_fragmentation_ratio', 1.0)
-        
-        return ComponentStatus(
-            name="cache",
-            status=ComponentStatusType.HEALTHY,
-            message="Redis cache connection and operations successful",
-            response_time_ms=None,  # Will be set by caller
-            metadata={
-                "implementation": "redis",
-                "version": info.get("redis_version", "unknown"),
-                "url": redis_url,
-                "db": settings.REDIS_DB,
-                
-                # Connection and client metrics
-                "connected_clients": clients_info.get("connected_clients", 0),
-                "blocked_clients": clients_info.get("blocked_clients", 0),
-                "client_longest_output_list": clients_info.get(
-                    "client_longest_output_list", 0
-                ),
-                
-                # Server uptime
-                "uptime_in_seconds": info.get("uptime_in_seconds", 0),
-                
-                # Memory metrics
-                "used_memory": used_memory,
-                "used_memory_human": memory_info.get("used_memory_human", "unknown"),
-                "used_memory_peak": used_memory_peak,
-                "used_memory_peak_human": memory_info.get(
-                    "used_memory_peak_human", "unknown"
-                ),
-                "mem_fragmentation_ratio": mem_fragmentation_ratio,
-                "maxmemory": memory_info.get("maxmemory", 0),
-                "maxmemory_human": memory_info.get("maxmemory_human", "0B"),
-                
-                # Performance and cache metrics
-                "instantaneous_ops_per_sec": stats_info.get(
-                    "instantaneous_ops_per_sec", 0
-                ),
-                "keyspace_hits": keyspace_hits,
-                "keyspace_misses": keyspace_misses,
-                "hit_rate_percent": hit_rate,
-                "evicted_keys": stats_info.get("evicted_keys", 0),
-                "expired_keys": stats_info.get("expired_keys", 0),
-                
-                # Keyspace statistics
-                "total_keys": total_keys,
-                "keys_with_expiry": keys_with_expiry,
-                
-                # Additional useful stats
-                "total_commands_processed": stats_info.get(
-                    "total_commands_processed", 0
-                ),
-                "total_connections_received": stats_info.get(
-                    "total_connections_received", 0
-                ),
-                "rejected_connections": stats_info.get("rejected_connections", 0),
-
-                # Slow queries and client connections
-                "slowlog_entries": slowlog_entries,
-                "active_clients": active_clients,
-            },
-        )
-
-    except ImportError:
-        return ComponentStatus(
-            name="cache",
-            status=ComponentStatusType.UNHEALTHY,
-            message="Cache library not installed",
-            response_time_ms=None,
-            metadata={
-                "implementation": "redis",
-                "error": "Redis library not available",
-            },
-        )
-    except Exception as e:
-        return ComponentStatus(
-            name="cache",
-            status=ComponentStatusType.UNHEALTHY,
-            message=f"Cache health check failed: {str(e)}",
-            response_time_ms=None,
-            metadata={
-                "implementation": "redis",
-                "url": (
-                    settings.redis_url_effective 
-                    if hasattr(settings, 'redis_url_effective') 
-                    else settings.REDIS_URL
-                ),
-                "db": settings.REDIS_DB,
-                "error": str(e),
-                # Provide fallback values for card display
-                "connected_clients": 0,
-                "used_memory_human": "unknown",
-                "uptime_in_seconds": 0,
-                "instantaneous_ops_per_sec": 0,
-                "hit_rate_percent": 0,
-                "total_keys": 0,
-                "evicted_keys": 0,
-                "expired_keys": 0,
-            },
-        )
-{% endif %}
-
-
-
-
+from app.services.system.health_cache import check_cache_health  # noqa: E402, F401
+{%- endif %}
+{%- if include_worker %}
+from app.services.system.health_worker import check_worker_health  # noqa: E402, F401
+{%- endif %}
 {%- if ollama_mode != "none" %}
-async def check_ollama_health() -> ComponentStatus:
-    """
-    Check Ollama server health and running models.
-
-    Returns:
-        ComponentStatus indicating Ollama infrastructure health with model info
-    """
-    try:
-        from app.services.ai.domains.llm.ollama import OllamaClient
-
-        # Get Ollama URL from settings (uses effective URL for Docker/local auto-detection)
-        ollama_url = settings.ollama_base_url_effective
-
-        client = OllamaClient(base_url=ollama_url)
-
-        # Get comprehensive server status
-        server_status = await client.get_server_status()
-
-        if not server_status.available:
-            return ComponentStatus(
-                name="ollama",
-                status=ComponentStatusType.UNHEALTHY,
-                message="Ollama server not reachable",
-                response_time_ms=None,
-                metadata={
-                    "available": False,
-                    "base_url": ollama_url,
-                    "error": "Connection failed",
-                },
-            )
-
-        # Feed the activity tracker: diffing the running set on every poll
-        # is how idle evictions and externally triggered loads get noticed
-        # (Ollama has no event API).
-        from app.services.ai.domains.llm.ollama_activity import get_ollama_activity
-
-        get_ollama_activity().observe(
-            {m.name: m.size_vram_gb for m in server_status.running_models}
-        )
-
-        # Use Pydantic's model_dump for clean serialization
-        running_models_info = [
-            m.model_dump(include={"name", "size_vram_gb", "is_warm", "context_length", "details"})
-            for m in server_status.running_models
-        ]
-        installed_models_info = [
-            m.model_dump(
-                include={
-                    "name",
-                    "size_gb",
-                    "details",
-                    # What `ollama list` prints and the table could not show:
-                    # the digest tells two pulls of one tag apart, and the
-                    # timestamp is how you spot a model that has gone stale.
-                    "digest",
-                    "modified_at",
-                    "capabilities",
-                },
-                mode="json",
-            )
-            for m in server_status.installed_models
-        ]
-
-        # Determine status based on server state
-        if server_status.running_models:
-            status = ComponentStatusType.HEALTHY
-            primary_model = server_status.running_models[0]
-            message = f"{primary_model.name} • {primary_model.size_vram_gb:.1f}GB VRAM • warm"
-        elif server_status.installed_models_count > 0:
-            status = ComponentStatusType.INFO
-            message = f"Ollama ready • {server_status.installed_models_count} models installed • none loaded"
-        else:
-            status = ComponentStatusType.WARNING
-            message = "Ollama running but no models installed"
-
-        return ComponentStatus(
-            name="ollama",
-            status=status,
-            message=message,
-            response_time_ms=None,
-            metadata={
-                "available": True,
-                "base_url": ollama_url,
-                "version": server_status.version,
-                "running_models": running_models_info,
-                "running_models_count": len(server_status.running_models),
-                "installed_models": installed_models_info,
-                "installed_models_count": server_status.installed_models_count,
-                "total_vram_gb": round(server_status.total_vram_gb, 2),
-            },
-        )
-
-    except ImportError:
-        return ComponentStatus(
-            name="ollama",
-            status=ComponentStatusType.UNHEALTHY,
-            message="Ollama client not available",
-            response_time_ms=None,
-            metadata={"error": "OllamaClient not installed"},
-        )
-    except Exception as e:
-        logger.error(f"Ollama health check failed: {e}")
-        return ComponentStatus(
-            name="ollama",
-            status=ComponentStatusType.UNHEALTHY,
-            message=f"Ollama health check failed: {str(e)}",
-            response_time_ms=None,
-            metadata={"error": str(e)},
-        )
-{% endif %}
-
-
+from app.services.system.health_ollama import check_ollama_health  # noqa: E402, F401
+{%- endif %}
 {%- if include_observability %}
-async def check_observability_health() -> ComponentStatus:
-    """
-    Check Logfire observability status and query trace analytics.
-
-    Reports whether Logfire is configured, whether cloud sending is active,
-    and the service name being used. When LOGFIRE_READ_TOKEN is set, queries
-    the Logfire Query API for trace statistics (spans, exceptions, latency).
-
-    Returns:
-        ComponentStatus indicating observability configuration status
-    """
-    try:
-        import logfire
-
-        send_to_logfire = bool(settings.LOGFIRE_TOKEN)
-        read_token = settings.LOGFIRE_READ_TOKEN
-        project_url = settings.LOGFIRE_PROJECT_URL
-
-        if send_to_logfire:
-            status = ComponentStatusType.HEALTHY
-            message = "Logfire active (sending to cloud)"
-        else:
-            status = ComponentStatusType.INFO
-            message = "Logfire instrumented (cloud disabled -- no token)"
-
-        metadata: dict[str, Any] = {
-            "configured": True,
-            "send_to_logfire": send_to_logfire,
-            "service_name": settings.PROJECT_NAME,
-            "query_api_available": bool(read_token),
-            "project_url": project_url,
-            "logfire_version": logfire.VERSION,
-        }
-
-        # Query Logfire API for trace analytics when read token is available
-        if read_token:
-            trace_data = await _query_logfire_trace_data(read_token)
-            metadata.update(trace_data)
-
-        return ComponentStatus(
-            name="observability",
-            status=status,
-            message=message,
-            response_time_ms=None,
-            metadata=metadata,
-        )
-
-    except Exception as e:
-        logger.error(f"Observability health check failed: {e}")
-        return ComponentStatus(
-            name="observability",
-            status=ComponentStatusType.UNHEALTHY,
-            message=f"Observability health check failed: {str(e)}",
-            response_time_ms=None,
-            metadata={"error": str(e)},
-        )
-
-
-# Cache for Logfire query results to avoid rate limiting
-# Free tier has per-minute AND per-hour limits
-_logfire_query_cache: dict[str, tuple[dict[str, Any], datetime]] = {}
-_logfire_last_attempt: datetime | None = None
-_LOGFIRE_CACHE_SECONDS = 120  # 2 minutes between successful queries (3 sub-queries per cycle)
-_LOGFIRE_RETRY_SECONDS = 300  # 5 minutes between retries on failure
-
-
-async def _query_logfire_trace_data(read_token: str) -> dict[str, Any]:
-    """
-    Query Logfire Query API for trace statistics over the last hour.
-
-    Results are cached for 5 minutes to avoid hitting rate limits.
-    On failure, backs off for 5 minutes and returns stale cached data.
-
-    Runs three lightweight queries concurrently:
-    1. Aggregate stats (span count, exceptions, avg/max duration, trace count)
-    2. Top 20 slowest span types
-    3. Recent exceptions
-
-    Args:
-        read_token: Logfire read token for API authentication
-
-    Returns:
-        Dict with trace analytics data for metadata
-    """
-    global _logfire_last_attempt
-
-    now = datetime.now(UTC)
-
-    # Check cache - return cached data if still fresh
-    if "logfire" in _logfire_query_cache:
-        cached_result, cached_time = _logfire_query_cache["logfire"]
-        age = (now - cached_time).total_seconds()
-        if age < _LOGFIRE_CACHE_SECONDS:
-            return cached_result
-
-    # Backoff - don't retry if we attempted recently (even if it failed)
-    if _logfire_last_attempt is not None:
-        since_last = (now - _logfire_last_attempt).total_seconds()
-        if since_last < _LOGFIRE_RETRY_SECONDS:
-            # Return stale cache if available
-            if "logfire" in _logfire_query_cache:
-                stale_result, _ = _logfire_query_cache["logfire"]
-                return stale_result
-            return {}
-
-    # Mark attempt time BEFORE querying to prevent concurrent retries
-    _logfire_last_attempt = now
-
-    try:
-        from logfire.experimental.query_client import AsyncLogfireQueryClient
-    except ImportError:
-        logger.warning("Logfire query client not available")
-        return {"query_error": "logfire query client not installed"}
-
-    result: dict[str, Any] = {}
-
-    try:
-        async with AsyncLogfireQueryClient(read_token=read_token) as client:
-            # Run all three queries concurrently
-            agg_task = asyncio.create_task(_query_aggregate_stats(client))
-            slow_task = asyncio.create_task(_query_slowest_spans(client))
-            exc_task = asyncio.create_task(_query_recent_exceptions(client))
-
-            agg_data = await agg_task
-            slow_data = await slow_task
-            exc_data = await exc_task
-
-        # Check for partial failures (None = sub-query failed)
-        all_succeeded = (
-            agg_data is not None
-            and slow_data is not None
-            and exc_data is not None
-        )
-
-        # Always assemble what we have (use defaults for failed sub-queries)
-        if agg_data is not None:
-            result.update(agg_data)
-        else:
-            result.update({
-                "total_spans": 0, "total_traces": 0, "exceptions": 0,
-                "avg_duration_ms": 0, "max_duration_ms": 0,
-            })
-        result["slowest_spans"] = slow_data if slow_data is not None else []
-        result["recent_exceptions"] = exc_data if exc_data is not None else []
-
-        if all_succeeded:
-            assert agg_data is not None and slow_data is not None  # for type narrowing
-            # All queries succeeded - cache the complete result
-            _logfire_query_cache["logfire"] = (result, now)
-            # Reset backoff on success so cache TTL controls refresh rate
-            _logfire_last_attempt = None
-            logger.info(
-                f"Logfire query refreshed: {agg_data.get('total_spans', 0)} spans, "
-                f"{agg_data.get('exceptions', 0)} exceptions, "
-                f"{len(slow_data)} slow spans"
-            )
-        else:
-            # Partial failure - log which queries failed, don't cache
-            failed = []
-            if agg_data is None:
-                failed.append("aggregate")
-            if slow_data is None:
-                failed.append("slowest_spans")
-            if exc_data is None:
-                failed.append("exceptions")
-            logger.warning(
-                f"Logfire partial query failure ({', '.join(failed)})"
-            )
-            # Prefer stale cache if it has richer data
-            if "logfire" in _logfire_query_cache:
-                stale_result, _ = _logfire_query_cache["logfire"]
-                return stale_result
-
-    except Exception as e:
-        logger.warning(f"Logfire query API error: {e}")
-        result["query_error"] = str(e)
-        # Return stale cache if available rather than empty data
-        if "logfire" in _logfire_query_cache:
-            stale_result, _ = _logfire_query_cache["logfire"]
-            return stale_result
-
-    return result
-
-
-async def _query_aggregate_stats(client: Any) -> dict[str, Any] | None:
-    """Query aggregate span stats for the last hour. Returns None on failure."""
-    try:
-        results = await client.query_json_rows(
-            sql="""
-                SELECT
-                    count(*) as total_spans,
-                    count(*) FILTER (WHERE is_exception) as exceptions,
-                    avg(duration) as avg_duration_sec,
-                    max(duration) as max_duration_sec,
-                    count(DISTINCT trace_id) as total_traces
-                FROM records
-                WHERE start_timestamp > now() - interval '1 hour'
-            """
-        )
-        rows = results.get("rows", [])
-        if rows:
-            row = rows[0]
-            avg_sec = row.get("avg_duration_sec") or 0
-            max_sec = row.get("max_duration_sec") or 0
-            return {
-                "total_spans": row.get("total_spans", 0),
-                "total_traces": row.get("total_traces", 0),
-                "exceptions": row.get("exceptions", 0),
-                "avg_duration_ms": round(float(avg_sec) * 1000, 1),
-                "max_duration_ms": round(float(max_sec) * 1000, 1),
-            }
-        logger.warning("Logfire aggregate stats query returned no rows")
-        return None
-    except Exception as e:
-        logger.warning(f"Logfire aggregate stats query failed: {e}")
-        return None
-
-
-async def _query_slowest_spans(client: Any) -> list[dict[str, Any]] | None:
-    """Query top 20 slowest span types for the last hour. Returns None on failure."""
-    try:
-        results = await client.query_json_rows(
-            sql="""
-                SELECT
-                    span_name,
-                    avg(duration) as avg_sec,
-                    max(duration) as max_sec,
-                    percentile_cont(0.95) WITHIN GROUP (ORDER BY duration) as p95_sec,
-                    count(*) as count,
-                    count(*) FILTER (WHERE is_exception) as errors,
-                    sum(duration) as total_sec
-                FROM records
-                WHERE start_timestamp > now() - interval '1 hour'
-                  AND duration IS NOT NULL
-                GROUP BY span_name
-                ORDER BY avg_sec DESC
-                LIMIT 20
-            """
-        )
-        rows = results.get("rows", [])
-        spans = []
-        for row in rows:
-            avg_sec = row.get("avg_sec") or 0
-            max_sec = row.get("max_sec") or 0
-            p95_sec = row.get("p95_sec") or 0
-            total_sec = row.get("total_sec") or 0
-            spans.append({
-                "name": row.get("span_name", "unknown"),
-                "avg_ms": round(float(avg_sec) * 1000, 1),
-                "max_ms": round(float(max_sec) * 1000, 1),
-                "p95_ms": round(float(p95_sec) * 1000, 1),
-                "count": row.get("count", 0),
-                "errors": row.get("errors", 0),
-                "total_ms": round(float(total_sec) * 1000, 1),
-            })
-        return spans
-    except Exception as e:
-        logger.warning(f"Logfire slowest spans query failed: {e}")
-        return None
-
-
-async def _query_recent_exceptions(client: Any) -> list[dict[str, Any]] | None:
-    """Query recent exceptions for the last 24 hours. Returns None on failure."""
-    try:
-        results = await client.query_json_rows(
-            sql="""
-                SELECT
-                    span_name,
-                    message,
-                    start_timestamp,
-                    exception_type,
-                    exception_message,
-                    exception_stacktrace,
-                    trace_id,
-                    service_name
-                FROM records
-                WHERE is_exception AND start_timestamp > now() - interval '24 hours'
-                ORDER BY start_timestamp DESC
-                LIMIT 200
-            """
-        )
-        exceptions = []
-        for row in results.get("rows", []):
-            exceptions.append({
-                "span_name": row.get("span_name", "unknown"),
-                "message": row.get("message", ""),
-                "timestamp": row.get("start_timestamp", ""),
-                "exception_type": row.get("exception_type", ""),
-                "exception_message": row.get("exception_message", ""),
-                "stacktrace": row.get("exception_stacktrace", ""),
-                "trace_id": row.get("trace_id", ""),
-                "service_name": row.get("service_name", ""),
-            })
-        return exceptions
-    except Exception as e:
-        logger.warning(f"Logfire recent exceptions query failed: {e}")
-        return None
-{% endif %}
-
-
+from app.services.system.health_observability import (  # noqa: E402, F401
+    check_observability_health,
+)
+{%- endif %}
 {%- if include_ingress %}
-async def check_ingress_health() -> ComponentStatus:
-    """
-    Check Traefik reverse proxy health and configuration.
-
-    Returns:
-        ComponentStatus indicating Traefik infrastructure health with router info
-    """
-    try:
-        import httpx
-
-        # Traefik API endpoint (dashboard API)
-        traefik_api_url = settings.traefik_api_url_effective
-
-        async with httpx.AsyncClient(
-            timeout=settings.HEALTH_CHECK_TIMEOUT_SECONDS,
-        ) as client:
-            # Check Traefik health endpoint
-            try:
-                health_response = await client.get(f"{traefik_api_url}/ping")
-                traefik_available = health_response.status_code == 200
-            except Exception:
-                traefik_available = False
-
-            if not traefik_available:
-                return ComponentStatus(
-                    name="ingress",
-                    status=ComponentStatusType.UNHEALTHY,
-                    message="Traefik not reachable",
-                    response_time_ms=None,
-                    metadata={
-                        "available": False,
-                        "api_url": traefik_api_url,
-                        "error": "Connection failed",
-                    },
-                )
-
-            # Get Traefik version and overview
-            try:
-                version_response = await client.get(
-                    f"{traefik_api_url}/api/version"
-                )
-                if version_response.status_code == 200:
-                    version_data = version_response.json()
-                else:
-                    version_data = {}
-            except Exception:
-                version_data = {}
-
-            # Get HTTP routers
-            try:
-                routers_response = await client.get(
-                    f"{traefik_api_url}/api/http/routers"
-                )
-                if routers_response.status_code == 200:
-                    routers = routers_response.json()
-                else:
-                    routers = []
-            except Exception:
-                routers = []
-
-            # Get HTTP services
-            try:
-                services_response = await client.get(
-                    f"{traefik_api_url}/api/http/services"
-                )
-                if services_response.status_code == 200:
-                    services = services_response.json()
-                else:
-                    services = []
-            except Exception:
-                services = []
-
-            # Get entrypoints
-            try:
-                entrypoints_response = await client.get(
-                    f"{traefik_api_url}/api/entrypoints"
-                )
-                if entrypoints_response.status_code == 200:
-                    entrypoints = entrypoints_response.json()
-                else:
-                    entrypoints = []
-            except Exception:
-                entrypoints = []
-
-            # Count enabled routers and services
-            enabled_routers = [r for r in routers if r.get("status") == "enabled"]
-            enabled_services = [s for s in services if s.get("status") == "enabled"]
-
-            # Determine status based on configuration
-            if len(enabled_routers) == 0:
-                status = ComponentStatusType.WARNING
-                message = "Traefik running but no routers configured"
-            else:
-                status = ComponentStatusType.HEALTHY
-                message = (
-                    f"Traefik active: {len(enabled_routers)} routers, "
-                    f"{len(enabled_services)} services"
-                )
-
-            # Extract entrypoint info
-            entrypoint_info = []
-            for ep in entrypoints:
-                ep_name = ep.get("name", "unknown")
-                ep_addr = ep.get("address", "unknown")
-                entrypoint_info.append({"name": ep_name, "address": ep_addr})
-
-            # Extract router info (limited to first 10 for metadata)
-            router_info = []
-            for router in enabled_routers[:10]:
-                router_info.append({
-                    "name": router.get("name", "unknown"),
-                    "rule": router.get("rule", ""),
-                    "service": router.get("service", ""),
-                    "entryPoints": router.get("entryPoints", []),
-                    "tls": router.get("tls") is not None,
-                })
-
-            return ComponentStatus(
-                name="ingress",
-                status=status,
-                message=message,
-                response_time_ms=None,
-                metadata={
-                    "available": True,
-                    "api_url": traefik_api_url,
-                    "version": version_data.get("Version", "unknown"),
-                    "codename": version_data.get("Codename", ""),
-                    "total_routers": len(routers),
-                    "enabled_routers": len(enabled_routers),
-                    "total_services": len(services),
-                    "enabled_services": len(enabled_services),
-                    "entrypoints": entrypoint_info,
-                    "routers": router_info,
-                },
-            )
-
-    except ImportError:
-        return ComponentStatus(
-            name="ingress",
-            status=ComponentStatusType.UNHEALTHY,
-            message="HTTP client not available",
-            response_time_ms=None,
-            metadata={"error": "httpx not installed"},
-        )
-    except Exception as e:
-        logger.error(f"Ingress health check failed: {e}")
-        return ComponentStatus(
-            name="ingress",
-            status=ComponentStatusType.UNHEALTHY,
-            message=f"Ingress health check failed: {str(e)}",
-            response_time_ms=None,
-            metadata={"error": str(e)},
-        )
-{% endif %}
+from app.services.system.health_ingress import check_ingress_health  # noqa: E402, F401
+{%- endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_cache.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_cache.py.jinja
@@ -1,0 +1,253 @@
+{#- aegis: no-backup -#}
+"""
+Redis cache health check for {{ project_name }}.
+
+Extracted from the system health module; registered via the same
+register_health_check machinery.
+"""
+{% if include_redis %}
+from datetime import UTC, datetime
+from typing import Any, cast
+
+from app.core.config import settings
+from app.core.log import logger
+
+from .models import ComponentStatus, ComponentStatusType
+
+
+
+def _decode_slowlog_arg(arg: Any) -> str:
+    """Decode a single SLOWLOG command argument to a readable string."""
+    if isinstance(arg, bytes):
+        return arg.decode("utf-8", errors="replace")
+    if isinstance(arg, str):
+        return arg
+    if isinstance(arg, list | tuple):
+        # redis-py can return args as list of ints (ASCII byte values)
+        try:
+            return bytes(arg).decode("utf-8", errors="replace")
+        except (ValueError, TypeError):
+            return str(arg)
+    return str(arg)
+
+
+def _decode_slowlog_command(command: Any) -> str:
+    """Decode a SLOWLOG command entry to a human-readable string."""
+    if isinstance(command, list | tuple):
+        return " ".join(_decode_slowlog_arg(arg) for arg in command)
+    if isinstance(command, bytes):
+        return command.decode("utf-8", errors="replace")
+    return str(command)
+
+
+async def check_cache_health() -> ComponentStatus:
+    """
+    Check cache connectivity and basic functionality.
+
+    Returns:
+        ComponentStatus indicating cache health
+    """
+    try:
+        import redis
+        import redis.asyncio as aioredis
+
+        # Create Redis connection with timeout
+        redis_url = (
+            settings.redis_url_effective
+            if hasattr(settings, 'redis_url_effective')
+            else settings.REDIS_URL
+        )
+        redis_connection = aioredis.from_url(  # type: ignore[no-untyped-call]
+            redis_url,
+            db=settings.REDIS_DB,
+            socket_timeout=settings.HEALTH_CHECK_TIMEOUT_SECONDS,
+            socket_connect_timeout=settings.HEALTH_CHECK_TIMEOUT_SECONDS,
+        )
+        redis_client: aioredis.Redis = cast(aioredis.Redis, redis_connection)
+
+        start_time = datetime.now(UTC)
+
+        # Test basic connectivity with ping
+        await redis_client.ping()
+
+        # Test basic set/get functionality
+        test_key = "health_check:test"
+        test_value = f"test_{start_time.timestamp()}"
+        await redis_client.set(test_key, test_value, ex=10)  # Expire in 10 seconds
+        retrieved_value = await redis_client.get(test_key)
+
+        # Cleanup test key
+        await redis_client.delete(test_key)
+
+        # Verify test worked
+        if retrieved_value.decode() != test_value:
+            raise Exception("Redis set/get test failed")
+
+        # Get comprehensive Redis info for detailed monitoring
+        # Reuse existing connection instead of creating a second one
+        redis_info_client = redis_client
+
+        # Get multiple INFO sections for comprehensive metrics
+        info = await redis_info_client.info()
+        stats_info = await redis_info_client.info('stats')
+        memory_info = await redis_info_client.info('memory')
+        clients_info = await redis_info_client.info('clients')
+        keyspace_info = await redis_info_client.info('keyspace')
+
+        # Get recent slow query log entries from Redis SLOWLOG
+        slowlog_entries: list[dict[str, Any]] = []
+        try:
+            slowlog = await redis_info_client.slowlog_get(10)
+            slowlog_entries = [
+                {
+                    "id": entry["id"],
+                    "timestamp": entry["start_time"],
+                    # Convert microseconds to ms
+                    "duration_ms": round(entry["duration"] / 1000, 2),
+                    "command": _decode_slowlog_command(entry["command"]),
+                }
+                for entry in slowlog
+            ]
+        except (redis.exceptions.RedisError, AttributeError, KeyError) as e:
+            logger.warning(f"Failed to get SLOWLOG: {e}")
+
+        # Get active client connections
+        active_clients: list[dict[str, str]] = []
+        try:
+            client_list = await redis_info_client.client_list()
+            active_clients = [
+                {
+                    "id": str(client.get("id", "")),
+                    "addr": str(client.get("addr", "")),
+                    "age": str(client.get("age", "0")),
+                    "idle": str(client.get("idle", "0")),
+                    "db": str(client.get("db", "0")),
+                    "cmd": str(client.get("cmd", "")),
+                }
+                for client in client_list
+            ]
+        except (redis.exceptions.RedisError, AttributeError, KeyError) as e:
+            logger.warning(f"Failed to get CLIENT LIST: {e}")
+
+        await redis_info_client.aclose()
+        
+        # Calculate derived metrics
+        keyspace_hits = stats_info.get('keyspace_hits', 0)
+        keyspace_misses = stats_info.get('keyspace_misses', 0)
+        total_keyspace_ops = keyspace_hits + keyspace_misses
+        hit_rate = (keyspace_hits / max(total_keyspace_ops, 1)) * 100
+        
+        # Extract total keys from all databases
+        total_keys = 0
+        keys_with_expiry = 0
+        for key, value in keyspace_info.items():
+            if key.startswith('db'):
+                # Redis info('keyspace') returns nested dict format
+                if isinstance(value, dict):
+                    total_keys += value.get('keys', 0)
+                    keys_with_expiry += value.get('expires', 0)
+        
+        # Memory usage calculations
+        used_memory = memory_info.get('used_memory', 0)
+        used_memory_peak = memory_info.get('used_memory_peak', 0)
+        mem_fragmentation_ratio = memory_info.get('mem_fragmentation_ratio', 1.0)
+        
+        return ComponentStatus(
+            name="cache",
+            status=ComponentStatusType.HEALTHY,
+            message="Redis cache connection and operations successful",
+            response_time_ms=None,  # Will be set by caller
+            metadata={
+                "implementation": "redis",
+                "version": info.get("redis_version", "unknown"),
+                "url": redis_url,
+                "db": settings.REDIS_DB,
+                
+                # Connection and client metrics
+                "connected_clients": clients_info.get("connected_clients", 0),
+                "blocked_clients": clients_info.get("blocked_clients", 0),
+                "client_longest_output_list": clients_info.get(
+                    "client_longest_output_list", 0
+                ),
+                
+                # Server uptime
+                "uptime_in_seconds": info.get("uptime_in_seconds", 0),
+                
+                # Memory metrics
+                "used_memory": used_memory,
+                "used_memory_human": memory_info.get("used_memory_human", "unknown"),
+                "used_memory_peak": used_memory_peak,
+                "used_memory_peak_human": memory_info.get(
+                    "used_memory_peak_human", "unknown"
+                ),
+                "mem_fragmentation_ratio": mem_fragmentation_ratio,
+                "maxmemory": memory_info.get("maxmemory", 0),
+                "maxmemory_human": memory_info.get("maxmemory_human", "0B"),
+                
+                # Performance and cache metrics
+                "instantaneous_ops_per_sec": stats_info.get(
+                    "instantaneous_ops_per_sec", 0
+                ),
+                "keyspace_hits": keyspace_hits,
+                "keyspace_misses": keyspace_misses,
+                "hit_rate_percent": hit_rate,
+                "evicted_keys": stats_info.get("evicted_keys", 0),
+                "expired_keys": stats_info.get("expired_keys", 0),
+                
+                # Keyspace statistics
+                "total_keys": total_keys,
+                "keys_with_expiry": keys_with_expiry,
+                
+                # Additional useful stats
+                "total_commands_processed": stats_info.get(
+                    "total_commands_processed", 0
+                ),
+                "total_connections_received": stats_info.get(
+                    "total_connections_received", 0
+                ),
+                "rejected_connections": stats_info.get("rejected_connections", 0),
+
+                # Slow queries and client connections
+                "slowlog_entries": slowlog_entries,
+                "active_clients": active_clients,
+            },
+        )
+
+    except ImportError:
+        return ComponentStatus(
+            name="cache",
+            status=ComponentStatusType.UNHEALTHY,
+            message="Cache library not installed",
+            response_time_ms=None,
+            metadata={
+                "implementation": "redis",
+                "error": "Redis library not available",
+            },
+        )
+    except Exception as e:
+        return ComponentStatus(
+            name="cache",
+            status=ComponentStatusType.UNHEALTHY,
+            message=f"Cache health check failed: {str(e)}",
+            response_time_ms=None,
+            metadata={
+                "implementation": "redis",
+                "url": (
+                    settings.redis_url_effective 
+                    if hasattr(settings, 'redis_url_effective') 
+                    else settings.REDIS_URL
+                ),
+                "db": settings.REDIS_DB,
+                "error": str(e),
+                # Provide fallback values for card display
+                "connected_clients": 0,
+                "used_memory_human": "unknown",
+                "uptime_in_seconds": 0,
+                "instantaneous_ops_per_sec": 0,
+                "hit_rate_percent": 0,
+                "total_keys": 0,
+                "evicted_keys": 0,
+                "expired_keys": 0,
+            },
+        )
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_ingress.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_ingress.py.jinja
@@ -1,0 +1,167 @@
+{#- aegis: no-backup -#}
+"""
+Ingress (Traefik) health check for {{ project_name }}.
+
+Extracted from the system health module; registered via the same
+register_health_check machinery.
+"""
+{% if include_ingress %}
+from app.core.config import settings
+from app.core.log import logger
+
+from .models import ComponentStatus, ComponentStatusType
+
+async def check_ingress_health() -> ComponentStatus:
+    """
+    Check Traefik reverse proxy health and configuration.
+
+    Returns:
+        ComponentStatus indicating Traefik infrastructure health with router info
+    """
+    try:
+        import httpx
+
+        # Traefik API endpoint (dashboard API)
+        traefik_api_url = settings.traefik_api_url_effective
+
+        async with httpx.AsyncClient(
+            timeout=settings.HEALTH_CHECK_TIMEOUT_SECONDS,
+        ) as client:
+            # Check Traefik health endpoint
+            try:
+                health_response = await client.get(f"{traefik_api_url}/ping")
+                traefik_available = health_response.status_code == 200
+            except Exception:
+                traefik_available = False
+
+            if not traefik_available:
+                return ComponentStatus(
+                    name="ingress",
+                    status=ComponentStatusType.UNHEALTHY,
+                    message="Traefik not reachable",
+                    response_time_ms=None,
+                    metadata={
+                        "available": False,
+                        "api_url": traefik_api_url,
+                        "error": "Connection failed",
+                    },
+                )
+
+            # Get Traefik version and overview
+            try:
+                version_response = await client.get(
+                    f"{traefik_api_url}/api/version"
+                )
+                if version_response.status_code == 200:
+                    version_data = version_response.json()
+                else:
+                    version_data = {}
+            except Exception:
+                version_data = {}
+
+            # Get HTTP routers
+            try:
+                routers_response = await client.get(
+                    f"{traefik_api_url}/api/http/routers"
+                )
+                if routers_response.status_code == 200:
+                    routers = routers_response.json()
+                else:
+                    routers = []
+            except Exception:
+                routers = []
+
+            # Get HTTP services
+            try:
+                services_response = await client.get(
+                    f"{traefik_api_url}/api/http/services"
+                )
+                if services_response.status_code == 200:
+                    services = services_response.json()
+                else:
+                    services = []
+            except Exception:
+                services = []
+
+            # Get entrypoints
+            try:
+                entrypoints_response = await client.get(
+                    f"{traefik_api_url}/api/entrypoints"
+                )
+                if entrypoints_response.status_code == 200:
+                    entrypoints = entrypoints_response.json()
+                else:
+                    entrypoints = []
+            except Exception:
+                entrypoints = []
+
+            # Count enabled routers and services
+            enabled_routers = [r for r in routers if r.get("status") == "enabled"]
+            enabled_services = [s for s in services if s.get("status") == "enabled"]
+
+            # Determine status based on configuration
+            if len(enabled_routers) == 0:
+                status = ComponentStatusType.WARNING
+                message = "Traefik running but no routers configured"
+            else:
+                status = ComponentStatusType.HEALTHY
+                message = (
+                    f"Traefik active: {len(enabled_routers)} routers, "
+                    f"{len(enabled_services)} services"
+                )
+
+            # Extract entrypoint info
+            entrypoint_info = []
+            for ep in entrypoints:
+                ep_name = ep.get("name", "unknown")
+                ep_addr = ep.get("address", "unknown")
+                entrypoint_info.append({"name": ep_name, "address": ep_addr})
+
+            # Extract router info (limited to first 10 for metadata)
+            router_info = []
+            for router in enabled_routers[:10]:
+                router_info.append({
+                    "name": router.get("name", "unknown"),
+                    "rule": router.get("rule", ""),
+                    "service": router.get("service", ""),
+                    "entryPoints": router.get("entryPoints", []),
+                    "tls": router.get("tls") is not None,
+                })
+
+            return ComponentStatus(
+                name="ingress",
+                status=status,
+                message=message,
+                response_time_ms=None,
+                metadata={
+                    "available": True,
+                    "api_url": traefik_api_url,
+                    "version": version_data.get("Version", "unknown"),
+                    "codename": version_data.get("Codename", ""),
+                    "total_routers": len(routers),
+                    "enabled_routers": len(enabled_routers),
+                    "total_services": len(services),
+                    "enabled_services": len(enabled_services),
+                    "entrypoints": entrypoint_info,
+                    "routers": router_info,
+                },
+            )
+
+    except ImportError:
+        return ComponentStatus(
+            name="ingress",
+            status=ComponentStatusType.UNHEALTHY,
+            message="HTTP client not available",
+            response_time_ms=None,
+            metadata={"error": "httpx not installed"},
+        )
+    except Exception as e:
+        logger.error(f"Ingress health check failed: {e}")
+        return ComponentStatus(
+            name="ingress",
+            status=ComponentStatusType.UNHEALTHY,
+            message=f"Ingress health check failed: {str(e)}",
+            response_time_ms=None,
+            metadata={"error": str(e)},
+        )
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_observability.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_observability.py.jinja
@@ -1,0 +1,315 @@
+{#- aegis: no-backup -#}
+"""
+Observability (Logfire) health check for {{ project_name }}.
+
+Extracted from the system health module; registered via the same
+register_health_check machinery.
+"""
+{% if include_observability %}
+import asyncio
+from datetime import UTC, datetime
+from typing import Any
+
+from app.core.config import settings
+from app.core.log import logger
+
+from .models import ComponentStatus, ComponentStatusType
+
+async def check_observability_health() -> ComponentStatus:
+    """
+    Check Logfire observability status and query trace analytics.
+
+    Reports whether Logfire is configured, whether cloud sending is active,
+    and the service name being used. When LOGFIRE_READ_TOKEN is set, queries
+    the Logfire Query API for trace statistics (spans, exceptions, latency).
+
+    Returns:
+        ComponentStatus indicating observability configuration status
+    """
+    try:
+        import logfire
+
+        send_to_logfire = bool(settings.LOGFIRE_TOKEN)
+        read_token = settings.LOGFIRE_READ_TOKEN
+        project_url = settings.LOGFIRE_PROJECT_URL
+
+        if send_to_logfire:
+            status = ComponentStatusType.HEALTHY
+            message = "Logfire active (sending to cloud)"
+        else:
+            status = ComponentStatusType.INFO
+            message = "Logfire instrumented (cloud disabled -- no token)"
+
+        metadata: dict[str, Any] = {
+            "configured": True,
+            "send_to_logfire": send_to_logfire,
+            "service_name": settings.PROJECT_NAME,
+            "query_api_available": bool(read_token),
+            "project_url": project_url,
+            "logfire_version": logfire.VERSION,
+        }
+
+        # Query Logfire API for trace analytics when read token is available
+        if read_token:
+            trace_data = await _query_logfire_trace_data(read_token)
+            metadata.update(trace_data)
+
+        return ComponentStatus(
+            name="observability",
+            status=status,
+            message=message,
+            response_time_ms=None,
+            metadata=metadata,
+        )
+
+    except Exception as e:
+        logger.error(f"Observability health check failed: {e}")
+        return ComponentStatus(
+            name="observability",
+            status=ComponentStatusType.UNHEALTHY,
+            message=f"Observability health check failed: {str(e)}",
+            response_time_ms=None,
+            metadata={"error": str(e)},
+        )
+
+
+# Cache for Logfire query results to avoid rate limiting
+# Free tier has per-minute AND per-hour limits
+_logfire_query_cache: dict[str, tuple[dict[str, Any], datetime]] = {}
+_logfire_last_attempt: datetime | None = None
+_LOGFIRE_CACHE_SECONDS = 120  # 2 minutes between successful queries (3 sub-queries per cycle)
+_LOGFIRE_RETRY_SECONDS = 300  # 5 minutes between retries on failure
+
+
+async def _query_logfire_trace_data(read_token: str) -> dict[str, Any]:
+    """
+    Query Logfire Query API for trace statistics over the last hour.
+
+    Results are cached for 5 minutes to avoid hitting rate limits.
+    On failure, backs off for 5 minutes and returns stale cached data.
+
+    Runs three lightweight queries concurrently:
+    1. Aggregate stats (span count, exceptions, avg/max duration, trace count)
+    2. Top 20 slowest span types
+    3. Recent exceptions
+
+    Args:
+        read_token: Logfire read token for API authentication
+
+    Returns:
+        Dict with trace analytics data for metadata
+    """
+    global _logfire_last_attempt
+
+    now = datetime.now(UTC)
+
+    # Check cache - return cached data if still fresh
+    if "logfire" in _logfire_query_cache:
+        cached_result, cached_time = _logfire_query_cache["logfire"]
+        age = (now - cached_time).total_seconds()
+        if age < _LOGFIRE_CACHE_SECONDS:
+            return cached_result
+
+    # Backoff - don't retry if we attempted recently (even if it failed)
+    if _logfire_last_attempt is not None:
+        since_last = (now - _logfire_last_attempt).total_seconds()
+        if since_last < _LOGFIRE_RETRY_SECONDS:
+            # Return stale cache if available
+            if "logfire" in _logfire_query_cache:
+                stale_result, _ = _logfire_query_cache["logfire"]
+                return stale_result
+            return {}
+
+    # Mark attempt time BEFORE querying to prevent concurrent retries
+    _logfire_last_attempt = now
+
+    try:
+        from logfire.experimental.query_client import AsyncLogfireQueryClient
+    except ImportError:
+        logger.warning("Logfire query client not available")
+        return {"query_error": "logfire query client not installed"}
+
+    result: dict[str, Any] = {}
+
+    try:
+        async with AsyncLogfireQueryClient(read_token=read_token) as client:
+            # Run all three queries concurrently
+            agg_task = asyncio.create_task(_query_aggregate_stats(client))
+            slow_task = asyncio.create_task(_query_slowest_spans(client))
+            exc_task = asyncio.create_task(_query_recent_exceptions(client))
+
+            agg_data = await agg_task
+            slow_data = await slow_task
+            exc_data = await exc_task
+
+        # Check for partial failures (None = sub-query failed)
+        all_succeeded = (
+            agg_data is not None
+            and slow_data is not None
+            and exc_data is not None
+        )
+
+        # Always assemble what we have (use defaults for failed sub-queries)
+        if agg_data is not None:
+            result.update(agg_data)
+        else:
+            result.update({
+                "total_spans": 0, "total_traces": 0, "exceptions": 0,
+                "avg_duration_ms": 0, "max_duration_ms": 0,
+            })
+        result["slowest_spans"] = slow_data if slow_data is not None else []
+        result["recent_exceptions"] = exc_data if exc_data is not None else []
+
+        if all_succeeded:
+            assert agg_data is not None and slow_data is not None  # for type narrowing
+            # All queries succeeded - cache the complete result
+            _logfire_query_cache["logfire"] = (result, now)
+            # Reset backoff on success so cache TTL controls refresh rate
+            _logfire_last_attempt = None
+            logger.info(
+                f"Logfire query refreshed: {agg_data.get('total_spans', 0)} spans, "
+                f"{agg_data.get('exceptions', 0)} exceptions, "
+                f"{len(slow_data)} slow spans"
+            )
+        else:
+            # Partial failure - log which queries failed, don't cache
+            failed = []
+            if agg_data is None:
+                failed.append("aggregate")
+            if slow_data is None:
+                failed.append("slowest_spans")
+            if exc_data is None:
+                failed.append("exceptions")
+            logger.warning(
+                f"Logfire partial query failure ({', '.join(failed)})"
+            )
+            # Prefer stale cache if it has richer data
+            if "logfire" in _logfire_query_cache:
+                stale_result, _ = _logfire_query_cache["logfire"]
+                return stale_result
+
+    except Exception as e:
+        logger.warning(f"Logfire query API error: {e}")
+        result["query_error"] = str(e)
+        # Return stale cache if available rather than empty data
+        if "logfire" in _logfire_query_cache:
+            stale_result, _ = _logfire_query_cache["logfire"]
+            return stale_result
+
+    return result
+
+
+async def _query_aggregate_stats(client: Any) -> dict[str, Any] | None:
+    """Query aggregate span stats for the last hour. Returns None on failure."""
+    try:
+        results = await client.query_json_rows(
+            sql="""
+                SELECT
+                    count(*) as total_spans,
+                    count(*) FILTER (WHERE is_exception) as exceptions,
+                    avg(duration) as avg_duration_sec,
+                    max(duration) as max_duration_sec,
+                    count(DISTINCT trace_id) as total_traces
+                FROM records
+                WHERE start_timestamp > now() - interval '1 hour'
+            """
+        )
+        rows = results.get("rows", [])
+        if rows:
+            row = rows[0]
+            avg_sec = row.get("avg_duration_sec") or 0
+            max_sec = row.get("max_duration_sec") or 0
+            return {
+                "total_spans": row.get("total_spans", 0),
+                "total_traces": row.get("total_traces", 0),
+                "exceptions": row.get("exceptions", 0),
+                "avg_duration_ms": round(float(avg_sec) * 1000, 1),
+                "max_duration_ms": round(float(max_sec) * 1000, 1),
+            }
+        logger.warning("Logfire aggregate stats query returned no rows")
+        return None
+    except Exception as e:
+        logger.warning(f"Logfire aggregate stats query failed: {e}")
+        return None
+
+
+async def _query_slowest_spans(client: Any) -> list[dict[str, Any]] | None:
+    """Query top 20 slowest span types for the last hour. Returns None on failure."""
+    try:
+        results = await client.query_json_rows(
+            sql="""
+                SELECT
+                    span_name,
+                    avg(duration) as avg_sec,
+                    max(duration) as max_sec,
+                    percentile_cont(0.95) WITHIN GROUP (ORDER BY duration) as p95_sec,
+                    count(*) as count,
+                    count(*) FILTER (WHERE is_exception) as errors,
+                    sum(duration) as total_sec
+                FROM records
+                WHERE start_timestamp > now() - interval '1 hour'
+                  AND duration IS NOT NULL
+                GROUP BY span_name
+                ORDER BY avg_sec DESC
+                LIMIT 20
+            """
+        )
+        rows = results.get("rows", [])
+        spans = []
+        for row in rows:
+            avg_sec = row.get("avg_sec") or 0
+            max_sec = row.get("max_sec") or 0
+            p95_sec = row.get("p95_sec") or 0
+            total_sec = row.get("total_sec") or 0
+            spans.append({
+                "name": row.get("span_name", "unknown"),
+                "avg_ms": round(float(avg_sec) * 1000, 1),
+                "max_ms": round(float(max_sec) * 1000, 1),
+                "p95_ms": round(float(p95_sec) * 1000, 1),
+                "count": row.get("count", 0),
+                "errors": row.get("errors", 0),
+                "total_ms": round(float(total_sec) * 1000, 1),
+            })
+        return spans
+    except Exception as e:
+        logger.warning(f"Logfire slowest spans query failed: {e}")
+        return None
+
+
+async def _query_recent_exceptions(client: Any) -> list[dict[str, Any]] | None:
+    """Query recent exceptions for the last 24 hours. Returns None on failure."""
+    try:
+        results = await client.query_json_rows(
+            sql="""
+                SELECT
+                    span_name,
+                    message,
+                    start_timestamp,
+                    exception_type,
+                    exception_message,
+                    exception_stacktrace,
+                    trace_id,
+                    service_name
+                FROM records
+                WHERE is_exception AND start_timestamp > now() - interval '24 hours'
+                ORDER BY start_timestamp DESC
+                LIMIT 200
+            """
+        )
+        exceptions = []
+        for row in results.get("rows", []):
+            exceptions.append({
+                "span_name": row.get("span_name", "unknown"),
+                "message": row.get("message", ""),
+                "timestamp": row.get("start_timestamp", ""),
+                "exception_type": row.get("exception_type", ""),
+                "exception_message": row.get("exception_message", ""),
+                "stacktrace": row.get("exception_stacktrace", ""),
+                "trace_id": row.get("trace_id", ""),
+                "service_name": row.get("service_name", ""),
+            })
+        return exceptions
+    except Exception as e:
+        logger.warning(f"Logfire recent exceptions query failed: {e}")
+        return None
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_ollama.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_ollama.py.jinja
@@ -1,0 +1,123 @@
+{#- aegis: no-backup -#}
+"""
+Ollama health check for {{ project_name }}.
+
+Extracted from the system health module; registered via the same
+register_health_check machinery.
+"""
+{% if ollama_mode != "none" %}
+from app.core.config import settings
+from app.core.log import logger
+
+from .models import ComponentStatus, ComponentStatusType
+
+async def check_ollama_health() -> ComponentStatus:
+    """
+    Check Ollama server health and running models.
+
+    Returns:
+        ComponentStatus indicating Ollama infrastructure health with model info
+    """
+    try:
+        from app.services.ai.domains.llm.ollama import OllamaClient
+
+        # Get Ollama URL from settings (uses effective URL for Docker/local auto-detection)
+        ollama_url = settings.ollama_base_url_effective
+
+        client = OllamaClient(base_url=ollama_url)
+
+        # Get comprehensive server status
+        server_status = await client.get_server_status()
+
+        if not server_status.available:
+            return ComponentStatus(
+                name="ollama",
+                status=ComponentStatusType.UNHEALTHY,
+                message="Ollama server not reachable",
+                response_time_ms=None,
+                metadata={
+                    "available": False,
+                    "base_url": ollama_url,
+                    "error": "Connection failed",
+                },
+            )
+
+        # Feed the activity tracker: diffing the running set on every poll
+        # is how idle evictions and externally triggered loads get noticed
+        # (Ollama has no event API).
+        from app.services.ai.domains.llm.ollama_activity import get_ollama_activity
+
+        get_ollama_activity().observe(
+            {m.name: m.size_vram_gb for m in server_status.running_models}
+        )
+
+        # Use Pydantic's model_dump for clean serialization
+        running_models_info = [
+            m.model_dump(include={"name", "size_vram_gb", "is_warm", "context_length", "details"})
+            for m in server_status.running_models
+        ]
+        installed_models_info = [
+            m.model_dump(
+                include={
+                    "name",
+                    "size_gb",
+                    "details",
+                    # What `ollama list` prints and the table could not show:
+                    # the digest tells two pulls of one tag apart, and the
+                    # timestamp is how you spot a model that has gone stale.
+                    "digest",
+                    "modified_at",
+                    "capabilities",
+                },
+                mode="json",
+            )
+            for m in server_status.installed_models
+        ]
+
+        # Determine status based on server state
+        if server_status.running_models:
+            status = ComponentStatusType.HEALTHY
+            primary_model = server_status.running_models[0]
+            message = f"{primary_model.name} • {primary_model.size_vram_gb:.1f}GB VRAM • warm"
+        elif server_status.installed_models_count > 0:
+            status = ComponentStatusType.INFO
+            message = f"Ollama ready • {server_status.installed_models_count} models installed • none loaded"
+        else:
+            status = ComponentStatusType.WARNING
+            message = "Ollama running but no models installed"
+
+        return ComponentStatus(
+            name="ollama",
+            status=status,
+            message=message,
+            response_time_ms=None,
+            metadata={
+                "available": True,
+                "base_url": ollama_url,
+                "version": server_status.version,
+                "running_models": running_models_info,
+                "running_models_count": len(server_status.running_models),
+                "installed_models": installed_models_info,
+                "installed_models_count": server_status.installed_models_count,
+                "total_vram_gb": round(server_status.total_vram_gb, 2),
+            },
+        )
+
+    except ImportError:
+        return ComponentStatus(
+            name="ollama",
+            status=ComponentStatusType.UNHEALTHY,
+            message="Ollama client not available",
+            response_time_ms=None,
+            metadata={"error": "OllamaClient not installed"},
+        )
+    except Exception as e:
+        logger.error(f"Ollama health check failed: {e}")
+        return ComponentStatus(
+            name="ollama",
+            status=ComponentStatusType.UNHEALTHY,
+            message=f"Ollama health check failed: {str(e)}",
+            response_time_ms=None,
+            metadata={"error": str(e)},
+        )
+{% endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
@@ -127,6 +127,12 @@ services:
     <<: *app
     command:
       - scheduler
+    healthcheck:
+      test: ["CMD", "python", "-c", "import os,sys,time; sys.exit(0 if time.time()-os.stat('/tmp/aegis-scheduler-heartbeat').st_mtime<60 else 1)"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 {%- if include_redis or scheduler_backend == 'postgres' or database_engine == 'postgres' %}
     depends_on:
 {%- if include_redis %}
@@ -175,6 +181,8 @@ services:
     command:
       - worker
       - load_test
+    healthcheck:
+      disable: true
     depends_on:
       redis:
         condition: service_healthy
@@ -215,6 +223,8 @@ services:
     command:
       - worker
       - system
+    healthcheck:
+      disable: true
     depends_on:
       redis:
         condition: service_healthy

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/health.md.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docs/health.md.jinja
@@ -5,10 +5,12 @@
 
 ## Health Check Endpoints
 
-### Basic Health Check
+### Liveness Probe
 - **URL**: `GET /health/`
-- **Purpose**: Quick health status check
-- **Response Time**: < 100ms
+- **Purpose**: Constant-time liveness check for load balancers and container
+  healthchecks. Answers 200 when the process can serve a request; it walks no
+  components and its `components` field is always empty.
+- **Response Time**: < 10ms
 
 ### Detailed Health Check  
 - **URL**: `GET /health/detailed`

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_health_endpoints.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/api/test_health_endpoints.py.jinja
@@ -232,12 +232,12 @@ class TestHealthEndpoints:
                                         assert metadata["queue_type"] == queue_name
 
     @pytest.mark.asyncio
-    async def test_basic_health_includes_worker_in_components(
+    async def test_detailed_health_includes_worker_in_components(
         self, async_client: AsyncClient
     ) -> None:
-        """Test that basic health endpoint includes worker in components dict."""
+        """Test that detailed health endpoint includes worker in components dict."""
 
-        response = await async_client.get("/health/")
+        response = await async_client.get("/health/detailed")
         assert response.status_code in [200, 503]
 
         data = response.json()
@@ -326,3 +326,29 @@ class TestHealthEndpoints:
         else:
             # For 503 responses, check error structure
             assert "detail" in data
+
+class TestLivenessProbe:
+    """/health/ is a constant-time liveness probe: no component walk."""
+
+    @pytest.mark.asyncio
+    async def test_basic_health_skips_component_walk(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import app.components.backend.api.health as health_api
+
+        async def _walk_forbidden() -> None:
+            raise AssertionError("liveness probe must not run the component walk")
+
+        monkeypatch.setattr(health_api, "get_system_status", _walk_forbidden)
+
+        # No startup hooks on purpose: liveness must answer even before
+        # (or without) health-check registration.
+        app = create_integrated_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/health/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["healthy"] is True
+        assert data["components"] == {}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_scheduler.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_scheduler.py
@@ -41,3 +41,23 @@ async def test_system_service_can_be_scheduled() -> None:
     system_job = scheduler.get_job("system")
 
     assert system_job.func == check_system_status
+
+
+@pytest.mark.asyncio
+async def test_scheduler_heartbeat_job_registered() -> None:
+    """The heartbeat job exists and its beacon file gets touched."""
+    from app.components.scheduler.heartbeat import (
+        HEARTBEAT_FILE,
+        HEARTBEAT_JOB_ID,
+        touch_scheduler_heartbeat,
+    )
+    from app.components.scheduler.main import create_scheduler
+
+    scheduler = create_scheduler()
+    job = scheduler.get_job(HEARTBEAT_JOB_ID)
+    assert job is not None
+    assert job.trigger.interval.total_seconds() <= 30
+
+    HEARTBEAT_FILE.unlink(missing_ok=True)
+    await touch_scheduler_heartbeat()
+    assert HEARTBEAT_FILE.exists()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_session_health.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_session_health.py
@@ -1,0 +1,15 @@
+"""The corruption detector matches Flet's desynced-tree signature and
+nothing else - background loops key their terminate-vs-retry decision on it."""
+
+from app.components.frontend.core.session_health import is_tree_corruption
+
+
+def test_matches_flet_tree_desync_signature() -> None:
+    exc = AssertionError("_process_remove_command: control with ID 'None' not found.")
+    assert is_tree_corruption(exc) is True
+
+
+def test_ignores_other_errors() -> None:
+    assert is_tree_corruption(AssertionError("something else")) is False
+    assert is_tree_corruption(RuntimeError("_process_remove_command")) is False
+    assert is_tree_corruption(ValueError("boom")) is False

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/conftest.py.jinja
@@ -34,6 +34,7 @@ from fastapi.testclient import TestClient
 from sqlalchemy import create_engine, event
 from sqlalchemy.engine.base import Engine
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.orm import sessionmaker
 from sqlmodel import Session, SQLModel
 from sqlmodel.ext.asyncio.session import AsyncSession
 {% endif %}
@@ -133,6 +134,15 @@ from app.integrations.main import create_integrated_app
 # (uvicorn keeps one loop for the server's lifetime); only the
 # test suite needs this swap. Dict-mode keeps the same async API,
 # so call sites don't change.
+@pytest.fixture(autouse=True)
+def _fresh_system_status_cache():
+    """No test sees another test's cached system-status walk."""
+    from app.services.system.health import invalidate_status_cache
+
+    invalidate_status_cache()
+    yield
+
+
 @pytest.fixture(autouse=True, scope="session")
 def _use_dict_backed_cache():
     import app.core.cache as cache_module
@@ -323,6 +333,39 @@ def _no_production_database(app_owned_engine, monkeypatch):
             app_owned_engine, class_=AsyncSession, expire_on_commit=False
         ),
     )
+    # The sync factory too: ``db_session()`` is what service code like
+    # ``get_conversation()`` opens for itself. A sync engine on the SAME
+    # file, with the same schema attachments, so both factories see one
+    # database - the one ``app_owned_engine`` already ran ``create_all`` on.
+    # Left uncovered, a Postgres project fails "no such table" on the first
+    # sync lookup: its startup migrations begin with CREATE SCHEMA, which
+    # SQLite rejects, so nothing else ever creates tables for that path.
+    owned_db = Path(app_owned_engine.url.database)
+    schema_names = {
+        table.schema for table in SQLModel.metadata.tables.values() if table.schema
+    }
+    sync_engine = create_engine(
+        f"sqlite:///{owned_db}", echo=False, connect_args={"check_same_thread": False}
+    )
+
+    @event.listens_for(sync_engine, "connect")
+    def attach_schemas_sync(dbapi_connection: Any, connection_record: Any) -> None:
+        cursor = dbapi_connection.cursor()
+        cursor.execute("PRAGMA foreign_keys=ON")
+        for schema_name in schema_names:
+            cursor.execute(
+                f"ATTACH DATABASE '{owned_db.parent / (schema_name + '.sqlite')}' "
+                f"AS {schema_name}"
+            )
+        cursor.close()
+
+    monkeypatch.setattr(
+        db_module,
+        "SessionLocal",
+        sessionmaker(bind=sync_engine, class_=Session, expire_on_commit=False),
+    )
+    yield
+    sync_engine.dispose()
 
 
 @pytest.fixture(scope="session")

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_finance_pending_changes.py
@@ -897,7 +897,9 @@ class TestWithdraw:
 
         from app.core import db as app_db
 
-        if app_db.async_engine.dialect.name != "sqlite":
+        # Every project's tests run on SQLite, so the dialect says nothing
+        # about the project; the knob is only wired on a SQLite project.
+        if getattr(app_db, "SQLITE_BUSY_TIMEOUT_MS", None) is None:
             pytest.skip("busy_timeout is a SQLite knob")
         async with app_db.async_engine.connect() as conn:
             timeout = (await conn.execute(text("PRAGMA busy_timeout"))).scalar()

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_health_status_cache.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/services/test_health_status_cache.py
@@ -1,0 +1,71 @@
+"""The system-status walk is shared: concurrent and repeated callers within
+the TTL reuse one walk instead of each running every component check."""
+
+import asyncio
+
+import pytest
+
+from app.services.system.health import (
+    _health_checks,
+    get_system_status,
+    invalidate_status_cache,
+    register_health_check,
+)
+from app.services.system.models import ComponentStatus, ComponentStatusType
+
+
+def _counting_check(counter: dict[str, int]) -> object:
+    async def check() -> ComponentStatus:
+        counter["calls"] += 1
+        return ComponentStatus(
+            name="counted",
+            status=ComponentStatusType.HEALTHY,
+            message="ok",
+            response_time_ms=1.0,
+        )
+
+    return check
+
+
+@pytest.fixture
+def counted_check():
+    counter = {"calls": 0}
+    register_health_check("counted", _counting_check(counter))
+    yield counter
+    _health_checks.pop("counted", None)
+    invalidate_status_cache()
+
+
+@pytest.mark.asyncio
+async def test_repeated_calls_within_ttl_share_one_walk(counted_check) -> None:
+    first = await get_system_status()
+    second = await get_system_status()
+    assert counted_check["calls"] == 1
+    assert second is first
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_share_one_walk(counted_check) -> None:
+    results = await asyncio.gather(*(get_system_status() for _ in range(5)))
+    assert counted_check["calls"] == 1
+    assert all(r is results[0] for r in results)
+
+
+@pytest.mark.asyncio
+async def test_force_refresh_bypasses_cache(counted_check) -> None:
+    await get_system_status()
+    await get_system_status(force_refresh=True)
+    assert counted_check["calls"] == 2
+
+
+@pytest.mark.asyncio
+async def test_registering_a_check_invalidates_cache(counted_check) -> None:
+    await get_system_status()
+    counter2 = {"calls": 0}
+    register_health_check("counted_2", _counting_check(counter2))
+    try:
+        await get_system_status()
+    finally:
+        _health_checks.pop("counted_2", None)
+    assert counter2["calls"] == 1
+    assert counted_check["calls"] == 2

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_app_owned_sessions.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_app_owned_sessions.py
@@ -1,0 +1,32 @@
+"""Every session the app opens for itself lands in the app-owned test database.
+
+``_no_production_database`` redirects the module-level session factories in
+``app.core.db`` so startup hooks, background tasks and service code that open
+their own session never touch the database in ``DATABASE_URL``. The sync
+factory must be covered as well as the async one: ``db_session()`` is what
+``get_conversation()`` and friends use, and on a Postgres project nothing
+else creates tables for it (startup migrations begin with ``CREATE SCHEMA``,
+which SQLite rejects), so an uncovered sync path fails with "no such table"
+on the first lookup a route makes after a write.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Skip before touching SQLAlchemy: a stack without a database ships neither.
+db_module = pytest.importorskip("app.core.db", reason="no database in this stack")
+
+from sqlalchemy import inspect  # noqa: E402
+from sqlmodel import SQLModel  # noqa: E402
+
+
+def test_sync_and_async_app_owned_sessions_share_one_database(
+    app_owned_engine,
+) -> None:
+    with db_module.db_session(autocommit=False) as session:
+        bind = session.get_bind()
+        assert bind.url.database == app_owned_engine.url.database
+        present = set(inspect(bind).get_table_names())
+    expected = {t.name for t in SQLModel.metadata.tables.values() if t.schema is None}
+    assert expected <= present, sorted(expected - present)

--- a/docs/components/backend/routes.md
+++ b/docs/components/backend/routes.md
@@ -60,7 +60,12 @@ A few conventions to notice:
 
 - **`/health` is always present.** It carries no version prefix because
   the health surface is used by orchestrators (Docker, Kubernetes,
-  Overseer) that should not have to know about API versions.
+  Overseer) that should not have to know about API versions. `/health/`
+  is a constant-time liveness probe: it answers 200 without walking any
+  component, which is all a load balancer or container healthcheck needs.
+  Component status lives at `/health/detailed`, backed by a shared status
+  cache so the dashboard, the scheduler and the probe never trigger more
+  than one full walk every ten seconds between them.
 - **Versioned APIs live under `/api/v1`.** Every service-owned router
   mounts there. When the API contract changes incompatibly, the next
   router goes under `/api/v2` and lives alongside the old one until

--- a/docs/integration-patterns.md
+++ b/docs/integration-patterns.md
@@ -288,11 +288,11 @@ API endpoints, CLI commands, and worker tasks validate incoming data:
 
 ```python
 # Entry point - validate with Pydantic
-@router.get("/health", response_model=HealthResponse)
-async def health_check() -> HealthResponse:
+@router.get("/detailed", response_model=DetailedHealthResponse)
+async def detailed_health() -> DetailedHealthResponse:
     # Internal code - trust the data
     status = await get_system_status()
-    return HealthResponse(healthy=status.overall_healthy, ...)
+    return DetailedHealthResponse(healthy=status.overall_healthy, ...)
 ```
 
 ### Trust Internally

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -2,10 +2,12 @@
 Pytest configuration for CLI integration tests.
 """
 
+import dataclasses
 import hashlib
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from collections.abc import Callable, Generator, Iterable
@@ -64,6 +66,11 @@ class ProjectTemplateSpec:
     components: tuple[str, ...] = ()
     scheduler_backend: str = "memory"
     services: tuple[str, ...] = ()
+    # None = the template default. The db runtime fixtures set the RUNNING
+    # interpreter so the cached project is rendered and formatted for the
+    # Python it will execute under: a 3.14 render is not importable on 3.11
+    # (post-gen ruff unquotes forward references under deferred annotations).
+    python_version: str | None = None
 
 
 NAMED_PROJECT_SPECS: dict[str, ProjectTemplateSpec] = {
@@ -199,6 +206,11 @@ def project_template_cache(
                         selected_components=list(spec.components),
                         scheduler_backend=spec.scheduler_backend,
                         selected_services=list(spec.services),
+                        **(
+                            {"python_version": spec.python_version}
+                            if spec.python_version
+                            else {}
+                        ),
                     )
                     generate_with_copier(template_gen, staging_parent, dev_mode=True)
                     staged = staging_parent / project_name
@@ -413,34 +425,25 @@ def generated_db_project_postgres(
 
     # Get cached project and copy to session temp dir (exclude .venv - wrong Python version)
     print("Using cached PostgreSQL project template...")
-    spec = NAMED_PROJECT_SPECS["base_with_database_postgres"]
+    # Rendered for the interpreter these tests run under, not the default.
+    spec = dataclasses.replace(
+        NAMED_PROJECT_SPECS["base_with_database_postgres"],
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
     cached_project = project_template_cache(spec)
     project_path = session_temp_dir / "db-postgres-runtime"
+    # .git too: the runtime tests never read history, and copying the
+    # shared cache's loose objects races git's own gc (copytree fails with
+    # ENOENT on .git/objects/xx that vanished mid-copy).
     shutil.copytree(
-        cached_project, project_path, ignore=shutil.ignore_patterns(".venv")
+        cached_project, project_path, ignore=shutil.ignore_patterns(".venv", ".git")
     )
-
-    # Patch pyproject.toml to use current Python version (cached may have different version)
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    pyproject_path = project_path / "pyproject.toml"
-    content = pyproject_path.read_text()
-    import re
-
-    content = re.sub(
-        r'requires-python\s*=\s*"[^"]+"',
-        f'requires-python = ">={python_version}"',
-        content,
-    )
-    pyproject_path.write_text(content)
-
-    # Update .python-version to match current Python (cached may have different version)
-    python_version_file = project_path / ".python-version"
-    python_version_file.write_text(f"{python_version}\n")
 
     # Install dependencies
     print("Installing dependencies in PostgreSQL project...")
+    assert spec.python_version is not None  # set just above, for this interpreter
     install_result = run_project_command(
-        ["uv", "sync", "--extra", "dev", "--python", python_version],
+        ["uv", "sync", "--extra", "dev", "--python", spec.python_version],
         project_path,
         step_name="Install Dependencies",
         env_overrides={"VIRTUAL_ENV": ""},
@@ -475,30 +478,16 @@ def generated_db_project(
 
     # Get cached project and copy to session temp dir (exclude .venv - wrong Python version)
     print("Using cached SQLite project template...")
-    spec = NAMED_PROJECT_SPECS["base_with_database"]
+    # Rendered for the interpreter these tests run under, not the default.
+    spec = dataclasses.replace(
+        NAMED_PROJECT_SPECS["base_with_database"],
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
     cached_project = project_template_cache(spec)
     project_path = session_temp_dir / "db-sqlite-runtime"
     shutil.copytree(
-        cached_project, project_path, ignore=shutil.ignore_patterns(".venv")
+        cached_project, project_path, ignore=shutil.ignore_patterns(".venv", ".git")
     )
-
-    # Patch pyproject.toml to use current Python version (cached may have different version)
-    import re
-    import sys
-
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    pyproject_path = project_path / "pyproject.toml"
-    content = pyproject_path.read_text()
-    content = re.sub(
-        r'requires-python\s*=\s*"[^"]+"',
-        f'requires-python = ">={python_version}"',
-        content,
-    )
-    pyproject_path.write_text(content)
-
-    # Update .python-version to match current Python (cached may have different version)
-    python_version_file = project_path / ".python-version"
-    python_version_file.write_text(f"{python_version}\n")
 
     # Install dependencies
     print("Installing dependencies in SQLite project...")

--- a/tests/cli/test_database_config.py
+++ b/tests/cli/test_database_config.py
@@ -141,10 +141,15 @@ class TestPostgreSQLConfiguration:
         db_file = project_path / "app" / "core" / "db.py"
         db_content = db_file.read_text()
 
-        # Should NOT have SQLite-specific code
+        # Should NOT have SQLite runtime specifics: pragmas, the file-path
+        # plumbing, the pooling workaround. The async URL converter is the
+        # one place a Postgres project may name the aiosqlite driver - every
+        # project's tests run on SQLite, and a converter that only knows
+        # postgresql:// hands create_async_engine a sync driver there.
         assert "PRAGMA foreign_keys" not in db_content
         assert "DATABASE_PATH" not in db_content
-        assert "aiosqlite" not in db_content
+        assert "apply_sqlite_pragmas" not in db_content
+        assert "NullPool" not in db_content
         # Should have PostgreSQL references
         assert "postgresql" in db_content.lower() or "asyncpg" in db_content.lower()
 

--- a/tests/core/test_ci_covers_slow_tests.py
+++ b/tests/core/test_ci_covers_slow_tests.py
@@ -1,0 +1,43 @@
+"""Every slow-marked test file runs somewhere in CI.
+
+The PR run deselects ``-m slow``. Two tests sat red on main for weeks
+because nothing ever ran them (the add/remove/update suites had no CI home
+at all), and a real lifecycle regression would have looked identical. This
+pins the property: a file carrying ``pytest.mark.slow`` is either driven
+explicitly by the stack matrix or picked up by a workflow that runs
+``-m slow`` and does not ``--ignore`` it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO / ".github" / "workflows"
+
+
+def _slow_test_files() -> set[str]:
+    return {
+        str(p.relative_to(REPO))
+        for p in (REPO / "tests").rglob("test_*.py")
+        if "pytest.mark.slow" in p.read_text()
+    }
+
+
+def _ci_homes() -> set[str]:
+    """Files CI runs: named node ids, plus everything a ``-m slow`` run keeps."""
+    covered: set[str] = set()
+    slow_files = _slow_test_files()
+    for wf in WORKFLOWS.glob("*.yml"):
+        text = wf.read_text()
+        covered |= {f for f in slow_files if f in text and "--ignore=" + f not in text}
+        if re.search(r"pytest[^\n]*-m slow", text):
+            ignored = set(re.findall(r"--ignore=(\S+)", text))
+            covered |= slow_files - ignored
+    return covered
+
+
+def test_every_slow_test_file_has_a_ci_home() -> None:
+    homeless = sorted(_slow_test_files() - _ci_homes())
+    assert not homeless, "slow tests no workflow ever runs:\n  " + "\n  ".join(homeless)

--- a/tests/core/test_db_template_async_url.py
+++ b/tests/core/test_db_template_async_url.py
@@ -1,0 +1,47 @@
+"""The async URL converter in ``app/core/db.py`` must accept a SQLite URL
+whatever engine the project chose.
+
+The generated test suite points ``DATABASE_URL`` at a throwaway SQLite file
+at import time, before ``app.core.db`` builds its engines, so the suite of
+a Postgres project runs on SQLite like every other. A converter that only
+knows ``postgresql://`` hands ``create_async_engine`` a sync ``sqlite://``
+URL and the whole suite fails to collect. The CI matrix never generates a
+Postgres project (it would need a server), so nothing else catches this.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+import pytest
+from jinja2 import Environment, FileSystemLoader
+
+from aegis.core.component_files import get_copier_defaults, get_template_path
+
+
+def _converter(engine: str) -> Any:
+    env = Environment(
+        loader=FileSystemLoader(str(get_template_path())), keep_trailing_newline=True
+    )
+    ctx = {**get_copier_defaults(), "include_database": True, "database_engine": engine}
+    source = env.get_template("{{ project_slug }}/app/core/db.py.jinja").render(ctx)
+    tree = ast.parse(source)
+    fn = next(
+        n for n in tree.body
+        if isinstance(n, ast.FunctionDef) and n.name == "_get_async_database_url"
+    )
+    ns: dict[str, Any] = {}
+    exec(compile(ast.Module(body=[fn], type_ignores=[]), "db.py", "exec"), ns)
+    return ns["_get_async_database_url"]
+
+
+@pytest.mark.parametrize("engine", ["sqlite", "postgres"])
+def test_sqlite_url_becomes_aiosqlite_for_every_engine(engine: str) -> None:
+    convert = _converter(engine)
+    assert convert("sqlite:////tmp/x/app.db") == "sqlite+aiosqlite:////tmp/x/app.db"
+
+
+def test_postgres_url_becomes_asyncpg_for_a_postgres_project() -> None:
+    convert = _converter("postgres")
+    assert convert("postgresql://u:p@h/db") == "postgresql+asyncpg://u:p@h/db"

--- a/tests/core/test_ingress_component.py
+++ b/tests/core/test_ingress_component.py
@@ -294,11 +294,11 @@ class TestIngressHealthCheck:
     """Test ingress health check implementation in templates."""
 
     def test_health_py_has_ingress_check(self) -> None:
-        """Test that health.py.jinja has ingress health check function."""
+        """The ingress health check lives in its own gated module."""
         from pathlib import Path
 
         template_path = Path(
-            "aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health.py.jinja"
+            "aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_ingress.py.jinja"
         )
         content = template_path.read_text()
 
@@ -310,7 +310,7 @@ class TestIngressHealthCheck:
         from pathlib import Path
 
         template_path = Path(
-            "aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health.py.jinja"
+            "aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/system/health_ingress.py.jinja"
         )
         content = template_path.read_text()
 

--- a/tests/core/test_module_size_budget.py
+++ b/tests/core/test_module_size_budget.py
@@ -56,7 +56,7 @@ BUDGET: dict[str, int] = {
     "components/frontend/dashboard/modals/finance_modal/overview_tab.py": 749,
     "components/frontend/dashboard/modals/finance_modal/budget_cards.py": 681,
     "components/frontend/dashboard/modals/insights_modal.py": 3940,
-    "services/system/health.py.jinja": 1456,
+    "services/system/health.py.jinja": 714,
     "cli/ai.py.jinja": 2338,
     "components/frontend/dashboard/modals/modal_sections.py": 2093,
     "components/frontend/dashboard/modals/voice_settings_tab.py": 1649,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ to avoid regenerating projects for each test.
 
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -123,6 +124,12 @@ def head_project_cache(
             "cached-head-project",
             "--to-version",
             head_commit_hash,
+            # The project is rendered and formatted for the interpreter that
+            # will run it: a 3.14 render is not importable on 3.11 (post-gen
+            # ruff unquotes forward references under deferred annotations),
+            # and the update path executes project code under this venv.
+            "--python-version",
+            f"{sys.version_info.major}.{sys.version_info.minor}",
             "--no-interactive",
             "--yes",
         ],


### PR DESCRIPTION
One branch for the session's work (per request). Three parts, one commit.

**Health checks** (the long-lived worktree, rebased onto main). `/health/` is a constant-time liveness probe (empty `components`); `/health/detailed` walks components through a shared status cache, one full walk per `STATUS_CACHE_TTL_SECONDS` (10s) however many callers ask. Scheduler liveness via heartbeat file + compose healthcheck; worker services drop redundant HTTP checks; Flet keeps one health session per page. `system/health.py` split by component (`health_cache`, `health_ingress`, `health_observability`, `health_ollama`), 1456 -> 714 lines; main's `health_worker*` kept. Idle CPU on a full stack 13.4% -> 0.26%. Docs (`routes.md`, `integration-patterns.md`, generated `health.md`) and changelog updated. Verified: base 613, everything 2052, my-app 3241.

**A Postgres project's test suite runs.** Every project's tests run on SQLite, but three things only worked on a SQLite project: `_get_async_database_url` did not know `sqlite://` (nothing collected); `_no_production_database` redirected only `AsyncSessionLocal`, so a sync `db_session()` lookup after a write hit a database with no tables (Postgres migrations open with `CREATE SCHEMA`); the busy-timeout test skipped on dialect. New generated test asserts sync and async app-owned sessions share one database. The CI matrix has no Postgres project; the evidence is my-app.

**Slow suites nightly, with a `postgres:16` service** (closes #1053). The 16 `slow`-marked files had no CI home. Nightly + `workflow_dispatch`, excluding `test_stack_validation.py` (matrix owns it); `tests/core/test_ci_covers_slow_tests.py` pins that every slow file has one. First run: 4m11s, 15 failures, one cause in the harness: db-runtime fixtures and the update head project reused a 3.14-cached project and rewrote `requires-python` to 3.11, so 3.14-formatted source (post-gen ruff unquotes `-> "Settings"` under deferred annotations) ran on 3.11. The cache spec now carries the interpreter. In a 3.11 venv: sqlite runtime 6/6, postgres runtime 8/8, update quick-exit green.

Supersedes #1104 and #1106.