### PR TITLE
update: gated-off stubs, predated migrations, and honest failure reporting

### DIFF
--- a/aegis/commands/update.py
+++ b/aegis/commands/update.py
@@ -34,6 +34,7 @@ from ..core.copier_updater import (
     validate_clean_git_tree,
 )
 from ..core.manual_updater import detect_insights_sources
+from ..core.migration_generator import generate_missing_migrations
 from ..core.post_gen_tasks import cleanup_components, run_post_generation_tasks
 from ..core.template_cleanup import (
     cleanup_nested_project_directory,
@@ -668,10 +669,31 @@ def update_command(
                 or include_documents
             )
 
+            # Migrations the project predates. A project generated before a
+            # revision existed never receives it otherwise: ``add-service``
+            # and ``ManualUpdater.add_service`` both call this, ``update``
+            # did not, so a v0.10.1 auth project kept ``001 -> 003`` with
+            # ``auth_tokens`` never written (#1024). Must run BEFORE the
+            # ``alembic upgrade head`` inside post-gen, or the DB is
+            # stamped past a revision that only lands afterwards.
+            if include_migrations:
+                for migration_path in generate_missing_migrations(target_path, answers):
+                    brand.success(
+                        f"   {t('add_service.generated_migration', name=migration_path.name)}"
+                    )
+
             typer.echo(t("update.running_postgen"))
+            postgen_report: dict[str, bool] = {}
             tasks_success = run_post_generation_tasks(
-                target_path, include_migrations=include_migrations
+                target_path,
+                include_migrations=include_migrations,
+                report=postgen_report,
             )
+            # A failed upgrade is non-fatal to generation but must not be
+            # reported as a clean update: the deployed app is what crashes
+            # (UndefinedColumnError on first request), not this command.
+            if postgen_report.get("migrations_ok") is False:
+                tasks_success = False
 
         # Update __aegis_version__ directly (Copier doesn't re-render unchanged files)
         init_file = target_path / "app" / "__init__.py"

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -4214,33 +4214,42 @@ def upgrade() -> None:
 {%- if schema %}
     op.execute('CREATE SCHEMA IF NOT EXISTS "{{ schema }}"')
 {%- endif %}
+    # SQLite projects run ``create_all`` at startup, so a table this
+    # revision creates may already exist when ``aegis update`` delivers
+    # the revision to an existing project. Skip per table so one chain
+    # serves both a pre-populated and a fresh database. Postgres is
+    # migration-only and never pre-creates, so the check is a no-op
+    # there. ``add_column`` on an existing table is deliberately NOT
+    # guarded: a duplicate column is a real conflict, not pre-creation.
+    _existing = set(sa.inspect(op.get_bind()).get_table_names({% if schema %}schema='{{ schema }}'{% endif %}))
 {% for table in tables %}
     # Create {{ table.name }} table
-    op.create_table(
-        '{{ table.name }}',
+    if '{{ table.name }}' not in _existing:
+        op.create_table(
+            '{{ table.name }}',
 {% for column in table.columns %}
 {% set pk_attr = ", primary_key=True" if column.primary_key else "" %}
 {% set default_attr = ", default=" ~ column.default if column.default else "" %}
-        sa.Column('{{ column.name }}', {{ column.type }}, nullable={{ column.nullable }}{{ pk_attr }}{{ default_attr }}),
+            sa.Column('{{ column.name }}', {{ column.type }}, nullable={{ column.nullable }}{{ pk_attr }}{{ default_attr }}),
 {% endfor %}
 {% if table.primary_keys %}
-        sa.PrimaryKeyConstraint({% for pk in table.primary_keys %}'{{ pk }}'{% if not loop.last %}, {% endif %}{% endfor %}){% if table.foreign_keys or table.check_constraints or schema %},{% endif %}
+            sa.PrimaryKeyConstraint({% for pk in table.primary_keys %}'{{ pk }}'{% if not loop.last %}, {% endif %}{% endfor %}){% if table.foreign_keys or table.check_constraints or schema %},{% endif %}
 
 {% endif %}
 {% for fk in table.foreign_keys %}
-        sa.ForeignKeyConstraint({{ fk.columns }}, ['{{ fk.ref_schema_qualified }}{{ fk.ref_table }}.{{ fk.ref_columns[0] }}']{% if fk.ondelete %}, ondelete='{{ fk.ondelete }}'{% endif %}){% if not loop.last or table.check_constraints or schema %},{% endif %}
+            sa.ForeignKeyConstraint({{ fk.columns }}, ['{{ fk.ref_schema_qualified }}{{ fk.ref_table }}.{{ fk.ref_columns[0] }}']{% if fk.ondelete %}, ondelete='{{ fk.ondelete }}'{% endif %}){% if not loop.last or table.check_constraints or schema %},{% endif %}
 
 {% endfor %}
 {% for chk in table.check_constraints %}
-        sa.CheckConstraint("{{ chk.sqltext }}", name='{{ chk.name }}'){% if not loop.last or schema %},{% endif %}
+            sa.CheckConstraint("{{ chk.sqltext }}", name='{{ chk.name }}'){% if not loop.last or schema %},{% endif %}
 
 {% endfor %}
 {%- if schema %}
-        schema='{{ schema }}',
+            schema='{{ schema }}',
 {%- endif %}
-    )
+        )
 {% for index in table.indexes %}
-    op.create_index(op.f('{{ index.name }}'), '{{ table.name }}', {{ index.columns }}{% if index.unique %}, unique=True{% endif %}{% if index.where %}, sqlite_where=sa.text("{{ index.where }}"), postgresql_where=sa.text("{{ index.where }}"){% endif %}{% if schema %}, schema='{{ schema }}'{% endif %})
+        op.create_index(op.f('{{ index.name }}'), '{{ table.name }}', {{ index.columns }}{% if index.unique %}, unique=True{% endif %}{% if index.where %}, sqlite_where=sa.text("{{ index.where }}"), postgresql_where=sa.text("{{ index.where }}"){% endif %}{% if schema %}, schema='{{ schema }}'{% endif %})
 {% endfor %}
 
 {% endfor %}

--- a/aegis/core/post_gen_tasks.py
+++ b/aegis/core/post_gen_tasks.py
@@ -1080,6 +1080,7 @@ def run_post_generation_tasks(
     skip_llm_sync: bool = False,
     project_slug: str | None = None,
     reporter: "BuildReporter | None" = None,
+    report: dict[str, bool] | None = None,
 ) -> bool:
     """
     Run all post-generation tasks for a project.
@@ -1138,7 +1139,14 @@ def run_post_generation_tasks(
     # Task 3: Run migrations if needed (non-critical)
     if reporter is not None and include_migrations:
         reporter.step("migrate", t("build.step.migrate"), "alembic upgrade head")
-    run_migrations(project_path, include_migrations, python_version)
+    # Non-fatal by design (see ``test_non_critical_failures_continue``): a
+    # failed upgrade must not fail generation. But the caller has to be
+    # able to see it - ``aegis update`` used to print "completed
+    # successfully" over a migration that never applied (#1024). The
+    # overall bool keeps its contract; the detail goes in ``report``.
+    migrations_ok = run_migrations(project_path, include_migrations, python_version)
+    if report is not None:
+        report["migrations_ok"] = migrations_ok
     if reporter is not None and include_migrations:
         reporter.done("migrate")
 

--- a/aegis/core/template_cleanup.py
+++ b/aegis/core/template_cleanup.py
@@ -331,6 +331,19 @@ def cleanup_nested_project_directory(
                 )
                 continue
 
+            # Copier renders every template file into the nested dir,
+            # gated-off ones included - those are a lone newline. Init
+            # sweeps such stubs after generation; promoting them here
+            # would plant them in the project instead. Same rule as the
+            # sync backstop (``_is_meaningful_render``).
+            # ``relative`` from the collection loop above is stale here; the
+            # name check must see THIS file's path.
+            rel = dest.relative_to(project_path)
+            if not _is_meaningful_render(rel, source.read_bytes()):
+                source.unlink()
+                verbose_print(f"   Dropped gated-off stub: {rel}")
+                continue
+
             shutil.move(str(source), str(dest))
 
             relative_path = str(dest.relative_to(project_path))
@@ -488,6 +501,16 @@ def sync_template_changes(
                 if not project_file.exists():
                     if template_changed_files is None:
                         verbose_print(f"   Skipped new file: {relative}")
+                        continue
+                    # A whole-file gate that is OFF for this stack renders to
+                    # nothing. Init sweeps those stubs after generation
+                    # (``sweep_empty_stubs``); this backstop must not put
+                    # them back, or a project accumulates 1-byte files for
+                    # every component it never selected. The changed-set
+                    # cannot tell a real addition from a gated-off one: git
+                    # sees the template file change either way.
+                    if not _is_meaningful_render(relative, new_content):
+                        verbose_print(f"   Skipped gated-off new file: {relative}")
                         continue
                     project_file.parent.mkdir(parents=True, exist_ok=True)
                     project_file.write_bytes(new_content)
@@ -895,6 +918,20 @@ def _three_way_merge(
             )
     except OSError as e:
         verbose_print(f"   Warning: Could not sync {relative}: {e}")
+
+
+def _is_meaningful_render(relative: Path, content: bytes) -> bool:
+    """False when a rendered template is a whole-file-gated empty stub.
+
+    The same rule as ``render_diff._is_meaningful`` and
+    ``manual_updater._is_empty_stub``, restated here rather than imported:
+    both of those modules import from this one, so importing either back
+    would be a cycle. ``__init__.py`` is the one legitimately-empty file,
+    a package marker, and is always meaningful.
+    """
+    if relative.name == "__init__.py":
+        return True
+    return bool(content.strip())
 
 
 def _should_skip_sync(relative_path: str) -> bool:

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -541,6 +541,46 @@ class TestUpdateCommandRollback:
         assert mock_create_backup.called, "Backup should be created"
         assert mock_cleanup.called, "Cleanup should be called when backup was created"
 
+    @patch("aegis.commands.update.sync_template_changes")
+    @patch("aegis.commands.update.run_post_generation_tasks")
+    @patch("aegis.commands.update.generate_missing_migrations")
+    @patch("copier.run_update")
+    @patch("aegis.commands.update.get_current_template_commit")
+    @patch("aegis.commands.update.create_backup_point")
+    def test_update_generates_migrations_the_project_predates(
+        self,
+        mock_create_backup: MagicMock,
+        mock_get_commit: MagicMock,
+        mock_copier_update: MagicMock,
+        mock_generate: MagicMock,
+        mock_post_gen: MagicMock,
+        mock_sync: MagicMock,
+        project_factory: "ProjectFactory",
+    ) -> None:
+        """A project generated before a migration existed must receive it on
+        update. `add-service` already calls `generate_missing_migrations`
+        for exactly this; `update` never did, so a v0.10.1 auth project
+        updated to HEAD kept its `001 -> 003` chain with `auth_tokens`
+        never written (#1024)."""
+        mock_create_backup.return_value = None
+        mock_get_commit.return_value = "different-commit"
+        mock_post_gen.return_value = True
+        mock_sync.return_value = SyncResult()
+        mock_generate.return_value = []
+
+        project_path = project_factory("base_with_auth_service")
+
+        run_aegis_command("update", "--project-path", str(project_path), "--yes")
+
+        assert mock_generate.called, (
+            "update must generate migrations the project predates"
+        )
+        # It must run BEFORE the alembic upgrade in post-gen, or the new
+        # revision is written after the DB was already stamped past it.
+        # macOS hands the fixture a /var path and the command resolves it
+        # to /private/var; compare identities, not spellings.
+        assert mock_generate.call_args[0][0].resolve() == project_path.resolve()
+
     @patch("aegis.commands.update.rollback_to_backup")
     @patch("aegis.commands.update.create_backup_point")
     @patch("copier.run_update")

--- a/tests/core/test_db_template_async_url.py
+++ b/tests/core/test_db_template_async_url.py
@@ -28,7 +28,8 @@ def _converter(engine: str) -> Any:
     source = env.get_template("{{ project_slug }}/app/core/db.py.jinja").render(ctx)
     tree = ast.parse(source)
     fn = next(
-        n for n in tree.body
+        n
+        for n in tree.body
         if isinstance(n, ast.FunctionDef) and n.name == "_get_async_database_url"
     )
     ns: dict[str, Any] = {}

--- a/tests/core/test_migration_generator.py
+++ b/tests/core/test_migration_generator.py
@@ -1795,3 +1795,101 @@ class TestPluginMigrations:
         assert len(first) == 1
         assert second == []
         assert len(list((tmp_path / "alembic" / "versions").glob("*.py"))) == 1
+
+
+class TestMigrationsAreIdempotentOnPrepopulatedSQLite:
+    """SQLite projects run ``SQLModel.metadata.create_all`` at startup
+    (``app/core/db.py``), so their database already holds every table the
+    models define - ahead of any migration. A revision the project predates
+    is then delivered by ``aegis update`` and its ``create_table`` collides
+    with a table ``create_all`` already made (#1024: ``table
+    password_reset_token already exists``).
+
+    Postgres projects are migration-only and never hit this, so the guard
+    is exactly what the ticket asked for: inspector-checked per table, one
+    chain serving both a pre-populated and a fresh database.
+    """
+
+    def _apply(self, source: str, url: str) -> None:
+        """Execute a rendered migration's ``upgrade()`` against ``url``."""
+        import sys
+        import types
+
+        import sqlalchemy as sa
+        from alembic.migration import MigrationContext
+        from alembic.operations import Operations
+
+        # Rendered migrations ``import sqlmodel`` (a generated-project
+        # dependency the framework venv does not carry). Only ``upgrade()``
+        # is under test, so a stub module satisfies the import.
+        stub = types.ModuleType("sqlmodel")
+        stub.sql = types.ModuleType("sqlmodel.sql")  # type: ignore[attr-defined]
+        stub.sql.sqltypes = types.ModuleType("sqlmodel.sql.sqltypes")  # type: ignore[attr-defined]
+        stub.sql.sqltypes.AutoString = sa.String  # type: ignore[attr-defined]
+        saved = {
+            k: sys.modules.get(k)
+            for k in ("sqlmodel", "sqlmodel.sql", "sqlmodel.sql.sqltypes")
+        }
+        sys.modules["sqlmodel"] = stub
+        sys.modules["sqlmodel.sql"] = stub.sql  # type: ignore[attr-defined]
+        sys.modules["sqlmodel.sql.sqltypes"] = stub.sql.sqltypes  # type: ignore[attr-defined]
+        try:
+            engine = sa.create_engine(url)
+            with engine.begin() as conn:
+                ctx = MigrationContext.configure(conn)
+                with Operations.context(ctx):
+                    ns: dict = {}
+                    exec(compile(source, "<migration>", "exec"), ns)
+                    ns["upgrade"]()
+            engine.dispose()
+        finally:
+            for k, v in saved.items():
+                if v is None:
+                    sys.modules.pop(k, None)
+                else:
+                    sys.modules[k] = v
+
+    def test_create_table_skips_tables_create_all_already_made(
+        self, tmp_path: Path
+    ) -> None:
+        import sqlalchemy as sa
+
+        url = f"sqlite:///{tmp_path / 'app.db'}"
+        source = _render_migration(AUTH_TOKENS_MIGRATION, "004", "003")
+
+        # First application: fresh DB, everything created.
+        self._apply(source, url)
+        engine = sa.create_engine(url)
+        names = set(sa.inspect(engine).get_table_names())
+        assert "password_reset_token" in names
+        assert "email_verification_token" in names
+        engine.dispose()
+
+        # Second application against the SAME database: every table now
+        # pre-exists, exactly the state ``create_all`` leaves a SQLite
+        # project in. Must not raise "already exists".
+        self._apply(source, url)
+
+    def test_add_column_on_existing_table_still_fails_loudly(
+        self, tmp_path: Path
+    ) -> None:
+        """The table guard must NOT extend to ``add_column``: a column that
+        already exists is a real schema conflict (#1023-shaped), not
+        ``create_all`` pre-creation, and hiding it would hide the bug."""
+        import pytest
+        import sqlalchemy as sa
+
+        url = f"sqlite:///{tmp_path / 'app.db'}"
+        engine = sa.create_engine(url)
+        with engine.begin() as conn:
+            conn.execute(sa.text("CREATE TABLE t (id INTEGER PRIMARY KEY, x TEXT)"))
+        engine.dispose()
+
+        source = (
+            "from alembic import op\nimport sqlalchemy as sa\n"
+            "def upgrade():\n"
+            "    with op.batch_alter_table('t') as b:\n"
+            "        b.add_column(sa.Column('x', sa.String(), nullable=True))\n"
+        )
+        with pytest.raises(Exception):
+            self._apply(source, url)

--- a/tests/core/test_post_gen_tasks.py
+++ b/tests/core/test_post_gen_tasks.py
@@ -355,6 +355,38 @@ class TestRunPostGenerationTasks:
 
             assert result is True  # Deps succeeded, so overall success
 
+    def test_migration_failure_is_reported_not_swallowed(self, tmp_path: Path) -> None:
+        """`run_migrations` returns False on a failed `alembic upgrade`, but
+        the caller discarded that value, so nothing upstream could tell.
+        `aegis update` then printed "completed successfully" over a
+        migration that never applied (#1024). The overall return stays
+        True (migrations are non-fatal, see the test above); the failure
+        must be exposed through a separate channel the caller can read.
+        """
+        with (
+            patch("aegis.core.post_gen_tasks.install_dependencies", return_value=True),
+            patch("aegis.core.post_gen_tasks.setup_env_file", return_value=True),
+            patch("aegis.core.post_gen_tasks.run_migrations", return_value=False),
+            patch("aegis.core.post_gen_tasks.format_code", return_value=True),
+        ):
+            outcome = run_post_generation_tasks(
+                tmp_path, include_migrations=True, report=(report := {})
+            )
+
+            assert outcome is True
+            assert report["migrations_ok"] is False
+
+        with (
+            patch("aegis.core.post_gen_tasks.install_dependencies", return_value=True),
+            patch("aegis.core.post_gen_tasks.setup_env_file", return_value=True),
+            patch("aegis.core.post_gen_tasks.run_migrations", return_value=True),
+            patch("aegis.core.post_gen_tasks.format_code", return_value=True),
+        ):
+            run_post_generation_tasks(
+                tmp_path, include_migrations=True, report=(report := {})
+            )
+            assert report["migrations_ok"] is True
+
     def test_auth_migrations_triggered(self, tmp_path: Path) -> None:
         """Test that migrations run when auth is enabled."""
         with (

--- a/tests/core/test_template_cleanup.py
+++ b/tests/core/test_template_cleanup.py
@@ -141,6 +141,36 @@ class TestCleanupNestedProjectDirectory:
         # Nested directory should be removed
         assert not nested_dir.exists()
 
+    def test_gated_off_nested_file_is_dropped_not_promoted(
+        self, tmp_path: Path
+    ) -> None:
+        """Copier renders every template file into the nested ``slug/`` dir,
+        including ones whose whole-file gate is OFF for this stack - those
+        arrive as a lone newline. Promoting them to the project root plants
+        1-byte stubs a fresh render would never contain (init sweeps them).
+
+        The other half of the same defect as the sync backstop: four
+        ``tests/**`` files new at HEAD came in this way on a v0.10.1 update.
+        ``__init__.py`` is the one legitimately-empty file and must still
+        be promoted.
+        """
+        project_slug = "my-project"
+        nested_dir = tmp_path / project_slug
+        (nested_dir / "tests" / "components").mkdir(parents=True)
+        (nested_dir / "app" / "pkg").mkdir(parents=True)
+
+        (nested_dir / "tests" / "components" / "test_worker.py").write_text("\n")
+        (nested_dir / "app" / "real.py").write_text("x = 1\n")
+        (nested_dir / "app" / "pkg" / "__init__.py").write_text("")
+
+        result = cleanup_nested_project_directory(tmp_path, project_slug)
+
+        assert not (tmp_path / "tests" / "components" / "test_worker.py").exists()
+        assert "tests/components/test_worker.py" not in result
+        assert (tmp_path / "app" / "real.py").read_text() == "x = 1\n"
+        assert (tmp_path / "app" / "pkg" / "__init__.py").exists()
+        assert not nested_dir.exists()
+
     def test_moves_files_in_subdirectories(self, tmp_path: Path) -> None:
         """Test that files in nested subdirectories are moved correctly."""
         project_slug = "my-project"
@@ -625,6 +655,56 @@ class TestSyncTemplateChanges:
         assert "app/main.py" not in result.synced
         assert config_file.read_text() == "# new config"
         assert main_file.read_text() == "# old main"
+
+    def test_gated_off_new_file_is_not_created_as_an_empty_stub(
+        self, tmp_path: Path
+    ) -> None:
+        """A whole-file-gated template that renders to nothing for this stack
+        must not be materialised by the new-file backstop.
+
+        Reproduced updating a database+ingress+auth project from v0.10.1 to
+        HEAD: seven ``tests/**`` and ``app/**`` files gated on
+        ``include_worker`` / ``include_finance`` / ``insights_per_user`` were
+        in the changed-set and got written as 1-byte stubs. A fresh render
+        of the same answers has none of them, because init sweeps empty
+        stubs; the update path never did. ``__init__.py`` is the one
+        legitimately-empty file and must still be created.
+        """
+        project_slug = "my-project"
+        answers = {"project_slug": project_slug}
+
+        def mock_run_copy(**kwargs: object) -> None:
+            dst_path = str(kwargs["dst_path"])
+            rendered = Path(dst_path) / project_slug
+            (rendered / "tests" / "components").mkdir(parents=True)
+            (rendered / "app" / "pkg").mkdir(parents=True)
+            if "/old" not in dst_path:
+                # Gate off for this stack: the template emits only a newline.
+                (rendered / "tests" / "components" / "test_worker.py").write_text("\n")
+                # A real new file alongside it, to prove the backstop still
+                # creates meaningful content.
+                (rendered / "app" / "real.py").write_text("x = 1\n")
+                # Legitimately empty package marker: must be created.
+                (rendered / "app" / "pkg" / "__init__.py").write_text("")
+
+        with patch("copier.run_copy", side_effect=mock_run_copy):
+            result = sync_template_changes(
+                tmp_path,
+                answers,
+                "gh:test/repo",
+                "v1.0.0",
+                template_changed_files={
+                    "tests/components/test_worker.py",
+                    "app/real.py",
+                    "app/pkg/__init__.py",
+                },
+                old_commit="abc123",
+            )
+
+        assert not (tmp_path / "tests" / "components" / "test_worker.py").exists()
+        assert "tests/components/test_worker.py" not in result.synced
+        assert (tmp_path / "app" / "real.py").read_text() == "x = 1\n"
+        assert (tmp_path / "app" / "pkg" / "__init__.py").exists()
 
     def test_empty_template_changed_files_syncs_nothing(self, tmp_path: Path) -> None:
         """Test that empty set means no files changed — nothing synced."""


### PR DESCRIPTION
Closes #1028, #1024. Refs #1017, #1021.

Two commits, both found by **reproducing** rather than reading: a project generated with sector-7g's exact answer set at `v0.10.1`, updated to `HEAD`, and compared against ground truth.

---

## Commit 1 — gated-off template files landed as empty stubs (#1028)

Diffed the updated tree against a fresh `HEAD` render of the same answers. Three milestone tickets describe this scenario:

| Ticket | Claim | On `main` today |
|---|---|---|
| #1017 | unselected-service files deposited | **Does not reproduce.** `app/services/` identical to fresh. |
| #1021 | new template files skipped | **Does not reproduce.** 0 missing files. |
| #1028 | template-removed files linger | **Misdiagnosed but real.** 7 extra files — none template-removed. |

#1017 and #1021 were closed by `_prune_render` (ed93c971, 2026-09-06). Closed both with the evidence.

The 7 leftovers were **1-byte stubs**: templates whose whole-file gate is off for this stack, rendering to a lone newline. `init` sweeps those; `update` created them on **both** its new-file paths (`sync_template_changes`' backstop, and `cleanup_nested_project_directory`'s raw `shutil.move`). Both now apply the rule init already uses: no non-whitespace content means *absent*, not new. `__init__.py` stays.

**Result: 304 = 304**, file-for-file identical to a fresh render, zero stubs, and the project imports.

---

## Commit 2 — migrations never delivered, and failures reported as success (#1024)

Repro: same project, plus a user-authored `003` migration and a DB stamped at `001`. Three distinct defects:

**1. `generate_missing_migrations` was never called on update.** It's wired into `add-service` and `ManualUpdater.add_service` — but `aegis update` only ran `alembic upgrade head`. A project generated before a revision existed never received it; the chain stayed `001 → 003` with `auth_tokens` never written. The generator already chains correctly after the project's own head (`max+1` / `existing[-1]`). It now runs *before* post-gen's upgrade.

**2. A failed upgrade printed "completed successfully".** `run_migrations` returns `False`, but `run_post_generation_tasks` discarded it — `tasks_success` could never reflect a migration failure. The deployed app was what crashed. Migrations stay non-fatal to generation (`add_service` and `test_non_critical_failures_continue` depend on that); the result is exposed through a `report` dict, and `update` turns it into the partial-success outcome.

**3. `create_table` collided with `create_all`.** SQLite projects run `SQLModel.metadata.create_all` at startup, so the DB already holds every model table — ahead of any migration. Delivering `auth_tokens` failed with `table password_reset_token already exists`. The migration template now inspects the connection once and skips `create_table` (plus that table's indexes) per pre-existing table. **SQLite-specific by construction**: Postgres is migration-only and never pre-creates, so it's a no-op there. `add_column` is deliberately unguarded — a duplicate column is a real conflict (#1023-shaped), not pre-creation.

**Result:** the same update now generates `004_auth_tokens.py` chained after `003`, applies it over the pre-populated DB, advances the stamp to `004`, and "completed successfully" is finally true. All 17 migration specs still render to valid Python on both engines.

---

## Tests

TDD throughout; every test red before its fix. The second stub test caught a stale loop variable in my first patch (the `__init__.py` check read the wrong path). The idempotency test is the first in the repo to *execute* a generated migration against a real SQLite engine, not just assert rendered text. **236 pass** across generator, post-gen, cleanup, updater and size-budget; add-service (9) unaffected; ruff and `ty` clean.

## Also in this PR

`tests/core/test_db_template_async_url.py` had failed `ruff format --check` on `main` since 8189c451, so every branch cut after it tripped the pre-commit hook on a file it never touched. Reformatted in its own commit — a two-line generator-expression reflow, no behaviour change.
