### PR TITLE
Update Path Hardening: re-lock, orphan export, image tag, sentinel owner (#1019, #1026, #1027, #1110)

### DIFF
--- a/aegis/commands/update.py
+++ b/aegis/commands/update.py
@@ -42,6 +42,7 @@ from ..core.post_gen_tasks import cleanup_components, run_post_generation_tasks
 from ..core.template_cleanup import (
     cleanup_nested_project_directory,
     removed_env_keys,
+    stale_env_defaults,
     sync_template_changes,
 )
 from ..core.version_compatibility import get_cli_version, get_project_template_version
@@ -237,6 +238,7 @@ def _run_postgen(target_path: Path, answers: dict[str, Any]) -> bool:
         target_path,
         include_migrations=include_migrations,
         report=postgen_report,
+        relock=True,
     )
     # A failed upgrade is non-fatal to generation but must not be
     # reported as a clean update: the deployed app is what crashes
@@ -838,7 +840,9 @@ def update_command(
         # ticket. Neither is derived from a diff - the keys are a set
         # difference against the updated Settings, the changes are declared
         # per version by whoever changed the behavior. Report only.
-        stale_keys = removed_env_keys(target_path)
+        stale_keys = removed_env_keys(target_path) + stale_env_defaults(
+            target_path, answers
+        )
         changes = behavior_changes_for(
             from_version=current_version or "",
             to_version=_template_version_for_ref(target_ref),

--- a/aegis/core/behavior_changes.py
+++ b/aegis/core/behavior_changes.py
@@ -55,6 +55,21 @@ BEHAVIOR_CHANGES: tuple[BehaviorChange, ...] = (
         ),
         restore="AUTH_ENABLED=false in .env keeps the dashboard open (synthetic dev user).",
     ),
+    BehaviorChange(
+        since="0.7.0",
+        when=lambda a: _truthy(a, "include_scheduler")
+        and a.get("scheduler_backend", "memory") != "memory",
+        message=(
+            "The scheduler now treats code as the source of truth for jobs: "
+            "on boot it deletes every persisted job whose id is not registered "
+            "in create_scheduler. Schedules added at runtime (UI/CLI) count as "
+            "orphans on the first boot after this update."
+        ),
+        restore=(
+            "The deleted rows are exported to DATABASE_BACKUP_DIR/orphan_jobs_<ts>.json "
+            "before removal; register the ones you want in create_scheduler."
+        ),
+    ),
 )
 
 

--- a/aegis/core/components.py
+++ b/aegis/core/components.py
@@ -208,6 +208,7 @@ COMPONENTS: dict[str, ComponentSpec] = {
                 "app/components/scheduler",
                 ".claude/skills/add-scheduled-job",
                 "app/services/scheduler/execution_log.py",
+                "app/services/scheduler/orphans.py",
                 "tests/components/test_scheduler.py",
                 "tests/services/test_scheduler_execution_log.py",
                 "tests/services/test_scheduler_executions_read.py",

--- a/aegis/core/migration_generator.py
+++ b/aegis/core/migration_generator.py
@@ -157,11 +157,17 @@ class ServiceMigrationSpec:
     schema: str | None = None
     # Proof this migration already ran, for the startup hook that
     # re-adopts a persisted database by stamping instead of replaying
-    # DDL. ``("table", name)``, ``("column", table, col)`` or
-    # ``("foreign_key", table, col)``. A migration without one opts out
+    # DDL. ``("table", name)``, ``("column", table, col)``,
+    # ``("foreign_key", table, col)``, or ``("row", table, where)`` for a
+    # data-only revision (data_sql). A migration without one opts out
     # of that recovery, so every shipped migration should carry it;
     # in-tree services declare theirs in ``migration_signatures.py``.
     stamp_signature: tuple[str, ...] | None = None
+    # Raw statements run after the DDL in ``upgrade()``, for the rare data
+    # a schema change makes mandatory (a row a new FK points at). Each
+    # must be idempotent: ``aegis update`` can deliver a migration to a
+    # database that already holds the row. Not reversed in ``downgrade``.
+    data_sql: list[str] = field(default_factory=list)
 
 
 # ============================================================================
@@ -4002,6 +4008,24 @@ def _build_finance_auth_link(
             )
             for table in _FINANCE_OWNED_TABLES
         ],
+        # Finance writes ``owner_user_id = 0`` when no owner is given
+        # (standalone installs, AI tools). With the FKs above that value
+        # must exist in ``user`` or every such insert fails (#1110). One
+        # inactive row, never a login; idempotent so re-delivery is safe.
+        data_sql=[_sentinel_owner_insert(user_ref_schema)],
+    )
+
+
+def _sentinel_owner_insert(user_ref_schema: str | None) -> str:
+    user_table = f'"{user_ref_schema}"."user"' if user_ref_schema else '"user"'
+    return (
+        f"INSERT INTO {user_table} "
+        "(id, email, is_active, is_verified, hashed_password, "
+        "failed_login_attempts, created_at) "
+        # Boolean literals, not 0: Postgres refuses an integer in a boolean
+        # column and SQLite accepts FALSE (3.23+), so one statement serves both.
+        "SELECT 0, 'standalone@finance.local', FALSE, FALSE, '!', 0, CURRENT_TIMESTAMP "
+        f"WHERE NOT EXISTS (SELECT 1 FROM {user_table} WHERE id = 0)"
     )
 
 
@@ -4279,6 +4303,9 @@ def upgrade() -> None:
 {% endfor %}
 
 {% endfor %}
+{% for stmt in data_sql %}
+    op.execute("""{{ stmt }}""")
+{% endfor %}
 
 def downgrade() -> None:
     """Reverse {{ service_name }} migration."""
