### PR TITLE
Run the slow suites nightly, with a Postgres service

### DIFF
--- a/.github/workflows/slow-suites.yml
+++ b/.github/workflows/slow-suites.yml
@@ -1,0 +1,61 @@
+name: Slow Suites
+
+# The PR run deselects ``-m slow``. This job runs everything it leaves
+# behind - the add, add-service, remove and update lifecycle suites, the
+# database runtime tests, plugin conformance - once a night and on demand,
+# so a lifecycle regression or a stale assertion is caught within a day
+# instead of at release time. The stack matrix owns
+# tests/cli/test_stack_validation.py; it is not repeated here.
+#
+# A Postgres service is provided so the postgres-marked runtime tests run
+# for real instead of skipping for want of localhost:5432.
+
+on:
+  schedule:
+    - cron: '30 7 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/slow-suites.yml'
+
+concurrency:
+  group: slow-suites-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  slow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      POSTGRES_TEST_PASSWORD: postgres
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: uv sync --all-extras
+
+      - name: Run the slow suites
+        run: >
+          uv run pytest -m slow -n auto --dist=loadgroup -v --tb=short
+          --ignore=tests/cli/test_stack_validation.py

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -2,10 +2,12 @@
 Pytest configuration for CLI integration tests.
 """
 
+import dataclasses
 import hashlib
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import time
 from collections.abc import Callable, Generator, Iterable
@@ -64,6 +66,11 @@ class ProjectTemplateSpec:
     components: tuple[str, ...] = ()
     scheduler_backend: str = "memory"
     services: tuple[str, ...] = ()
+    # None = the template default. The db runtime fixtures set the RUNNING
+    # interpreter so the cached project is rendered and formatted for the
+    # Python it will execute under: a 3.14 render is not importable on 3.11
+    # (post-gen ruff unquotes forward references under deferred annotations).
+    python_version: str | None = None
 
 
 NAMED_PROJECT_SPECS: dict[str, ProjectTemplateSpec] = {
@@ -199,6 +206,11 @@ def project_template_cache(
                         selected_components=list(spec.components),
                         scheduler_backend=spec.scheduler_backend,
                         selected_services=list(spec.services),
+                        **(
+                            {"python_version": spec.python_version}
+                            if spec.python_version
+                            else {}
+                        ),
                     )
                     generate_with_copier(template_gen, staging_parent, dev_mode=True)
                     staged = staging_parent / project_name
@@ -413,34 +425,22 @@ def generated_db_project_postgres(
 
     # Get cached project and copy to session temp dir (exclude .venv - wrong Python version)
     print("Using cached PostgreSQL project template...")
-    spec = NAMED_PROJECT_SPECS["base_with_database_postgres"]
+    # Rendered for the interpreter these tests run under, not the default.
+    spec = dataclasses.replace(
+        NAMED_PROJECT_SPECS["base_with_database_postgres"],
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
     cached_project = project_template_cache(spec)
     project_path = session_temp_dir / "db-postgres-runtime"
     shutil.copytree(
         cached_project, project_path, ignore=shutil.ignore_patterns(".venv")
     )
 
-    # Patch pyproject.toml to use current Python version (cached may have different version)
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    pyproject_path = project_path / "pyproject.toml"
-    content = pyproject_path.read_text()
-    import re
-
-    content = re.sub(
-        r'requires-python\s*=\s*"[^"]+"',
-        f'requires-python = ">={python_version}"',
-        content,
-    )
-    pyproject_path.write_text(content)
-
-    # Update .python-version to match current Python (cached may have different version)
-    python_version_file = project_path / ".python-version"
-    python_version_file.write_text(f"{python_version}\n")
-
     # Install dependencies
     print("Installing dependencies in PostgreSQL project...")
+    assert spec.python_version is not None  # set just above, for this interpreter
     install_result = run_project_command(
-        ["uv", "sync", "--extra", "dev", "--python", python_version],
+        ["uv", "sync", "--extra", "dev", "--python", spec.python_version],
         project_path,
         step_name="Install Dependencies",
         env_overrides={"VIRTUAL_ENV": ""},
@@ -475,30 +475,16 @@ def generated_db_project(
 
     # Get cached project and copy to session temp dir (exclude .venv - wrong Python version)
     print("Using cached SQLite project template...")
-    spec = NAMED_PROJECT_SPECS["base_with_database"]
+    # Rendered for the interpreter these tests run under, not the default.
+    spec = dataclasses.replace(
+        NAMED_PROJECT_SPECS["base_with_database"],
+        python_version=f"{sys.version_info.major}.{sys.version_info.minor}",
+    )
     cached_project = project_template_cache(spec)
     project_path = session_temp_dir / "db-sqlite-runtime"
     shutil.copytree(
         cached_project, project_path, ignore=shutil.ignore_patterns(".venv")
     )
-
-    # Patch pyproject.toml to use current Python version (cached may have different version)
-    import re
-    import sys
-
-    python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
-    pyproject_path = project_path / "pyproject.toml"
-    content = pyproject_path.read_text()
-    content = re.sub(
-        r'requires-python\s*=\s*"[^"]+"',
-        f'requires-python = ">={python_version}"',
-        content,
-    )
-    pyproject_path.write_text(content)
-
-    # Update .python-version to match current Python (cached may have different version)
-    python_version_file = project_path / ".python-version"
-    python_version_file.write_text(f"{python_version}\n")
 
     # Install dependencies
     print("Installing dependencies in SQLite project...")

--- a/tests/core/test_ci_covers_slow_tests.py
+++ b/tests/core/test_ci_covers_slow_tests.py
@@ -1,0 +1,43 @@
+"""Every slow-marked test file runs somewhere in CI.
+
+The PR run deselects ``-m slow``. Two tests sat red on main for weeks
+because nothing ever ran them (the add/remove/update suites had no CI home
+at all), and a real lifecycle regression would have looked identical. This
+pins the property: a file carrying ``pytest.mark.slow`` is either driven
+explicitly by the stack matrix or picked up by a workflow that runs
+``-m slow`` and does not ``--ignore`` it.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+WORKFLOWS = REPO / ".github" / "workflows"
+
+
+def _slow_test_files() -> set[str]:
+    return {
+        str(p.relative_to(REPO))
+        for p in (REPO / "tests").rglob("test_*.py")
+        if "pytest.mark.slow" in p.read_text()
+    }
+
+
+def _ci_homes() -> set[str]:
+    """Files CI runs: named node ids, plus everything a ``-m slow`` run keeps."""
+    covered: set[str] = set()
+    slow_files = _slow_test_files()
+    for wf in WORKFLOWS.glob("*.yml"):
+        text = wf.read_text()
+        covered |= {f for f in slow_files if f in text and "--ignore=" + f not in text}
+        if re.search(r"pytest[^\n]*-m slow", text):
+            ignored = set(re.findall(r"--ignore=(\S+)", text))
+            covered |= slow_files - ignored
+    return covered
+
+
+def test_every_slow_test_file_has_a_ci_home() -> None:
+    homeless = sorted(_slow_test_files() - _ci_homes())
+    assert not homeless, "slow tests no workflow ever runs:\n  " + "\n  ".join(homeless)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -7,6 +7,7 @@ to avoid regenerating projects for each test.
 
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -123,6 +124,12 @@ def head_project_cache(
             "cached-head-project",
             "--to-version",
             head_commit_hash,
+            # The project is rendered and formatted for the interpreter that
+            # will run it: a 3.14 render is not importable on 3.11 (post-gen
+            # ruff unquotes forward references under deferred annotations),
+            # and the update path executes project code under this venv.
+            "--python-version",
+            f"{sys.version_info.major}.{sys.version_info.minor}",
             "--no-interactive",
             "--yes",
         ],