@@ -4515,6 +4542,7 @@ def _render_migration(
         tables=tables_data,
         alter_tables=alter_tables_data,
         forward_only=spec.forward_only,
+        data_sql=spec.data_sql,
         schema=spec.schema,
     )
 
@@ -4644,7 +4672,84 @@ def generate_revisions(
         raise MigrationGenerationError(
             f"migrate_gen failed for {', '.join(services)}:\n{result.stderr[-2000:]}"
         )
-    return sorted(set(versions_dir.glob("*.py")) - before)
+    written = sorted(set(versions_dir.glob("*.py")) - before)
+    written.extend(_place_data_statements(project_path, services, written))
+    return sorted(written)
+
+
+_DATA_REVISION = '''"""{description}
+
+Revision ID: {revision}
+Revises: {down_revision}
+Create Date: {create_date}
+
+"""
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = {revision!r}
+down_revision = {down_revision!r}
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+{body}
+
+
+def downgrade() -> None:
+    pass
+'''
+
+
+def _data_lines(statements: list[str]) -> str:
+    return "\n".join(f'    op.execute("""{stmt}""")' for stmt in statements)
+
+
+def _place_data_statements(
+    project_path: Path, services: list[str], written: list[Path]
+) -> list[Path]:
+    """Give every service's ``data_sql`` a revision to run in.
+
+    The models decide the DDL; ``data_sql`` is the one thing they cannot
+    describe (a row a new FK points at, #1110). It rides in the revision
+    the run just wrote for its service, or - when the models produced
+    nothing for that service, as ``finance_auth_link`` does now that its
+    FKs are inline in ``finance`` - in a data-only revision written here.
+    Each statement must be idempotent: ``aegis update`` can deliver a
+    revision to a database that already holds the row.
+
+    Returns the data-only revisions this call created.
+    """
+    specs = _get_migration_specs()
+    created: list[Path] = []
+    for service in services:
+        spec = specs.get(service)
+        if spec is None or not spec.data_sql:
+            continue
+        own = [p for p in written if p.name.endswith(f"_{service}.py")]
+        if own:
+            src = own[0].read_text()
+            head, sep, tail = src.rpartition("\n\n\ndef downgrade")
+            if not sep:
+                raise MigrationGenerationError(
+                    f"{own[0].name}: no downgrade() to anchor data statements"
+                )
+            own[0].write_text(f"{head}\n{_data_lines(spec.data_sql)}{sep}{tail}")
+        elif not service_has_migration(project_path, service):
+            revision = get_next_revision_id(project_path)
+            path = get_versions_dir(project_path) / f"{revision}_{service}.py"
+            path.write_text(
+                _DATA_REVISION.format(
+                    description=spec.description,
+                    revision=revision,
+                    down_revision=get_previous_revision(project_path),
+                    create_date=datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S.%f"),
+                    body=_data_lines(spec.data_sql),
+                )
+            )
+            created.append(path)
+    return created
 
 
 def generate_migration(

--- a/aegis/core/post_gen_tasks.py
+++ b/aegis/core/post_gen_tasks.py
@@ -674,7 +674,9 @@ def copy_service_files(
         )
 
 
-def install_dependencies(project_path: Path, python_version: str | None = None) -> bool:
+def install_dependencies(
+    project_path: Path, python_version: str | None = None, *, relock: bool = False
+) -> bool:
     """
     Install project dependencies using uv.
 
@@ -707,6 +709,13 @@ def install_dependencies(project_path: Path, python_version: str | None = None) 
         # pytest) are present — the post-gen ``make fix`` formatting step needs
         # ruff, and without it generated projects shipped unformatted.
         cmd = ["uv", "sync", "--all-extras"]
+        # A plain sync honours whatever uv.lock already pins. After a
+        # template update that is a stale resolve of the OLD pyproject
+        # (#1019: year-old httpx/pydantic, ~80 phantom type errors in
+        # byte-identical files). ``--upgrade`` re-resolves; on a fresh
+        # project there is no lock yet, so it changes nothing there.
+        if relock:
+            cmd.append("--upgrade")
         if python_version:
             cmd.extend(["--python", python_version])
 
@@ -1064,6 +1073,7 @@ def run_post_generation_tasks(
     reporter: "BuildReporter | None" = None,
     report: dict[str, bool] | None = None,
     migration_services: list[str] | None = None,
+    relock: bool = False,
 ) -> bool:
     """
     Run all post-generation tasks for a project.
@@ -1099,7 +1109,7 @@ def run_post_generation_tasks(
     # Task 1: Install dependencies (CRITICAL - fails entire generation if this fails)
     if reporter is not None:
         reporter.step("deps", t("build.step.deps"), "uv sync")
-    deps_success = install_dependencies(project_path, python_version)
+    deps_success = install_dependencies(project_path, python_version, relock=relock)
 
     if not deps_success:
         typer.echo()

--- a/aegis/core/template_cleanup.py
+++ b/aegis/core/template_cleanup.py
@@ -993,6 +993,38 @@ def _settings_field_names(config_path: Path) -> set[str] | None:
     return None
 
 
+def stale_env_defaults(
+    project_path: Path, answers: dict[str, Any]
+) -> list[RemovedEnvKey]:
+    """Keys still holding a template default that later became harmful.
+
+    Every project once shipped ``AEGIS_STACK_TAG=aegis-stack:latest``, so two
+    projects on one machine shared one image tag and ``docker compose up``
+    in one silently ran the other's build (#1027). The template default is
+    now the project slug; a project that kept the old value is told. Report
+    only - ``.env`` is never edited.
+    """
+    env_path = project_path / ".env"
+    if not env_path.exists():
+        return []
+    slug = answers.get("project_slug") or project_path.name
+    hits: list[RemovedEnvKey] = []
+    for line in env_path.read_text().splitlines():
+        line = line.strip().removeprefix("export ").strip()
+        if (
+            line.startswith("AEGIS_STACK_TAG=")
+            and line.split("=", 1)[1].strip().strip("\"'") == "aegis-stack:latest"
+        ):
+            hits.append(
+                RemovedEnvKey(
+                    "AEGIS_STACK_TAG",
+                    f"shared with every other Aegis project on this machine; "
+                    f"set AEGIS_STACK_TAG={slug}:latest",
+                )
+            )
+    return hits
+
+
 def removed_env_keys(project_path: Path) -> list[RemovedEnvKey]:
     """``.env`` keys the post-update ``Settings`` no longer declares (#1020).
 

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/.env.example.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/.env.example.jinja
@@ -31,7 +31,7 @@ AUTO_RELOAD=true
 # =============================================================================
 
 # Docker image tag (used by docker-compose)
-AEGIS_STACK_TAG=aegis-stack:latest
+AEGIS_STACK_TAG={{ project_slug }}:latest
 
 # Version tag for builds
 AEGIS_STACK_VERSION=dev

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/database_init.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/database_init.py.jinja
@@ -25,6 +25,25 @@ import_all_models()
 
 {% set needs_migrations = include_auth or include_blog or include_documents or include_insights or include_payment or include_finance or (include_ai and ai_backend != "memory") or (include_scheduler and scheduler_backend != "memory") %}
 {% if database_engine == "postgres" and needs_migrations %}
+def _row_exists(conn: Any, table: str, where: str) -> bool:
+    """Whether ``SELECT 1 FROM table WHERE where`` finds a row.
+
+    The ``("row", table, where)`` signature form: proof for a data-only
+    revision (``finance_auth_link`` inserts user 0). A table, column or FK
+    cannot prove such a revision ran - the FK it used to add is inline in
+    the ``finance`` revision now - and stamping it on a persisted volume
+    would skip the only INSERT that satisfies that FK (aegis-stack#1110).
+    """
+    from sqlmodel import text
+
+    schema, _, bare = table.rpartition(".")
+    qualified = f'"{schema}"."{bare}"' if schema else f'"{bare}"'
+    try:
+        return conn.execute(text(f"SELECT 1 FROM {qualified} WHERE {where} LIMIT 1")).first() is not None
+    except Exception:
+        return False
+
+
 def _check_and_stamp_existing_tables() -> None:
     """
     Detect when tables for a pending migration already exist.
@@ -129,6 +148,9 @@ def _check_and_stamp_existing_tables() -> None:
                 already_applied = any(
                     col_name in fk.get("constrained_columns", ()) for fk in fks
                 )
+            elif sig[0] == "row":
+                with db_session(autocommit=False) as session:
+                    already_applied = _row_exists(session.connection(), sig[1], sig[2])
 
             if already_applied:
                 logger.warning(

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/backend/startup/migration_signatures.py.jinja
@@ -19,6 +19,10 @@ Forms:
 - ``("column", table, col)`` - column exists (ALTER TABLE migrations).
 - ``("foreign_key", table, col)`` - an FK constraint covers the column
   (FK-only migrations, e.g. payment_auth_link).
+- ``("row", table, where)`` - ``SELECT 1 FROM table WHERE where`` finds a
+  row (data-only migrations, e.g. finance_auth_link's user 0). Schema
+  objects cannot prove a data revision ran; stamping one on a persisted
+  volume would skip its INSERT.
 """
 
 SERVICE_MIGRATION_SIGNATURES: dict[str, tuple[str, ...]] = {
@@ -41,7 +45,10 @@ SERVICE_MIGRATION_SIGNATURES: dict[str, tuple[str, ...]] = {
     "finance_subjects": ("table", "finance.finance_subject"),
     "finance": ("table", "finance.finance_account"),
     "finance_budget_payee": ("column", "finance.finance_budget_category", "payee_key"),
-    "finance_auth_link": ("foreign_key", "finance.finance_account", "owner_user_id"),
+    # Data-only since models-derived revisions: the owner FKs are inline in
+    # ``finance``, so the FK proves nothing about this revision. The row it
+    # inserts does.
+    "finance_auth_link": ("row", "user", "id = 0"),
     "finance_icon": ("table", "finance.finance_icon"),
     "pending_changes": ("table", "finance.finance_pending_change"),
     "pending_change_batch": (

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/scheduler/main.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/components/scheduler/main.py.jinja
@@ -18,6 +18,7 @@ from apscheduler.schedulers.asyncio import AsyncIOScheduler
 {% if scheduler_backend != "memory" %}
 from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
 from app.core.db import engine, init_database, db_session
+from app.services.scheduler.orphans import drop_unknown_persisted_jobs
 from app.services.scheduler.execution_log import (
     cancel_stale_running_rows,
     prune_executions,
@@ -66,47 +67,6 @@ from app.services.system import activity
 from .heartbeat import is_heartbeat_event, register_heartbeat_job
 
 {% if scheduler_backend != "memory" %}
-
-def _drop_unknown_persisted_jobs(scheduler: AsyncIOScheduler) -> None:
-    """Delete persisted rows whose ID isn't registered in code.
-
-    ``replace_existing=True`` keeps live jobs in sync when their triggers
-    change, but does nothing for jobs that were *removed* from
-    ``create_scheduler``. Without this sweep, the persistent jobstore
-    would keep firing the obsolete job indefinitely — breaking the
-    "code is the source of truth" promise. Runs after the ``add_job``
-    pass so the set of intended IDs is whatever ``scheduler.get_jobs()``
-    reports right now.
-    """
-    from sqlmodel import text
-
-    try:
-        intended_ids = {job.id for job in scheduler.get_jobs()}
-        with db_session() as session:
-            persisted_ids = {
-                row[0]
-                for row in session.exec(
-                    text("SELECT id FROM apscheduler_jobs")
-                ).fetchall()
-            }
-
-        orphans = persisted_ids - intended_ids
-        if not orphans:
-            return
-
-        with db_session(autocommit=True) as session:
-            for job_id in orphans:
-                session.exec(
-                    text("DELETE FROM apscheduler_jobs WHERE id = :id"),
-                    params={"id": job_id},
-                )
-        logger.info(
-            f"Removed {len(orphans)} orphan scheduled job(s) "
-            f"(no longer in code): {sorted(orphans)}"
-        )
-    except Exception as e:
-        logger.debug(f"Orphan job sweep skipped: {e}")
-
 
 def _cleanup_stale_jobs() -> None:
     """Remove persisted jobs whose func_ref can no longer be imported.
@@ -430,7 +390,7 @@ def create_scheduler() -> AsyncIOScheduler:
     # "schedule changed" case for jobs that still exist; this covers the
     # "job deleted" case so persistent storage doesn't keep firing an
     # obsolete job ID forever.
-    _drop_unknown_persisted_jobs(scheduler)
+    drop_unknown_persisted_jobs(scheduler)
 {% endif %}
 
     return scheduler

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/core/config.py.jinja
@@ -93,7 +93,7 @@ class Settings(
     AUTO_RELOAD: bool = False
 
     # Docker settings (used by docker-compose)
-    AEGIS_STACK_TAG: str = "aegis-stack:latest"
+    AEGIS_STACK_TAG: str = "{{ project_slug }}:latest"
     AEGIS_STACK_VERSION: str = "dev"
 
     # Health monitoring and alerting

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/scheduler/orphans.py.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/app/services/scheduler/orphans.py.jinja
@@ -1,0 +1,104 @@
+{%- if scheduler_backend != "memory" %}
+"""Orphan sweep for the persistent jobstore.
+
+Code is the source of truth for scheduled jobs: a persisted row whose id is
+not registered in ``create_scheduler`` is deleted on boot, so removing an
+``add_job`` call actually stops the job. The cost is that schedules added at
+runtime (UI/CLI, persisted only in the jobstore) are orphans by the same
+definition - on the first boot after the update that introduced the sweep,
+all of them. sector-7g lost 26 that way with one INFO line as the only
+trace (aegis-stack#1026). Rows are exported before deletion so the sweep is
+recoverable, and nothing is deleted if the export cannot be written.
+"""
+
+import json
+import pickle
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from sqlmodel import text
+
+from app.core.config import settings
+from app.core.db import db_session
+from app.core.log import logger
+
+
+def drop_unknown_persisted_jobs(scheduler: AsyncIOScheduler) -> None:
+    """Delete persisted rows whose ID isn't registered in code.
+
+    ``replace_existing=True`` keeps live jobs in sync when their triggers
+    change, but does nothing for jobs that were *removed* from
+    ``create_scheduler``. Without this sweep, the persistent jobstore
+    would keep firing the obsolete job indefinitely — breaking the
+    "code is the source of truth" promise. Runs after the ``add_job``
+    pass so the set of intended IDs is whatever ``scheduler.get_jobs()``
+    reports right now.
+    """
+    try:
+        intended_ids = {job.id for job in scheduler.get_jobs()}
+        with db_session() as session:
+            persisted_ids = {
+                row[0]
+                for row in session.exec(
+                    text("SELECT id FROM apscheduler_jobs")
+                ).fetchall()
+            }
+
+        orphans = persisted_ids - intended_ids
+        if not orphans:
+            return
+
+        # Export before delete. On the first boot after a template update
+        # every schedule ever added at runtime (UI/CLI, persisted only in
+        # the jobstore) is an "orphan" by this definition, and one INFO
+        # line was the only trace of 26 of them going. The file makes the
+        # sweep recoverable; nothing is deleted if it cannot be written.
+        export_path = _export_orphan_jobs(sorted(orphans))
+
+        with db_session(autocommit=True) as session:
+            for job_id in orphans:
+                session.exec(
+                    text("DELETE FROM apscheduler_jobs WHERE id = :id"),
+                    params={"id": job_id},
+                )
+        logger.warning(
+            f"Removed {len(orphans)} orphan scheduled job(s) "
+            f"(no longer in code): {sorted(orphans)}. "
+            f"Exported to {export_path} - re-add from there if they were wanted."
+        )
+    except Exception as e:
+        logger.debug(f"Orphan job sweep skipped: {e}")
+
+
+def _export_orphan_jobs(job_ids: list[str]) -> Path:
+    """Write the rows the sweep is about to delete to a timestamped JSON file.
+
+    APScheduler stores each job as a pickle in ``job_state``; the fields an
+    operator needs to re-add it (func, trigger, args, kwargs) are pulled out
+    when it unpickles, and the raw hex kept otherwise so nothing is lost.
+    """
+    rows: list[dict[str, Any]] = []
+    with db_session() as session:
+        for job_id in job_ids:
+            row = session.exec(
+                text("SELECT next_run_time, job_state FROM apscheduler_jobs WHERE id = :id"),
+                params={"id": job_id},
+            ).one()
+            entry: dict[str, Any] = {"id": job_id, "next_run_time": row[0]}
+            try:
+                state = pickle.loads(row[1])
+                for key in ("func", "trigger", "args", "kwargs"):
+                    entry[key] = state.get(key) if isinstance(state, dict) else None
+            except Exception:
+                entry["job_state_hex"] = bytes(row[1]).hex()
+            rows.append(entry)
+
+    export_dir = Path(settings.DATABASE_BACKUP_DIR)
+    export_dir.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    path = export_dir / f"orphan_jobs_{stamp}.json"
+    path.write_text(json.dumps(rows, indent=2, default=str))
+    return path
+{%- endif %}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.dev.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.dev.yml.jinja
@@ -119,7 +119,7 @@ services:
       - dev
 
   build-static-watcher:
-    image: ${AEGIS_STACK_TAG:-aegis-stack:latest}
+    image: ${AEGIS_STACK_TAG:-{{ project_slug }}:latest}
     env_file:
       - ${AEGIS_STACK_ENV_FILE:-.env}
     working_dir: /code

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/docker-compose.yml.jinja
@@ -1,6 +1,6 @@
 
 x-app: &app
-  image: ${AEGIS_STACK_TAG:-aegis-stack:latest}
+  image: ${AEGIS_STACK_TAG:-{{ project_slug }}:latest}
   build:
     context: .
     args:

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_scheduler.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/components/test_scheduler.py
@@ -8,9 +8,10 @@ For integration tests of the actual scheduler, see the CLI tests that generate
 complete projects and validate they work correctly.
 """
 
-import pytest
-from app.services.system.health import check_system_status
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
+import pytest
+
+from app.services.system.health import check_system_status
 
 
 @pytest.mark.asyncio
@@ -61,3 +62,69 @@ async def test_scheduler_heartbeat_job_registered() -> None:
     HEARTBEAT_FILE.unlink(missing_ok=True)
     await touch_scheduler_heartbeat()
     assert HEARTBEAT_FILE.exists()
+
+
+def test_orphan_sweep_exports_before_deleting(tmp_path, monkeypatch) -> None:
+    """#1026: the sweep enforces code-as-truth by deleting persisted jobs
+    not registered in code. On the first boot after an update that is
+    every schedule ever added at runtime (sector-7g lost 26 in one INFO
+    line). Deletion must leave a file the operator can restore from."""
+    # A memory-backed scheduler ships neither the sweep nor SQLAlchemy;
+    # skip before importing either.
+    orphans = pytest.importorskip("app.services.scheduler.orphans")
+    pytest.importorskip("sqlalchemy")
+    from contextlib import contextmanager
+    import json
+    import pickle
+
+    from sqlalchemy import create_engine, text
+    from sqlmodel import Session
+
+    engine = create_engine("sqlite:///:memory:")
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "CREATE TABLE apscheduler_jobs (id VARCHAR PRIMARY KEY, "
+                "next_run_time FLOAT, job_state BLOB)"
+            )
+        )
+        state = pickle.dumps(
+            {
+                "func": "app.jobs:morning_donut_run",
+                "trigger": "cron[hour=7]",
+                "kwargs": {"n": 1},
+            }
+        )
+        conn.execute(
+            text("INSERT INTO apscheduler_jobs VALUES ('morning_donut_run', 1.0, :s)"),
+            {"s": state},
+        )
+        conn.execute(
+            text("INSERT INTO apscheduler_jobs VALUES ('in_code', 2.0, :s)"),
+            {"s": state},
+        )
+
+    @contextmanager
+    def fake_session(autocommit: bool = True):
+        with Session(engine) as session:
+            yield session
+            session.commit()
+
+    monkeypatch.setattr(orphans, "db_session", fake_session)
+    monkeypatch.setattr(orphans.settings, "DATABASE_BACKUP_DIR", str(tmp_path))
+
+    scheduler = AsyncIOScheduler()
+    scheduler.add_job(check_system_status, trigger="interval", minutes=5, id="in_code")
+
+    orphans.drop_unknown_persisted_jobs(scheduler)
+
+    with engine.begin() as conn:
+        left = {r[0] for r in conn.execute(text("SELECT id FROM apscheduler_jobs"))}
+    assert left == {"in_code"}
+
+    exports = list(tmp_path.glob("orphan_jobs_*.json"))
+    assert len(exports) == 1, exports
+    rows = json.loads(exports[0].read_text())
+    assert rows[0]["id"] == "morning_donut_run"
+    assert "morning_donut_run" in rows[0]["func"]
+    assert rows[0]["kwargs"] == {"n": 1}

--- a/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_migration_signatures.py
+++ b/aegis/templates/copier-aegis-project/{{ project_slug }}/tests/test_migration_signatures.py
@@ -74,3 +74,33 @@ def test_signatures_name_real_model_objects() -> None:
         assert name in tables or name in bare or name.split(".")[-1] in bare, (
             f"signature for '{service}' names '{name}', which no model declares"
         )
+
+
+def test_row_signature_checks_the_live_database() -> None:
+    """``("row", table, where)``: the hook must replay a data-only revision
+    whose row is missing and stamp it when the row is there."""
+    database_init = pytest.importorskip(
+        "app.components.backend.startup.database_init",
+        reason="no database component in this stack",
+    )
+    row_exists = getattr(database_init, "_row_exists", None)
+    if row_exists is None:
+        pytest.skip("re-adoption hook is Postgres-only in this stack")
+    import sqlalchemy as sa
+
+    engine = sa.create_engine("sqlite://")
+    with engine.begin() as conn:
+        conn.execute(sa.text('CREATE TABLE "user" (id INTEGER PRIMARY KEY, email TEXT)'))
+        assert row_exists(conn, "user", "id = 0") is False
+        conn.execute(sa.text("INSERT INTO \"user\" VALUES (0, 'standalone@finance.local')"))
+        assert row_exists(conn, "user", "id = 0") is True
+        # A table that does not exist is "not applied", never an exception.
+        assert row_exists(conn, "nope", "id = 0") is False
+
+
+def test_data_only_revisions_use_the_row_form() -> None:
+    """A data-only revision cannot be proven by a schema object."""
+    sig = signatures_module.SERVICE_MIGRATION_SIGNATURES.get("finance_auth_link")
+    if sig is None:
+        pytest.skip("finance_auth_link not in this stack")
+    assert sig[0] == "row" and sig[1] == "user" and "id = 0" in sig[2]

--- a/tests/cli/test_add_service_migrations.py
+++ b/tests/cli/test_add_service_migrations.py
@@ -13,7 +13,7 @@ import sqlite3
 import pytest
 
 from tests.cli.conftest import ProjectFactory
-from tests.cli.test_utils import run_aegis_command
+from tests.cli.test_utils import run_aegis_command, run_project_command
 
 
 class TestAddServiceMigrationGeneration:
@@ -374,3 +374,57 @@ class TestAddServiceAIBackendMigrations:
         assert "Bootstrapping alembic" not in result.stdout
         assert "Applying database migrations" not in result.stdout
         assert "Generated migration" not in result.stdout
+
+
+class TestAddAuthOntoFinance:
+    def test_sentinel_owner_lands_after_user_exists(
+        self, project_factory: ProjectFactory
+    ) -> None:
+        """#1110 on the add path: a standalone finance project gains auth.
+        The owner FKs now arrive in a later revision than the finance
+        tables, and the row they point at (user 0) must land in that pass,
+        after ``user`` exists, so the run's order is auth, auth_tokens,
+        finance_auth_link."""
+        import sqlite3
+
+        project_path = project_factory(
+            components=["database", "scheduler"], services=["finance"]
+        )
+        versions_dir = project_path / "alembic" / "versions"
+        before = sorted(p.name for p in versions_dir.glob("*.py"))
+        assert not any("auth" in n for n in before)
+        # The cache copy carries a venv whose interpreter links are only
+        # valid at the cache's own path (as test_migrations_match_models
+        # notes); the post-add ``alembic upgrade`` needs a working one.
+        import shutil
+
+        shutil.rmtree(project_path / ".venv", ignore_errors=True)
+        # UV_PYTHON pins the interpreter for the aegis tool in CI (3.11);
+        # the project resolves its own requires-python.
+        sync = run_project_command(
+            ["uv", "sync", "--extra", "dev"],
+            project_path,
+            timeout=600,
+            env_overrides={"VIRTUAL_ENV": "", "UV_PYTHON": ""},
+        )
+        assert sync.success, sync.stderr[-800:]
+
+        result = run_aegis_command(
+            "add-service", "auth", "--project-path", str(project_path), "--yes"
+        )
+        assert result.returncode == 0, f"Add-service failed: {result.stderr}"
+
+        added = sorted({p.name for p in versions_dir.glob("*.py")} - set(before))
+        suffixes = [n.split("_", 1)[1] for n in added]
+        assert suffixes.index("auth.py") < suffixes.index("finance_auth_link.py")
+        link = (
+            versions_dir / added[suffixes.index("finance_auth_link.py")]
+        ).read_text()
+        assert "standalone@finance.local" in link
+
+        db_path = project_path / "data" / "app.db"
+        assert db_path.exists(), result.stdout[-1500:]
+        db = sqlite3.connect(db_path)
+        tables = {r[0] for r in db.execute("select name from sqlite_master")}
+        assert "user" in tables, (sorted(tables), result.stdout[-1500:])
+        assert db.execute("select id from user where id = 0").fetchall() == [(0,)]

--- a/tests/cli/test_update_command.py
+++ b/tests/cli/test_update_command.py
@@ -613,7 +613,10 @@ class TestUpdateCommandRollback:
 
         project_path = project_factory("base_with_auth_service")
         # A stale key the updated Settings no longer declares.
-        (project_path / ".env").write_text("DOCS_AUTH_ENABLED=true\nAPP_ENV=dev\n")
+        env_text = (
+            "DOCS_AUTH_ENABLED=true\nAPP_ENV=dev\nAEGIS_STACK_TAG=aegis-stack:latest\n"
+        )
+        (project_path / ".env").write_text(env_text)
         # Pin the recorded template version BELOW the auth gate (0.6.12) so
         # the update genuinely crosses it.
         answers_file = project_path / ".copier-answers.yml"
@@ -654,10 +657,10 @@ class TestUpdateCommandRollback:
         assert "DOCS_USERNAME" in out
         # #1029 - the behavior flip, and the flag that restores the old one.
         assert "AUTH_ENABLED=false" in out
+        # #1027 - the shared image tag is named, with the slug to use.
+        assert "AEGIS_STACK_TAG=" in out and ":latest" in out
         # Report only: .env is credentials and must be byte-identical.
-        assert (
-            project_path / ".env"
-        ).read_text() == "DOCS_AUTH_ENABLED=true\nAPP_ENV=dev\n"
+        assert (project_path / ".env").read_text() == env_text
 
     @patch("aegis.commands.update.sync_template_changes")
     @patch("aegis.commands.update.run_post_generation_tasks")
@@ -728,6 +731,8 @@ class TestUpdateCommandRollback:
         )
         assert result.returncode == 0, strip_ansi_codes(result.stdout)
         assert mock_post_gen.called
+        # #1019: the update path (and therefore finish) re-locks.
+        assert mock_post_gen.call_args.kwargs["relock"] is True
         assert answers_file.read_text() != version_before
         assert not pending.exists()
 

--- a/tests/core/test_behavior_changes.py
+++ b/tests/core/test_behavior_changes.py
@@ -92,3 +92,20 @@ class TestRegistryHygiene:
         gate = _auth_gate()
         assert gate.since == "0.6.12"
         assert gate.restore is not None and "AUTH_ENABLED=false" in gate.restore
+
+
+def test_scheduler_sweep_entry_needs_persistence() -> None:
+    """The sweep only exists with a persistent jobstore; a memory-backed
+    scheduler has nothing to lose and must not be warned."""
+    base = {"include_scheduler": True, "scheduler_backend": "postgres"}
+    assert behavior_changes_for(
+        from_version="0.6.13", to_version="0.10.1", answers=base
+    )
+    memory = {**base, "scheduler_backend": "memory"}
+    assert not [
+        c
+        for c in behavior_changes_for(
+            from_version="0.6.13", to_version="0.10.1", answers=memory
+        )
+        if c.since == "0.7.0"
+    ]

--- a/tests/core/test_generate_revisions.py
+++ b/tests/core/test_generate_revisions.py
@@ -98,3 +98,73 @@ def test_bootstrap_pins_alembic_once(tmp_path: Path) -> None:
     _pin_alembic(tmp_path)
     _pin_alembic(tmp_path)
     assert pyproject.read_text().count(ALEMBIC_PIN) == 1
+
+
+class TestDataStatements:
+    """``ServiceMigrationSpec.data_sql`` (#1110): the one thing the models
+    can never derive. ``generate_revisions`` appends it to the revision it
+    wrote for the service - or, when the models produced nothing for that
+    service (``finance_auth_link``: its FKs are inline in ``finance`` now),
+    writes a data-only revision so the statement still has a home."""
+
+    SENTINEL = "standalone@finance.local"
+
+    def test_appended_to_the_revision_the_service_wrote(self, tmp_path: Path) -> None:
+        versions = _versions(tmp_path)
+
+        def fake_run(cmd: list[str], **_kw: object) -> Mock:
+            (versions / "001_finance_auth_link.py").write_text(
+                "from alembic import op\n\n\ndef upgrade() -> None:\n    pass\n\n\n"
+                "def downgrade() -> None:\n    pass\n"
+            )
+            return Mock(returncode=0, stderr="", stdout="")
+
+        with patch(
+            "aegis.core.migration_generator.subprocess.run", side_effect=fake_run
+        ):
+            written = generate_revisions(tmp_path, ["finance_auth_link"])
+
+        assert written == [versions / "001_finance_auth_link.py"]
+        src = written[0].read_text()
+        assert self.SENTINEL in src
+        assert src.index(self.SENTINEL) < src.index("def downgrade")
+
+    def test_data_only_revision_when_the_models_wrote_nothing(
+        self, tmp_path: Path
+    ) -> None:
+        versions = _versions(tmp_path)
+        (versions / "001_auth.py").write_text("")
+        (versions / "002_finance.py").write_text("")
+
+        with patch(
+            "aegis.core.migration_generator.subprocess.run",
+            return_value=Mock(returncode=0, stderr="", stdout=""),
+        ):
+            written = generate_revisions(tmp_path, ["finance_auth_link"])
+
+        assert written == [versions / "003_finance_auth_link.py"]
+        src = written[0].read_text()
+        assert "revision = '003'" in src
+        assert "down_revision = '002'" in src
+        assert self.SENTINEL in src
+        assert "def downgrade" in src
+
+    def test_data_only_revision_is_written_once(self, tmp_path: Path) -> None:
+        versions = _versions(tmp_path)
+        (versions / "001_finance_auth_link.py").write_text("")
+
+        with patch(
+            "aegis.core.migration_generator.subprocess.run",
+            return_value=Mock(returncode=0, stderr="", stdout=""),
+        ):
+            assert generate_revisions(tmp_path, ["finance_auth_link"]) == []
+
+    def test_services_without_data_are_untouched(self, tmp_path: Path) -> None:
+        versions = _versions(tmp_path)
+
+        with patch(
+            "aegis.core.migration_generator.subprocess.run",
+            return_value=Mock(returncode=0, stderr="", stdout=""),
+        ):
+            assert generate_revisions(tmp_path, ["blog"]) == []
+        assert list(versions.glob("*.py")) == []

--- a/tests/core/test_model_registry_is_the_only_registrar.py
+++ b/tests/core/test_model_registry_is_the_only_registrar.py
@@ -47,7 +47,8 @@ def test_every_table_lives_where_the_registry_looks() -> None:
     off_path = sorted(
         p.relative_to(PROJECT).as_posix()
         for p in (PROJECT / "app").rglob("*.py*")
-        if p.suffix in (".py", ".jinja") and TABLE_RE.search(p.read_text())
+        if p.suffix in (".py", ".jinja")
+        and TABLE_RE.search(p.read_text())
         and not re.match(
             r"app/(models/|services/[a-z_]+/models(/|\.py))",
             p.relative_to(PROJECT).as_posix(),

--- a/tests/core/test_post_gen_tasks.py
+++ b/tests/core/test_post_gen_tasks.py
@@ -88,6 +88,22 @@ class TestInstallDependencies:
             assert args[1]["cwd"] == tmp_path
             assert "VIRTUAL_ENV" not in args[1]["env"]
 
+    def test_relock_re_resolves_the_lockfile(self, tmp_path: Path) -> None:
+        """#1019: a plain ``uv sync`` honours a stale ``uv.lock``, so an
+        updated project kept year-old pins and ~80 phantom type errors.
+        ``relock`` re-resolves against the updated pyproject."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = Mock(returncode=0, stderr="")
+
+            install_dependencies(tmp_path, relock=True)
+
+            assert mock_run.call_args[0][0] == [
+                "uv",
+                "sync",
+                "--all-extras",
+                "--upgrade",
+            ]
+
     def test_installation_failure(self, tmp_path: Path) -> None:
         """Test failed dependency installation."""
         with patch("subprocess.run") as mock_run:
@@ -405,7 +421,9 @@ class TestRunPostGenerationTasks:
         """Test that tasks run in the correct order."""
         call_order = []
 
-        def track_deps(path: Path, python_version: str | None = None) -> bool:
+        def track_deps(
+            path: Path, python_version: str | None = None, *, relock: bool = False
+        ) -> bool:
             call_order.append("deps")
             return True
 
@@ -496,7 +514,10 @@ class TestRevisionsDerivedInsideTheProjectVenv:
             patch("aegis.core.post_gen_tasks.format_code", return_value=True),
         ):
             run_post_generation_tasks(
-                tmp_path, include_migrations=True, migration_services=["auth"], report=report
+                tmp_path,
+                include_migrations=True,
+                migration_services=["auth"],
+                report=report,
             )
         assert report["revisions_ok"] is False
         # the upgrade is skipped: a DB must not be stamped past revisions

--- a/tests/core/test_template_cleanup.py
+++ b/tests/core/test_template_cleanup.py
@@ -1705,3 +1705,39 @@ class Settings(BaseSettings):
         removed_env_keys(tmp_path)
 
         assert env.read_text() == before
+
+
+class TestStaleEnvDefaultsReport:
+    """#1027: every project shipped AEGIS_STACK_TAG=aegis-stack:latest, so two
+    projects on one machine share one image and `docker compose up` in one
+    silently runs the other's build. The template default is now the slug;
+    an updated project still carrying the old shared value is told. Report
+    only - .env is never edited."""
+
+    def test_flags_shared_image_tag(self, tmp_path: Path) -> None:
+        from aegis.core.template_cleanup import stale_env_defaults
+
+        (tmp_path / ".env").write_text(
+            "AEGIS_STACK_TAG=aegis-stack:latest\nAPP_ENV=dev\n"
+        )
+        hits = stale_env_defaults(tmp_path, {"project_slug": "sector-7g"})
+        assert len(hits) == 1
+        assert hits[0].key == "AEGIS_STACK_TAG"
+        assert (
+            hits[0].replacement is not None
+            and "sector-7g:latest" in hits[0].replacement
+        )
+        assert (
+            tmp_path / ".env"
+        ).read_text() == "AEGIS_STACK_TAG=aegis-stack:latest\nAPP_ENV=dev\n"
+
+    def test_project_scoped_tag_is_quiet(self, tmp_path: Path) -> None:
+        from aegis.core.template_cleanup import stale_env_defaults
+
+        (tmp_path / ".env").write_text("AEGIS_STACK_TAG=sector-7g:latest\n")
+        assert stale_env_defaults(tmp_path, {"project_slug": "sector-7g"}) == []
+
+    def test_no_env_is_quiet(self, tmp_path: Path) -> None:
+        from aegis.core.template_cleanup import stale_env_defaults
+
+        assert stale_env_defaults(tmp_path, {"project_slug": "x"}) == []


### PR DESCRIPTION
Closes #1019, closes #1026, closes #1027, closes #1110. Third PR on the Update Path Hardening milestone; commits stack here until merge. Rebased onto #1112 (models-derived revisions).

## #1019 - Re-lock dependencies on update
`install_dependencies(relock=True)` adds `--upgrade` to `uv sync`; the update path passes it through `run_post_generation_tasks`. `--finish` shares `_run_postgen`, so a conflicted update re-locks once completed. init/add unchanged.

## #1026 - Export orphan scheduler jobs before the sweep deletes them
The 0.7.0 sweep now writes the rows it is about to delete to `DATABASE_BACKUP_DIR/orphan_jobs_<ts>.json` (id, next_run_time, func/trigger/args/kwargs unpickled from `job_state`, raw hex if that fails), logs at WARNING with the path, and deletes nothing if the export cannot be written. Moved to `app/services/scheduler/orphans.py` (memory-gated like its siblings) to stay inside the module size budget; registered in the scheduler component manifest. Declared in the behavior-change registry so a persistent-scheduler project crossing 0.7.0 is told before first boot.

## #1027 - Scope the default image tag to the project
`AEGIS_STACK_TAG` default is `{{ project_slug }}:latest` in both compose files, `.env.example` and Settings. `aegis update` adds a project still on `aegis-stack:latest` to the "Before you deploy" block with the slug to set. `.env` reported on, never edited.

## #1110 - Guarantee the sentinel owner the finance FKs point at
`owner_user_id = 0` is the designed convention for "no owner" (standalone installs, AI tools; NULL already means "system row" on categorization tables), so the fix is not to change the writes but to make the row exist. `ServiceMigrationSpec.data_sql` carries the idempotent `INSERT` of user 0 (inactive, unverified, password `!`).

**Rebased onto #1112:** revisions now come from the models, so `data_sql` is placed by `generate_revisions` - appended to the revision the run wrote for the service, or, when the models produced nothing for it (`finance_auth_link`, whose FKs are inline in `finance` now), a **data-only revision**. Data is the one thing the models cannot describe, so this is the hook phase 5 keeps; it covers in-tree services and plugins alike.

Verified: fresh SQLite auth+finance init -> `004_finance_auth_link` data-only, head reached, user 0 present; `aegis add-service auth` onto a standalone finance project runs `auth, auth_tokens, finance_auth_link` so the row lands after `user` exists (new CLI test `TestAddAuthOntoFinance`); both Postgres schema oracles pass.

**Stamp signatures gained a `row` form.** The Postgres-only re-adoption hook stamps a pending revision when its signature object already exists. `finance_auth_link` was proven by an FK that is now inline in `finance`, so on a persisted volume the hook would have stamped the data-only revision and skipped the only INSERT that satisfies that FK. `("row", table, where)` checks the live database instead; `finance_auth_link` is `("row", "user", "id = 0")`. Simulated against local Postgres: row missing -> not stamped, upgrade inserts; row present -> stamped.

## Also
- #1022 closed: not reproducible on a fresh postgres render with no DB (24 passed; every `--in-process` test mocks `_get_fastapi_app`).
- #1023: update-path half already covered by #1024 (commented); id-scheme half stays open.

## Verified
- `tests/core` + `tests/cli/test_update_command.py`: 1772 passed (post-rebase). `test_migrations_match_models[finance_auth]` passed against local Postgres. ruff/format/ty clean (also cleared the four pre-existing `Path | None` ty warnings in `test_migration_generator.py`).



- Also fixes `ruff format` drift left on main by #1112 (two test files), as its own commit.