### PR DESCRIPTION
Closes #1053.

CI runs `-m "not slow"`. The 16 files carrying `pytest.mark.slow` (add / add-service / remove / update lifecycle suites, database runtime, plugin conformance, python-version, issue-686/715 integration) had no CI home at all except `test_stack_validation.py`, which the stack matrix drives explicitly. #1047 showed the cost: two tests red on main for weeks, invisible.

- `.github/workflows/slow-suites.yml`: nightly at 07:30 (after the 07:00 matrix), `workflow_dispatch`, and on PRs that touch the workflow file. Runs `pytest -m slow -n auto --dist=loadgroup --ignore=tests/cli/test_stack_validation.py` against a `postgres:16` service with `POSTGRES_TEST_PASSWORD=postgres`, so the `postgres`-marked runtime tests execute instead of skipping for want of `localhost:5432` (the practical half of #1022 / #764; those tickets stay open for the generated-project side).
- `tests/core/test_ci_covers_slow_tests.py`: every slow-marked file must be either named by a workflow or covered by a `-m slow` run that does not `--ignore` it. Failed before the workflow existed, passes with it.

Runtime is unmeasured (#1053 estimated minutes, not seconds); the job has a 90-minute cap and this PR's own run is the first measurement. Two of the slow files were already red on main per #1047, so the first nightly may be red for reasons that predate this PR; that is the signal the job exists to surface.